### PR TITLE
Use no schedule taint for image jobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/docker v20.10.22+incompatible
 	github.com/docker/go-connections v0.4.0
+	github.com/go-logr/logr v1.2.3
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/golang/mock v1.6.0
 	github.com/google/go-containerregistry v0.12.0
@@ -46,7 +47,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.26.1
 	k8s.io/apimachinery v0.27.1
-	k8s.io/apiserver v0.26.1
 	k8s.io/client-go v0.26.1
 	k8s.io/klog/v2 v2.90.1
 	sigs.k8s.io/controller-runtime v0.14.2
@@ -90,7 +90,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.17.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver v3.5.1+incompatible // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/container-orchestrated-devices/container-device-interface v0.3.1 // indirect
 	github.com/containerd/cgroups v1.0.4 // indirect
@@ -114,7 +113,6 @@ require (
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/go-errors/errors v1.0.1 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect
 	github.com/go-openapi/jsonreference v0.20.1 // indirect
 	github.com/go-openapi/swag v0.22.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,7 +201,6 @@ github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJm
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bmatcuk/doublestar v1.3.4 h1:gPypJ5xD31uhX6Tf54sDPUOBXTqKH4c9aPY66CyQrS0=
 github.com/bombsimon/logrusr/v4 v4.0.0 h1:Pm0InGphX0wMhPqC02t31onlq9OVyJ98eP/Vh63t1Oo=
@@ -1678,7 +1677,6 @@ k8s.io/apimachinery v0.27.1 h1:EGuZiLI95UQQcClhanryclaQE6xjg1Bts6/L3cD7zyc=
 k8s.io/apimachinery v0.27.1/go.mod h1:5ikh59fK3AJ287GUvpUsryoMFtH9zj/ARfWCo3AyXTM=
 k8s.io/apiserver v0.24.1/go.mod h1:dQWNMx15S8NqJMp0gpYfssyvhYnkilc1LpExd/dkLh0=
 k8s.io/apiserver v0.26.1 h1:6vmnAqCDO194SVCPU3MU8NcDgSqsUA62tBUSWrFXhsc=
-k8s.io/apiserver v0.26.1/go.mod h1:wr75z634Cv+sifswE9HlAo5FQ7UoUauIICRlOE+5dCg=
 k8s.io/cli-runtime v0.25.3 h1:Zs7P7l7db/5J+KDePOVtDlArAa9pZXaDinGWGZl0aM8=
 k8s.io/cli-runtime v0.25.3/go.mod h1:InHHsjkyW5hQsILJGpGjeruiDZT/R0OkROQgD6GzxO4=
 k8s.io/client-go v0.24.1/go.mod h1:f1kIDqcEYmwXS/vTbbhopMUbhKp2JhOeVTfxgaCIlF8=

--- a/imagescan/delta.go
+++ b/imagescan/delta.go
@@ -219,7 +219,6 @@ func (d *deltaState) upsertImages(pod *corev1.Pod) {
 		img.id = cs.ImageID
 		img.name = cont.Image
 		img.containerRuntime = getContainerRuntime(cs.ContainerID)
-		img.podTolerations = pod.Spec.Tolerations
 
 		if owner, found := img.owners[ownerResourceID]; found {
 			// resources not changed because Resources we send are actually keys of img.owners and nothing changed there.
@@ -479,7 +478,6 @@ type image struct {
 	containerRuntime imgcollectorconfig.Runtime
 	owners           map[string]*imageOwner
 	nodes            map[string]*imageNode
-	podTolerations   []corev1.Toleration
 
 	scanned      bool
 	lastScanErr  error

--- a/imagescan/scanner.go
+++ b/imagescan/scanner.go
@@ -56,7 +56,6 @@ type ScanImageParams struct {
 	Mode                        string
 	NodeName                    string
 	ResourceIDs                 []string
-	Tolerations                 []corev1.Toleration
 	DeleteFinishedJob           bool
 	WaitForCompletion           bool
 	WaitDurationAfterCompletion time.Duration
@@ -221,6 +220,12 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 		})
 	}
 
+	tolerations := []corev1.Toleration{
+		{
+			Effect: corev1.TaintEffectNoSchedule,
+		},
+	}
+
 	jobSpec := scanJobSpec(
 		s.cfg.PodNamespace,
 		params.NodeName,
@@ -228,7 +233,7 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 		envVars,
 		podAnnotations,
 		vols,
-		params.Tolerations,
+		tolerations,
 		s.cfg.ImageScan,
 	)
 	jobs := s.client.BatchV1().Jobs(s.cfg.PodNamespace)

--- a/imagescan/scanner.go
+++ b/imagescan/scanner.go
@@ -222,7 +222,8 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 
 	tolerations := []corev1.Toleration{
 		{
-			Effect: corev1.TaintEffectNoSchedule,
+			Effect:   corev1.TaintEffectNoSchedule,
+			Operator: corev1.TolerationOpExists,
 		},
 	}
 

--- a/imagescan/scanner_test.go
+++ b/imagescan/scanner_test.go
@@ -108,6 +108,11 @@ func TestScanner(t *testing.T) {
 								},
 							},
 						},
+						Tolerations: []corev1.Toleration{
+							{
+								Effect: corev1.TaintEffectNoSchedule,
+							},
+						},
 						Containers: []corev1.Container{
 							{
 								Name:  "collector",

--- a/imagescan/scanner_test.go
+++ b/imagescan/scanner_test.go
@@ -110,7 +110,8 @@ func TestScanner(t *testing.T) {
 						},
 						Tolerations: []corev1.Toleration{
 							{
-								Effect: corev1.TaintEffectNoSchedule,
+								Effect:   corev1.TaintEffectNoSchedule,
+								Operator: corev1.TolerationOpExists,
 							},
 						},
 						Containers: []corev1.Container{

--- a/imagescan/subscriber.go
+++ b/imagescan/subscriber.go
@@ -227,7 +227,6 @@ func (s *Subscriber) scanImage(ctx context.Context, img *image) (rerr error) {
 		Mode:                        mode,
 		ResourceIDs:                 lo.Keys(img.owners),
 		NodeName:                    nodeName,
-		Tolerations:                 img.podTolerations, // Assign the same tolerations as on pod. That will ensure that scan job can run on selected node.
 		DeleteFinishedJob:           true,
 		WaitForCompletion:           true,
 		WaitDurationAfterCompletion: 30 * time.Second,


### PR DESCRIPTION
Looks that sometimes scan job doesn't get needed tains from the target pod. We could simplify this logic to simply use no schedule toleration.