### PR TITLE
 Find last known pod owners

### DIFF
--- a/imagescan/delta_test.go
+++ b/imagescan/delta_test.go
@@ -67,7 +67,7 @@ func TestDelta(t *testing.T) {
 			}
 		}
 
-		delta := newDeltaState()
+		delta := newTestDelta()
 
 		pod1 := createPod("nginx1", "img1", "node1")
 		pod2 := createPod("nginx2", "img2", "node1")
@@ -104,7 +104,7 @@ func TestDelta(t *testing.T) {
 	t.Run("find best node for image scan", func(t *testing.T) {
 		r := require.New(t)
 
-		delta := newDeltaState()
+		delta := newTestDelta()
 
 		delta.upsert(&corev1.Node{
 			TypeMeta: metav1.TypeMeta{
@@ -208,7 +208,7 @@ func TestDelta(t *testing.T) {
 
 	t.Run("returns error when no best node find", func(t *testing.T) {
 		r := require.New(t)
-		delta := newDeltaState()
+		delta := newTestDelta()
 
 		delta.upsert(&corev1.Node{
 			TypeMeta: metav1.TypeMeta{
@@ -272,7 +272,7 @@ func TestDelta(t *testing.T) {
 
 	t.Run("frees up resources", func(t *testing.T) {
 		r := require.New(t)
-		delta := newDeltaState()
+		delta := newTestDelta()
 
 		delta.upsert(&corev1.Node{
 			TypeMeta: metav1.TypeMeta{
@@ -331,7 +331,7 @@ func TestDelta(t *testing.T) {
 
 	t.Run("cleans up image references", func(t *testing.T) {
 		r := require.New(t)
-		delta := newDeltaState()
+		delta := newTestDelta()
 
 		node := &corev1.Node{
 			TypeMeta: metav1.TypeMeta{
@@ -401,4 +401,8 @@ func TestDelta(t *testing.T) {
 		_, found = delta.nodes["node1"]
 		r.False(found)
 	})
+}
+
+func newTestDelta() *deltaState {
+	return newDeltaState(&mockPodOwnerGetter{})
 }

--- a/kube/types.go
+++ b/kube/types.go
@@ -2,11 +2,8 @@ package kube
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"reflect"
 
-	json "github.com/json-iterator/go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -34,20 +31,4 @@ const (
 type Object interface {
 	runtime.Object
 	metav1.Object
-}
-
-func ObjectKey(obj Object) string {
-	return string(obj.GetUID())
-}
-
-func ObjectHash(obj Object) (string, error) {
-	h := sha256.New()
-	// Use std compatible json config since we need sorted map keys.
-	b, err := json.ConfigCompatibleWithStandardLibrary.Marshal(obj)
-	if err != nil {
-		return "", err
-	}
-	h.Write(b)
-	hash := hex.EncodeToString(h.Sum(nil))
-	return hash, nil
 }


### PR DESCRIPTION
Previously in deltas and image scans we would send any last owner from pod owners references. In some cases pods could be managed by custom crds. We don't sync custom crds hence we lose relationship to cluster resource.

Now kube controller will return last known owner id for the pod. Image controller and deltas controller attaches this owner during reports sending.