### PR TITLE
Remove TODO

### DIFF
--- a/imagescan/subscriber.go
+++ b/imagescan/subscriber.go
@@ -164,7 +164,6 @@ func (s *Subscriber) scheduleScans(ctx context.Context) (rerr error) {
 			log.Info("scanning image")
 			if err := s.scanImage(ctx, log, info); err != nil {
 				if errors.Is(err, allow.ErrNoCandidates) {
-					// TODO: no nodes with resources, schedule job for later
 					log.Debugf("no resources to scan image %q", info.imageName)
 				}
 				log.Errorf("image scan failed: %v", err)


### PR DESCRIPTION
I think that we do need to reschedule anything when there are nodes available. The scan job is only actual at the moment of detection of the new image - later rescheduled job might contain an image that is no longer present in the cluster.