### PR TITLE
Send image scan report from main kvisor deployment

### DIFF
--- a/blobscache/client.go
+++ b/blobscache/client.go
@@ -20,9 +20,9 @@ type Client interface {
 	GetBlob(ctx context.Context, key string) ([]byte, error)
 }
 
-func NewRemoteBlobsCache(url string) Client {
+func NewRemoteBlobsCacheClient(serverURL string) Client {
 	return &remoteBlobsCache{
-		url: url,
+		url: serverURL,
 		client: &http.Client{
 			Timeout: 10 * time.Second,
 		},
@@ -42,7 +42,7 @@ func (c *remoteBlobsCache) PutBlob(ctx context.Context, key string, blob []byte)
 	}); err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/PutBlob", c.url), &buf)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/v1/blobscache/PutBlob", c.url), &buf)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (c *remoteBlobsCache) GetBlob(ctx context.Context, key string) ([]byte, err
 	}); err != nil {
 		return nil, err
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/GetBlob", c.url), &buf)
+	req, err := http.NewRequestWithContext(ctx, "POST", fmt.Sprintf("%s/v1/blobscache/GetBlob", c.url), &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/blobscache/server.go
+++ b/blobscache/server.go
@@ -11,7 +11,7 @@ import (
 type ServerConfig struct {
 }
 
-func NewBlobsCacheServer(log logrus.FieldLogger, cfg ServerConfig) *Server {
+func NewServer(log logrus.FieldLogger, cfg ServerConfig) *Server {
 	return &Server{
 		log:        log,
 		cfg:        cfg,

--- a/blobscache/server.go
+++ b/blobscache/server.go
@@ -1,12 +1,7 @@
 package blobscache
 
 import (
-	"context"
-	"errors"
-	"fmt"
-	"net"
 	"net/http"
-	"time"
 
 	lru "github.com/hashicorp/golang-lru"
 	json "github.com/json-iterator/go"
@@ -14,7 +9,6 @@ import (
 )
 
 type ServerConfig struct {
-	ServePort int
 }
 
 func NewBlobsCacheServer(log logrus.FieldLogger, cfg ServerConfig) *Server {
@@ -29,42 +23,11 @@ type Server struct {
 	log        logrus.FieldLogger
 	cfg        ServerConfig
 	blobsCache blobsCacheStore
-	listener   net.Listener
 }
 
-func (s *Server) Start(ctx context.Context) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/PutBlob", s.putBlob)
-	mux.HandleFunc("/GetBlob", s.getBlob)
-
-	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", s.cfg.ServePort),
-		Handler:      mux,
-		WriteTimeout: 5 * time.Second,
-		ReadTimeout:  5 * time.Second,
-	}
-
-	go func() {
-		<-ctx.Done()
-		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-		defer cancel()
-		if err := srv.Shutdown(ctx); err != nil {
-			s.log.Errorf("blobs cache server shutdown: %v", err)
-		}
-	}()
-
-	if s.listener == nil {
-		var err error
-		s.listener, err = net.Listen("tcp", srv.Addr)
-		if err != nil {
-			s.log.Errorf("creating blobs cache server listener: %v", err)
-			return
-		}
-	}
-
-	if err := srv.Serve(s.listener); err != nil && errors.Is(err, http.ErrServerClosed) {
-		s.log.Errorf("serving blobs cache server: %v", err)
-	}
+func (s *Server) RegisterHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("/v1/blobscache/PutBlob", s.putBlob)
+	mux.HandleFunc("/v1/blobscache/GetBlob", s.getBlob)
 }
 
 func (s *Server) putBlob(w http.ResponseWriter, r *http.Request) {

--- a/blobscache/server_test.go
+++ b/blobscache/server_test.go
@@ -20,7 +20,7 @@ func TestBlobsCacheServer(t *testing.T) {
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
 
-	srv := NewBlobsCacheServer(log, ServerConfig{})
+	srv := NewServer(log, ServerConfig{})
 	mux := http.NewServeMux()
 	srv.RegisterHandlers(mux)
 	httpSrv := httptest.NewServer(mux)

--- a/blobscache/server_test.go
+++ b/blobscache/server_test.go
@@ -3,8 +3,8 @@ package blobscache
 import (
 	"context"
 	"errors"
-	"fmt"
-	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -21,28 +21,24 @@ func TestBlobsCacheServer(t *testing.T) {
 	log.SetLevel(logrus.DebugLevel)
 
 	srv := NewBlobsCacheServer(log, ServerConfig{})
-	listener, err := newLocalListener()
-	r.NoError(err)
-	srv.listener = listener
-	go srv.Start(ctx)
+	mux := http.NewServeMux()
+	srv.RegisterHandlers(mux)
+	httpSrv := httptest.NewServer(mux)
+	defer httpSrv.Close()
 
-	client := NewRemoteBlobsCache(fmt.Sprintf("http://%s", listener.Addr().String()))
+	client := NewRemoteBlobsCacheClient(httpSrv.URL)
 
-	// Wait unti server is ready
+	// Wait unti server is ready.
 	r.Eventually(func() bool {
 		_, err := client.GetBlob(ctx, "noop")
 		return errors.Is(err, ErrCacheNotFound)
 	}, 3*time.Second, 10*time.Millisecond)
 
 	blob := []byte(`{"some": "json"}`)
-	err = client.PutBlob(ctx, "b1", blob)
+	err := client.PutBlob(ctx, "b1", blob)
 	r.NoError(err)
 
 	addedBlob, err := client.GetBlob(ctx, "b1")
 	r.NoError(err)
 	r.Equal(blob, addedBlob)
-}
-
-func newLocalListener() (net.Listener, error) {
-	return net.Listen("tcp", "127.0.0.1:0")
 }

--- a/charts/castai-kvisor/templates/deployment.yaml
+++ b/charts/castai-kvisor/templates/deployment.yaml
@@ -96,7 +96,7 @@ spec:
               value: {{ ((.Values.kvisor | default dict).statusPort | default 7071) | quote }}
             - name: API_URL
               value: {{ .Values.castai.apiURL | quote }}
-            - name: CLUSTER_ID
+            - name: API_CLUSTER_ID
               value: {{ .Values.castai.clusterID | quote }}
           {{- range $k, $v := .Values.additionalEnv }}
             - name: {{ $k }}

--- a/charts/castai-kvisor/templates/service.yaml
+++ b/charts/castai-kvisor/templates/service.yaml
@@ -1,4 +1,3 @@
-{{- if (.Values.policyEnforcement | default dict).enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,8 +6,13 @@ spec:
   selector:
     app.kubernetes.io/name: castai-kvisor
   ports:
+    - name: http
+      protocol: TCP
+      port: 6060
+      targetPort: http
+    {{- if (.Values.policyEnforcement | default dict).enabled }}
     - name: webhook
       protocol: TCP
       port: {{ ((.Values.kvisor | default dict).servicePort | default 7070) }}
       targetPort: webhook
-{{- end}}
+    {{- end}}

--- a/charts/castai-kvisor/values.yaml
+++ b/charts/castai-kvisor/values.yaml
@@ -84,6 +84,7 @@ config: |
     scanInterval: "15s"
     maxConcurrentScans: 3
     hostfsSocketFallbackEnabled: true
+    apiUrl: "http://kvisor.{{ .Release.Namespace }}.svc.cluster.local.:6060"
     image:
       name: "{{ .Values.image.repository }}-imgcollector:{{ .Values.image.tag | default .Chart.AppVersion }}"
       pullPolicy: IfNotPresent

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -160,7 +160,7 @@ func run(ctx context.Context, logger logrus.FieldLogger, castaiClient castai.Cli
 	httpMux.Handle("/metrics", promhttp.Handler())
 	httpMux.HandleFunc("/v1/image-scan/report", scanHandler.Handle)
 	if cfg.ImageScan.Enabled {
-		blobsCache := blobscache.NewBlobsCacheServer(log, blobscache.ServerConfig{})
+		blobsCache := blobscache.NewServer(log, blobscache.ServerConfig{})
 		blobsCache.RegisterHandlers(httpMux)
 	}
 

--- a/cmd/imgcollector/collector/collector.go
+++ b/cmd/imgcollector/collector/collector.go
@@ -1,11 +1,17 @@
 package collector
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -56,11 +62,10 @@ import (
 	_ "github.com/castai/kvisor/cmd/imgcollector/analyzer/pkg/rpm"
 )
 
-func New(log logrus.FieldLogger, cfg config.Config, client castai.Client, cache blobscache.Client, hostfsConfig *hostfs.ContainerdHostFSConfig) *Collector {
+func New(log logrus.FieldLogger, cfg config.Config, cache blobscache.Client, hostfsConfig *hostfs.ContainerdHostFSConfig) *Collector {
 	return &Collector{
 		log:          log,
 		cfg:          cfg,
-		client:       client,
 		cache:        cache,
 		hostFsConfig: hostfsConfig,
 	}
@@ -69,7 +74,6 @@ func New(log logrus.FieldLogger, cfg config.Config, client castai.Client, cache 
 type Collector struct {
 	log          logrus.FieldLogger
 	cfg          config.Config
-	client       castai.Client
 	cache        blobscache.Client
 	hostFsConfig *hostfs.ContainerdHostFSConfig
 }
@@ -133,7 +137,13 @@ func (c *Collector) Collect(ctx context.Context) error {
 		metadata.Index = index
 	}
 
-	if err := c.client.SendImageMetadata(ctx, metadata); err != nil {
+	if err := backoff.RetryNotify(func() error {
+		return c.sendResult(ctx, metadata)
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Second), 3), func(err error, duration time.Duration) {
+		if err != nil {
+			c.log.Errorf("sending result: %v", err)
+		}
+	}); err != nil {
 		return err
 	}
 
@@ -179,4 +189,26 @@ func (c *Collector) getImage(ctx context.Context) (image.ImageWithIndex, func(),
 	}
 
 	return nil, nil, fmt.Errorf("unknown mode %q", c.cfg.Mode)
+}
+
+func (c *Collector) sendResult(ctx context.Context, report *castai.ImageMetadata) error {
+	client := http.Client{Timeout: 10 * time.Second}
+	reportBytes, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.cfg.ApiURL+"/v1/image-scan/report", bytes.NewBuffer(reportBytes))
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if st := resp.StatusCode; st != http.StatusOK {
+		errMsg, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("expected status %d, got %d: %v", http.StatusOK, st, string(errMsg))
+	}
+	return nil
 }

--- a/cmd/imgcollector/collector/collector.go
+++ b/cmd/imgcollector/collector/collector.go
@@ -208,7 +208,7 @@ func (c *Collector) sendResult(ctx context.Context, report *castai.ImageMetadata
 	defer resp.Body.Close()
 	if st := resp.StatusCode; st != http.StatusOK {
 		errMsg, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("expected status %d, got %d: %v", http.StatusOK, st, string(errMsg))
+		return fmt.Errorf("expected status %d, got %d, url=%s: %v", http.StatusOK, st, req.URL.String(), string(errMsg))
 	}
 	return nil
 }

--- a/cmd/imgcollector/config/config.go
+++ b/cmd/imgcollector/config/config.go
@@ -37,7 +37,6 @@ type Config struct {
 	Runtime          Runtime       `envconfig:"COLLECTOR_RUNTIME" required:"true"`
 	ResourceIDs      string        `envconfig:"COLLECTOR_RESOURCE_IDS" required:"true"`
 	DockerOptionPath string        `envconfig:"COLLECTOR_DOCKER_OPTION_PATH" default:""`
-	BlobsCacheURL    string        `envconfig:"COLLECTOR_BLOBS_CACHE_URL" default:""`
 	PprofAddr        string        `envconfig:"COLLECTOR_PPROF_ADDR" default:""`
 	SlowMode         bool          `envconfig:"SLOW_MODE" default:"true"`
 	// ImageLocalTarPath is used only with ModeTarArchive for local dev.

--- a/cmd/imgcollector/config/config.go
+++ b/cmd/imgcollector/config/config.go
@@ -29,9 +29,7 @@ const (
 )
 
 type Config struct {
-	ApiKey           string        `envconfig:"API_KEY" required:"true"`
-	ApiURL           string        `envconfig:"API_URL" default:"https://api.cast.ai"`
-	ClusterID        string        `envconfig:"CLUSTER_ID" required:"true"`
+	ApiURL           string        `envconfig:"KVISOR_SERVER_API_URL" required:"true"`
 	ImageID          string        `envconfig:"COLLECTOR_IMAGE_ID" required:"true"`
 	ImageName        string        `envconfig:"COLLECTOR_IMAGE_NAME" required:"true"`
 	Timeout          time.Duration `envconfig:"COLLECTOR_TIMEOUT" default:"5m"`

--- a/cmd/imgcollector/main.go
+++ b/cmd/imgcollector/main.go
@@ -11,12 +11,9 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/castai/kvisor/blobscache"
-	"github.com/castai/kvisor/castai"
 	"github.com/castai/kvisor/cmd/imgcollector/collector"
 	"github.com/castai/kvisor/cmd/imgcollector/config"
 	"github.com/castai/kvisor/cmd/imgcollector/image/hostfs"
-	globalconfig "github.com/castai/kvisor/config"
-	agentlog "github.com/castai/kvisor/log"
 )
 
 // These should be set via `go build` during a release.
@@ -29,31 +26,12 @@ var (
 func main() {
 	log := logrus.New()
 	log.SetLevel(logrus.DebugLevel)
+	log.Infof("running image scan job, version=%s, commit=%s", Version, GitCommit)
 
 	cfg, err := config.FromEnv()
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	client := castai.NewClient(
-		cfg.ApiURL, cfg.ApiKey,
-		log,
-		cfg.ClusterID,
-		"castai-imgcollector",
-		globalconfig.SecurityAgentVersion{
-			GitCommit: GitCommit,
-			GitRef:    GitRef,
-			Version:   Version,
-		},
-	)
-
-	e := agentlog.NewExporter(log, client, []logrus.Level{
-		logrus.ErrorLevel,
-		logrus.FatalLevel,
-		logrus.PanicLevel,
-	})
-
-	log.AddHook(e)
 
 	var blobsCache blobscache.Client
 	if cfg.BlobsCacheURL != "" {
@@ -73,7 +51,7 @@ func main() {
 			ContentDir: config.ContainerdContentDir,
 		}
 	}
-	c := collector.New(log, cfg, client, blobsCache, h)
+	c := collector.New(log, cfg, blobsCache, h)
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
 	defer cancel()

--- a/cmd/imgcollector/main.go
+++ b/cmd/imgcollector/main.go
@@ -33,13 +33,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	var blobsCache blobscache.Client
-	if cfg.BlobsCacheURL != "" {
-		blobsCache = blobscache.NewRemoteBlobsCache(cfg.BlobsCacheURL)
-	} else {
-		blobsCache = blobscache.NewMockBlobsCacheClient()
-		log.Warn("blobs cache is not enabled")
-	}
+	blobsCache := blobscache.NewRemoteBlobsCacheClient(cfg.ApiURL)
 
 	var h *hostfs.ContainerdHostFSConfig
 	if cfg.Runtime == config.RuntimeContainerd && cfg.Mode == config.ModeHostFS {

--- a/config/config.go
+++ b/config/config.go
@@ -34,9 +34,9 @@ type Config struct {
 }
 
 type PolicyEnforcement struct {
-	Enabled     bool    `envconfig:"ENABLED" yaml:"enabled"`
-	WebhookName string  `envconfig:"WEBHOOK_NAME" yaml:"webhookName"`
-	Bundles     Bundles `envconfig:"BUNDLES" yaml:"bundles"`
+	Enabled     bool    `envconfig:"POLICY_ENFORCEMENT_ENABLED" yaml:"enabled"`
+	WebhookName string  `envconfig:"POLICY_ENFORCEMENT_WEBHOOK_NAME" yaml:"webhookName"`
+	Bundles     Bundles `envconfig:"POLICY_ENFORCEMENT_BUNDLES" yaml:"bundles"`
 }
 
 type Bundles []string
@@ -48,55 +48,54 @@ func (b *Bundles) Decode(input string) error {
 }
 
 type CloudScan struct {
-	Enabled      bool          `envconfig:"ENABLED" yaml:"enabled"`
-	ScanInterval time.Duration `envconfig:"SCAN_INTERVAL" yaml:"scanInterval"`
-	GKE          *CloudScanGKE `envconfig:"GKE" yaml:"gke"`
-	EKS          *CloudScanEKS `envconfig:"EKS" yaml:"eks"`
+	Enabled      bool          `envconfig:"CLOUD_SCAN_ENABLED" yaml:"enabled"`
+	ScanInterval time.Duration `envconfig:"CLOUD_SCAN_SCAN_INTERVAL" yaml:"scanInterval"`
+	GKE          *CloudScanGKE `envconfig:"CLOUD_SCAN_GKE" yaml:"gke"`
+	EKS          *CloudScanEKS `envconfig:"CLOUD_SCAN_EKS" yaml:"eks"`
 }
 
 type CloudScanGKE struct {
-	ClusterName        string `envconfig:"CLUSTER_NAME" yaml:"clusterName"`
-	CredentialsFile    string `envconfig:"CREDENTIALS_FILE" yaml:"credentialsFile"`
-	ServiceAccountName string `envconfig:"SERVICE_ACCOUNT_NAME" yaml:"serviceAccountName"`
+	ClusterName        string `envconfig:"CLOUD_SCAN_GKE_CLUSTER_NAME" yaml:"clusterName"`
+	CredentialsFile    string `envconfig:"CLOUD_SCAN_GKE_CREDENTIALS_FILE" yaml:"credentialsFile"`
+	ServiceAccountName string `envconfig:"CLOUD_SCAN_GKE_SERVICE_ACCOUNT_NAME" yaml:"serviceAccountName"`
 }
 
 type CloudScanEKS struct {
-	ClusterName string `envconfig:"CLUSTER_NAME" yaml:"clusterName"`
+	ClusterName string `envconfig:"CLOUD_SCAN_EKS_CLUSTER_NAME" yaml:"clusterName"`
 }
 
 type ImageScan struct {
-	Enabled                     bool           `envconfig:"ENABLED" yaml:"enabled"`
-	ScanInterval                time.Duration  `envconfig:"SCAN_INTERVAL" yaml:"scanInterval"`
-	ScanTimeout                 time.Duration  `envconfig:"SCAN_TIMEOUT" yaml:"scanTimeout"`
-	MaxConcurrentScans          int64          `envconfig:"MAX_CONCURRENT_SCANS" yaml:"maxConcurrentScans"`
-	Image                       ImageScanImage `envconfig:"IMAGE" yaml:"image"`
-	Mode                        string         `envconfig:"MODE" yaml:"mode"`
-	APIUrl                      string         `envconfig:"API_URL" yaml:"apiUrl"`
-	HostfsSocketFallbackEnabled bool           `envconfig:"HOSTFS_SOCKET_FALLBACK_ENABLED" yaml:"hostfsSocketFallbackEnabled"`
-	DockerOptionsPath           string         `envconfig:"DOCKER_OPTIONS_PATH" yaml:"dockerOptionsPath"`
-	BlobsCachePort              int            `envconfig:"BLOBS_CACHE_PORT" yaml:"blobsCachePort"`
-	CPURequest                  string         `envconfig:"CPU_REQUEST" yaml:"cpuRequest"`
-	CPULimit                    string         `envconfig:"CPU_LIMIT" yaml:"cpuLimit"`
-	MemoryRequest               string         `envconfig:"MEMORY_REQUEST" yaml:"memoryRequest"`
-	MemoryLimit                 string         `envconfig:"MEMORY_LIMIT" yaml:"memoryLimit"`
-	Force                       bool           `envconfig:"FORCE" yaml:"force"`
-	ProfileEnabled              bool           `envconfig:"PROFILE_ENABLED" yaml:"profileEnabled"`
-	PhlareEnabled               bool           `envconfig:"PHLARE_ENABLED" yaml:"phlareEnabled"`
+	Enabled                     bool           `envconfig:"IMAGE_SCAN_ENABLED" yaml:"enabled"`
+	ScanInterval                time.Duration  `envconfig:"IMAGE_SCAN_SCAN_INTERVAL" yaml:"scanInterval"`
+	ScanTimeout                 time.Duration  `envconfig:"IMAGE_SCAN_SCAN_TIMEOUT" yaml:"scanTimeout"`
+	MaxConcurrentScans          int64          `envconfig:"IMAGE_SCAN_MAX_CONCURRENT_SCANS" yaml:"maxConcurrentScans"`
+	Image                       ImageScanImage `envconfig:"IMAGE_SCAN_IMAGE" yaml:"image"`
+	Mode                        string         `envconfig:"IMAGE_SCAN_MODE" yaml:"mode"`
+	APIUrl                      string         `envconfig:"IMAGE_SCAN_API_URL" yaml:"apiUrl"`
+	HostfsSocketFallbackEnabled bool           `envconfig:"IMAGE_SCAN_HOSTFS_SOCKET_FALLBACK_ENABLED" yaml:"hostfsSocketFallbackEnabled"`
+	DockerOptionsPath           string         `envconfig:"IMAGE_SCAN_DOCKER_OPTIONS_PATH" yaml:"dockerOptionsPath"`
+	CPURequest                  string         `envconfig:"IMAGE_SCAN_CPU_REQUEST" yaml:"cpuRequest"`
+	CPULimit                    string         `envconfig:"IMAGE_SCAN_CPU_LIMIT" yaml:"cpuLimit"`
+	MemoryRequest               string         `envconfig:"IMAGE_SCAN_MEMORY_REQUEST" yaml:"memoryRequest"`
+	MemoryLimit                 string         `envconfig:"IMAGE_SCAN_MEMORY_LIMIT" yaml:"memoryLimit"`
+	Force                       bool           `envconfig:"IMAGE_SCAN_FORCE" yaml:"force"`
+	ProfileEnabled              bool           `envconfig:"IMAGE_SCAN_PROFILE_ENABLED" yaml:"profileEnabled"`
+	PhlareEnabled               bool           `envconfig:"IMAGE_SCAN_PHLARE_ENABLED" yaml:"phlareEnabled"`
 }
 
 type ImageScanImage struct {
-	Name       string `envconfig:"NAME" yaml:"name"`
-	PullPolicy string `envconfig:"PULL_POLICY" yaml:"pullPolicy"`
+	Name       string `envconfig:"IMAGE_SCAN_IMAGE_NAME" yaml:"name"`
+	PullPolicy string `envconfig:"IMAGE_SCAN_IMAGE_PULL_POLICY" yaml:"pullPolicy"`
 }
 
 type Linter struct {
-	Enabled bool `envconfig:"ENABLED" yaml:"enabled"`
+	Enabled bool `envconfig:"LINTER_ENABLED" yaml:"enabled"`
 }
 
 type KubeBench struct {
-	Enabled      bool          `envconfig:"ENABLED" yaml:"enabled"`
-	Force        bool          `envconfig:"FORCE" yaml:"force"`
-	ScanInterval time.Duration `envconfig:"SCAN_INTERVAL" yaml:"scanInterval"`
+	Enabled      bool          `envconfig:"KUBE_BENCH_ENABLED" yaml:"enabled"`
+	Force        bool          `envconfig:"KUBE_BENCH_FORCE" yaml:"force"`
+	ScanInterval time.Duration `envconfig:"KUBE_BENCH_SCAN_INTERVAL" yaml:"scanInterval"`
 }
 
 type KubeClient struct {
@@ -104,20 +103,20 @@ type KubeClient struct {
 	// smoothed qps rate of 'qps'.
 	// The bucket is initially filled with 'burst' tokens, and refills at a rate of 'qps'.
 	// The maximum number of tokens in the bucket is capped at 'burst'.
-	QPS   int `envconfig:"QPS" yaml:"qps"`
-	Burst int `envconfig:"BURST" yaml:"burst"`
+	QPS   int `envconfig:"KUBE_CLIENT_QPS" yaml:"qps"`
+	Burst int `envconfig:"KUBE_CLIENT_BURST" yaml:"burst"`
 	// Custom kubeconfig path.
-	KubeConfigPath string `envconfig:"KUBECONFIG" yaml:"kubeconfig"`
+	KubeConfigPath string `envconfig:"KUBE_CLIENT_KUBECONFIG" yaml:"kubeconfig"`
 }
 
 type Log struct {
-	Level string `envconfig:"LEVEL" yaml:"level"`
+	Level string `envconfig:"LOG_LEVEL" yaml:"level"`
 }
 
 type API struct {
-	Key       string `envconfig:"KEY" yaml:"key"`
-	URL       string `envconfig:"URL" yaml:"url"`
-	ClusterID string `envconfig:"CLUSTER_ID" yaml:"clusterID"`
+	Key       string `envconfig:"API_KEY" yaml:"key"`
+	URL       string `envconfig:"API_URL" yaml:"url"`
+	ClusterID string `envconfig:"API_CLUSTER_ID" yaml:"clusterID"`
 }
 
 func Load(configPath string) (Config, error) {
@@ -172,9 +171,6 @@ func Load(configPath string) (Config, error) {
 		}
 		if cfg.ImageScan.MaxConcurrentScans == 0 {
 			cfg.ImageScan.MaxConcurrentScans = 3
-		}
-		if cfg.ImageScan.BlobsCachePort == 0 {
-			cfg.ImageScan.BlobsCachePort = 8080
 		}
 		if cfg.ImageScan.ScanInterval == 0 {
 			cfg.ImageScan.ScanInterval = 15 * time.Second

--- a/config/config.go
+++ b/config/config.go
@@ -23,7 +23,7 @@ type Config struct {
 	KubeClient        KubeClient        `envconfig:"KUBE_CLIENT" yaml:"kubeClient"`
 	Log               Log               `envconfig:"LOG" yaml:"log"`
 	API               API               `envconfig:"API" yaml:"api"`
-	PprofPort         int               `envconfig:"PPROF_PORT" yaml:"pprofPort"`
+	HTTPPort          int               `envconfig:"HTTP_PORT" yaml:"httpPort"`
 	StatusPort        int               `envconfig:"STATUS_PORT" yaml:"statusPort"`
 	Provider          string            `envconfig:"PROVIDER" yaml:"provider"`
 	DeltaSyncInterval time.Duration     `envconfig:"DELTA_SYNC_INTERVAL" yaml:"deltaSyncInterval"`
@@ -71,6 +71,7 @@ type ImageScan struct {
 	MaxConcurrentScans          int64          `envconfig:"MAX_CONCURRENT_SCANS" yaml:"maxConcurrentScans"`
 	Image                       ImageScanImage `envconfig:"IMAGE" yaml:"image"`
 	Mode                        string         `envconfig:"MODE" yaml:"mode"`
+	APIUrl                      string         `envconfig:"API_URL" yaml:"apiUrl"`
 	HostfsSocketFallbackEnabled bool           `envconfig:"HOSTFS_SOCKET_FALLBACK_ENABLED" yaml:"hostfsSocketFallbackEnabled"`
 	DockerOptionsPath           string         `envconfig:"DOCKER_OPTIONS_PATH" yaml:"dockerOptionsPath"`
 	BlobsCachePort              int            `envconfig:"BLOBS_CACHE_PORT" yaml:"blobsCachePort"`
@@ -193,6 +194,9 @@ func Load(configPath string) (Config, error) {
 		if cfg.ImageScan.MemoryRequest == "" {
 			cfg.ImageScan.MemoryRequest = "1Mi"
 		}
+		if cfg.ImageScan.APIUrl == "" {
+			cfg.ImageScan.APIUrl = "http://kvisor.castai-agent.svc.cluster.local.:6060"
+		}
 	}
 	if cfg.CloudScan.Enabled {
 		if cfg.CloudScan.ScanInterval == 0 {
@@ -205,8 +209,8 @@ func Load(configPath string) (Config, error) {
 		}
 	}
 
-	if cfg.PprofPort == 0 {
-		cfg.PprofPort = 6060
+	if cfg.HTTPPort == 0 {
+		cfg.HTTPPort = 6060
 	}
 	if cfg.Provider == "" {
 		cfg.Provider = "on-premise"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,7 +29,11 @@ func TestConfig(t *testing.T) {
 		r := require.New(t)
 		expectedCfg := newTestConfig()
 		expectedCfg.API.Key = "api-key-from-env"
+		expectedCfg.API.URL = "https://api-test.cast.ai"
+		expectedCfg.ImageScan.APIUrl = "http://server"
 		r.NoError(os.Setenv("API_KEY", expectedCfg.API.Key))
+		r.NoError(os.Setenv("API_URL", expectedCfg.API.URL))
+		r.NoError(os.Setenv("IMAGE_SCAN_API_URL", expectedCfg.ImageScan.APIUrl))
 
 		cfgBytes, err := yaml.Marshal(expectedCfg)
 		r.NoError(err)
@@ -75,7 +79,6 @@ func newTestConfig() Config {
 			Mode:                        "mode",
 			HostfsSocketFallbackEnabled: true,
 			DockerOptionsPath:           "/etc/config/docker-config.json",
-			BlobsCachePort:              8080,
 			CPURequest:                  "100m",
 			CPULimit:                    "2",
 			MemoryRequest:               "100Mi",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -56,7 +56,7 @@ func newTestConfig() Config {
 		},
 		Log:               Log{Level: "info"},
 		API:               API{URL: "https://api-test.cast.ai", Key: "key", ClusterID: "c1"},
-		PprofPort:         6090,
+		HTTPPort:          6090,
 		StatusPort:        7071,
 		Provider:          "gke",
 		DeltaSyncInterval: 15 * time.Second,
@@ -80,6 +80,7 @@ func newTestConfig() Config {
 			CPULimit:                    "2",
 			MemoryRequest:               "100Mi",
 			MemoryLimit:                 "2Gi",
+			APIUrl:                      "http://kvisor.castai-agent.svc.cluster.local.:6060",
 		},
 		Linter: Linter{
 			Enabled: true,

--- a/imagescan/http_handler.go
+++ b/imagescan/http_handler.go
@@ -1,0 +1,48 @@
+package imagescan
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"time"
+
+	json "github.com/json-iterator/go"
+	"github.com/sirupsen/logrus"
+
+	"github.com/castai/kvisor/castai"
+)
+
+func NewScanHttpHandler(log logrus.FieldLogger, client castai.Client) *ScanHTTPHandler {
+	return &ScanHTTPHandler{
+		log:    log.WithField("component", "scan_http_handler"),
+		client: client,
+	}
+}
+
+// ScanHTTPHandler receives image metadata from scan job and sends it to CAST AI platform.
+type ScanHTTPHandler struct {
+	log    logrus.FieldLogger
+	client castai.Client
+}
+
+func (h *ScanHTTPHandler) Handle(w http.ResponseWriter, r *http.Request) {
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		h.log.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	var md castai.ImageMetadata
+	if err := json.Unmarshal(data, &md); err != nil {
+		h.log.Error(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := h.client.SendImageMetadata(ctx, &md); err != nil {
+		h.log.Errorf("sending image report: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+}

--- a/imagescan/scanner.go
+++ b/imagescan/scanner.go
@@ -77,9 +77,6 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 	if params.NodeName == "" {
 		return errors.New("node name is required")
 	}
-	if s.cfg.ImageScan.BlobsCachePort == 0 {
-		return errors.New("blobs cache port is required")
-	}
 	if s.cfg.PodNamespace == "" {
 		return errors.New("pod namespace is required")
 	}
@@ -184,13 +181,6 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 			Name:  "KVISOR_SERVER_API_URL",
 			Value: s.cfg.ImageScan.APIUrl,
 		},
-	}
-
-	if s.cfg.PodIP != "" {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "COLLECTOR_BLOBS_CACHE_URL",
-			Value: fmt.Sprintf("http://%s:%d", s.cfg.PodIP, s.cfg.ImageScan.BlobsCachePort),
-		})
 	}
 
 	podAnnotations := map[string]string{}

--- a/imagescan/scanner.go
+++ b/imagescan/scanner.go
@@ -181,23 +181,8 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 			Value: strings.Join(params.ResourceIDs, ","),
 		},
 		{
-			Name:  "API_URL",
-			Value: s.cfg.API.URL,
-		},
-		{
-			Name: "API_KEY",
-			ValueFrom: &corev1.EnvVarSource{
-				SecretKeyRef: &corev1.SecretKeySelector{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "castai-kvisor",
-					},
-					Key: "API_KEY",
-				},
-			},
-		},
-		{
-			Name:  "CLUSTER_ID",
-			Value: s.cfg.API.ClusterID,
+			Name:  "KVISOR_SERVER_API_URL",
+			Value: s.cfg.ImageScan.APIUrl,
 		},
 	}
 

--- a/imagescan/scanner_test.go
+++ b/imagescan/scanner_test.go
@@ -39,7 +39,6 @@ func TestScanner(t *testing.T) {
 				},
 				APIUrl:            "http://kvisor:6060",
 				DockerOptionsPath: "/etc/docker/config.json",
-				BlobsCachePort:    8080,
 				CPURequest:        "500m",
 				CPULimit:          "2",
 				MemoryRequest:     "100Mi",
@@ -157,10 +156,6 @@ func TestScanner(t *testing.T) {
 										Value: "http://kvisor:6060",
 									},
 									{
-										Name:  "COLLECTOR_BLOBS_CACHE_URL",
-										Value: "http://10.10.5.77:8080",
-									},
-									{
 										Name:  "COLLECTOR_PPROF_ADDR",
 										Value: ":6060",
 									},
@@ -230,11 +225,10 @@ func TestScanner(t *testing.T) {
 			PodIP:        "ip",
 			PodNamespace: ns,
 			ImageScan: config.ImageScan{
-				BlobsCachePort: 8080,
-				CPURequest:     "500m",
-				CPULimit:       "2",
-				MemoryRequest:  "100Mi",
-				MemoryLimit:    "2Gi",
+				CPURequest:    "500m",
+				CPULimit:      "2",
+				MemoryRequest: "100Mi",
+				MemoryLimit:   "2Gi",
 			},
 		}, delta)
 		scanner.jobCheckInterval = 1 * time.Microsecond

--- a/imagescan/scanner_test.go
+++ b/imagescan/scanner_test.go
@@ -37,6 +37,7 @@ func TestScanner(t *testing.T) {
 				Image: config.ImageScanImage{
 					Name: "imgcollector:1.0.0",
 				},
+				APIUrl:            "http://kvisor:6060",
 				DockerOptionsPath: "/etc/docker/config.json",
 				BlobsCachePort:    8080,
 				CPURequest:        "500m",
@@ -152,23 +153,8 @@ func TestScanner(t *testing.T) {
 										Value: "p1,p2",
 									},
 									{
-										Name:  "API_URL",
-										Value: "https://api.cast.ai",
-									},
-									{
-										Name: "API_KEY",
-										ValueFrom: &corev1.EnvVarSource{
-											SecretKeyRef: &corev1.SecretKeySelector{
-												LocalObjectReference: corev1.LocalObjectReference{
-													Name: "castai-kvisor",
-												},
-												Key: "API_KEY",
-											},
-										},
-									},
-									{
-										Name:  "CLUSTER_ID",
-										Value: "c1",
+										Name:  "KVISOR_SERVER_API_URL",
+										Value: "http://kvisor:6060",
 									},
 									{
 										Name:  "COLLECTOR_BLOBS_CACHE_URL",


### PR DESCRIPTION
* Do not send image scan report directly from job. We allow to configure custom secret name for kvisor deployment. Currently jobs are using hardcoded secret name `kvisor`. Now job will send result back to kvisor agent and kvisor agent will send result to CAST AI platform. This allows to remove any dependency on remote api in scan job.
* All configs should have full env name to prevent conflicts.
* Blocks cache can now use the same kvisor agent http server exposed via service. No need to use hardcoded pod IP.