### PR TITLE
Use secret to pull images

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -5,6 +5,23 @@ To run agent locally you only need to have correct kubernetes contex and KUBECON
 go run ./cmd/agent
 ```
 
+### Creating image pull secrets
+
+To create secrets for specifying in kvisor config's `pullSecret` attribute there are two options:
+- From credential file:
+```shell
+kubectl -n [namespace] create secret docker-registry [secret-name] \
+  --from-file=.dockerconfigjson=/absolute/path/to/.docker/config.json
+```
+- From credential helper:
+```shell
+kubectl -n [namespace] create secret docker-registry [secret-name] \
+  --docker-server=[registry-server] \
+  --docker-username=[registry-username] \
+  --docker-password=[registry-password]
+```
+Read [more](https://docs.docker.com/engine/reference/commandline/login/#credential-helper-protocol).
+
 ### Running locally on tilt
 
 Start tilt on local kind cluster with mockapi backend which is located in ./tools/mockapi.

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
+TARGETARCH ?= amd64
+
 build-agent:
-	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/castai-kvisor ./cmd/agent
+	GOOS=linux GOARCH=$(TARGETARCH) go build -ldflags="-s -w" -o bin/castai-kvisor-$(TARGETARCH) ./cmd/agent
 
 build-agent-github-docker: build-agent
-	docker build -t ghcr.io/castai/kvisor/kvisor:$(IMAGE_TAG) -f Dockerfile.agent .
+	docker buildx build --build-arg TARGETARCH=$(TARGETARCH) --platform linux/$(TARGETARCH) -t ghcr.io/castai/kvisor/kvisor:$(IMAGE_TAG) -f Dockerfile.agent .
 
 push-agent-github-docker: build-agent-github-docker
 	docker push ghcr.io/castai/kvisor/kvisor:$(IMAGE_TAG)
 
 build-imgcollector:
-	GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o bin/castai-imgcollector ./cmd/imgcollector
+	GOOS=linux GOARCH=$(TARGETARCH) go build -ldflags="-s -w" -o bin/castai-imgcollector-$(TARGETARCH) ./cmd/imgcollector
 
 build-imgcollector-github-docker: build-imgcollector
-	docker build -t ghcr.io/castai/kvisor/kvisor-imgcollector:$(IMAGE_TAG) -f Dockerfile.imgcollector .
+	docker buildx build --build-arg TARGETARCH=$(TARGETARCH) --platform linux/$(TARGETARCH) -t ghcr.io/castai/kvisor/kvisor-imgcollector:$(IMAGE_TAG) -f Dockerfile.imgcollector .
 
 push-imgcollector-github-docker: build-imgcollector-github-docker
 	docker push ghcr.io/castai/kvisor/kvisor-imgcollector:$(IMAGE_TAG)

--- a/charts/castai-kvisor/values.yaml
+++ b/charts/castai-kvisor/values.yaml
@@ -1,5 +1,3 @@
-# Default values for castai-kvisor.
-# This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
 replicas: 1
@@ -24,6 +22,8 @@ image:
   pullPolicy: IfNotPresent
 
 imagePullSecrets: {}
+
+imageScanSecret: ""
 
 # Controls `deployment.spec.strategy` field
 updateStrategy:
@@ -87,6 +87,9 @@ config: |
     image:
       name: "{{ .Values.image.repository }}-imgcollector:{{ .Values.image.tag | default .Chart.AppVersion }}"
       pullPolicy: IfNotPresent
+    {{ if .Values.imageScanSecret }}
+    pullSecret: "{{ .Values.imageScanSecret }}"
+    {{ end }}
   cloudScan:
     enabled: false
     scanInterval: "1h"

--- a/cmd/imgcollector/config/config_test.go
+++ b/cmd/imgcollector/config/config_test.go
@@ -1,0 +1,26 @@
+package config
+
+import (
+	"encoding/json"
+	"testing"
+	"testing/fstest"
+
+	"github.com/castai/kvisor/cmd/imgcollector/image"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadImagePullSecret(t *testing.T) {
+	r := require.New(t)
+
+	data, err := ReadImagePullSecret(fstest.MapFS{".dockerconfigjson": {
+		Data: []byte(`{"auths": {"ghcr.io": {"username": "username", "password": "password", "auth": "token"}}}`),
+	}})
+	r.NoError(err)
+
+	var cfg image.DockerConfig
+	r.NoError(err, json.Unmarshal(data, &cfg))
+	auth := cfg.Auths["ghcr.io"]
+	r.Equal("username", auth.Username)
+	r.Equal("password", auth.Password)
+	r.Equal("token", auth.Token)
+}

--- a/cmd/imgcollector/image/image.go
+++ b/cmd/imgcollector/image/image.go
@@ -2,8 +2,10 @@ package image
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/aquasecurity/trivy/pkg/fanal/types"
+	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
@@ -33,4 +35,10 @@ func LayerIDs(img v1.Image) ([]string, error) {
 		layerIDs = append(layerIDs, d.String())
 	}
 	return layerIDs, nil
+}
+
+func NamespacedRegistry(ref name.Reference) string {
+	fullName := ref.Context().Name()
+	parts := strings.Split(fullName, "/")
+	return strings.Join(parts[:2], "/")
 }

--- a/cmd/imgcollector/image/image_test.go
+++ b/cmd/imgcollector/image/image_test.go
@@ -1,0 +1,44 @@
+package image
+
+import (
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNamespacedRegistry(t *testing.T) {
+	tests := []struct {
+		name     string
+		ref      name.Reference
+		expected string
+	}{
+		{
+			name:     "Github Container Registry",
+			ref:      name.MustParseReference("ghcr.io/castai/kvisor/kvisor:latest"),
+			expected: "ghcr.io/castai",
+		},
+		{
+			name:     "Gitlab Container Registry",
+			ref:      name.MustParseReference("registry.gitlab.com/castai/kvisor/kvisor:latest"),
+			expected: "registry.gitlab.com/castai",
+		},
+		{
+			name:     "Docker Container Registry Organization",
+			ref:      name.MustParseReference("castai/kvisor"),
+			expected: "index.docker.io/castai",
+		},
+		{
+			name:     "Docker Container Registry",
+			ref:      name.MustParseReference("kvisor"),
+			expected: "index.docker.io/library",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			registry := NamespacedRegistry(test.ref)
+			assert.Equal(t, test.expected, registry)
+		})
+	}
+}

--- a/cmd/imgcollector/image/remote.go
+++ b/cmd/imgcollector/image/remote.go
@@ -15,6 +15,16 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
+type DockerConfig struct {
+	Auths map[string]RegistryAuth `json:"auths"`
+}
+
+type RegistryAuth struct {
+	Username string `json:"username"`
+	Password string `json:"password"`
+	Token    string `json:"auth"`
+}
+
 type DockerOption struct {
 	// Auth
 	UserName string `yaml:"user_name"`

--- a/config/config.go
+++ b/config/config.go
@@ -80,6 +80,7 @@ type ImageScan struct {
 	Force              bool           `envconfig:"IMAGE_SCAN_FORCE" yaml:"force"`
 	ProfileEnabled     bool           `envconfig:"IMAGE_SCAN_PROFILE_ENABLED" yaml:"profileEnabled"`
 	PhlareEnabled      bool           `envconfig:"IMAGE_SCAN_PHLARE_ENABLED" yaml:"phlareEnabled"`
+	PullSecret         string         `envconfig:"IMAGE_SCAN_PULL_SECRET" yaml:"pullSecret"`
 }
 
 type ImageScanImage struct {

--- a/controller/controller.go
+++ b/controller/controller.go
@@ -138,7 +138,7 @@ func (c *Controller) transformFunc(i any) (any, error) {
 	obj := i.(Object)
 	// Add missing metadata which is removed by k8s.
 	addObjectMeta(obj)
-	// Remove manged fields since we don't need them. This should decrease memory usage.
+	// Remove managed fields since we don't need them. This should decrease memory usage.
 	obj.SetManagedFields(nil)
 	if _, ok := obj.(*appsv1.DaemonSet); ok {
 		// Remove this fields for ds to fix https://github.com/kubernetes/kubernetes/pull/106388 by custom hashing.

--- a/hack/install_agent.sh
+++ b/hack/install_agent.sh
@@ -1,20 +1,17 @@
 #!/bin/bash
-
 set -e
 
-local_charts_path="../gh-helm-charts/charts/castai-kvisor"
+default_chart_path="../gh-helm-charts/charts/castai-kvisor"
+chart_path="${CHART_PATH:-$default_chart_path}"
 
 default_api_url="https://api.cast.ai"
 api_url="${API_URL:-$default_api_url}"
 
-default_image_repo="ghcr.io/castai/kvisor"
+default_image_repo="ghcr.io/castai/kvisor/kvisor"
 image_repo="${IMAGE_REPO:-$default_image_repo}"
 
-default_image_tag="alpha1"
-image_tag="${IMAGE_TAG:-$default_image_tag}"
-
 if [ "$API_KEY" == "" ]; then
-  echo "CLUSTER_ID is required"
+  echo "API_KEY is required"
   exit 1
 fi
 
@@ -23,10 +20,22 @@ if [ "$CLUSTER_ID" == "" ]; then
   exit 1
 fi
 
-helm upgrade --install --create-namespace castai-kvisor $local_charts_path --devel \
-	--namespace castai-sec \
+if [ "$SECRET_NAME" == "" ]; then
+  echo "SECRET_NAME is required"
+  exit 1
+fi
+
+if [ "$IMAGE_TAG" == "" ]; then
+  echo "IMAGE_TAG is required"
+  exit 1
+fi
+
+helm upgrade --install --create-namespace castai-kvisor $chart_path --devel \
+	--namespace castai-agent \
 	--set castai.apiURL=${api_url} \
 	--set castai.apiKey=${API_KEY} \
 	--set castai.clusterID=${CLUSTER_ID} \
+	--set 'castai.imagePullSecrets[0].name=castai-kvisor-github' \
 	--set image.repository=${image_repo} \
-	--set image.tag=${image_tag}
+	--set image.tag=${IMAGE_TAG} \
+	--set imageScanSecret=${SECRET_NAME}


### PR DESCRIPTION
Newer (1.25+) versions of Kubernetes include:
```toml
[plugins."io.containerd.grpc.v1.cri".containerd]
discard_unpacked_layers = true
```
which necessitates image pull secrets for image scanning to work.

The following `--docker-server` url patterns for `kubernetes.io/dockerconfigjson` secret are supported:
- `registry.tld`
- `registry.tld/namespace`
- `registry.tld/namespace/repository`