### PR TITLE
Fix image delta dangling records

### DIFF
--- a/castai/imagemeta_types.go
+++ b/castai/imagemeta_types.go
@@ -38,6 +38,5 @@ type Image struct {
 }
 
 type ResourcesChange struct {
-	ResourceIDs        []string `json:"resourceIDs"`
-	RemovedResourceIDs []string `json:"removedResourceIDs"`
+	ResourceIDs []string `json:"resourceIDs"`
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -353,6 +353,7 @@ func run(ctx context.Context, logger logrus.FieldLogger, castaiClient castai.Cli
 		scanHandler := imagescan.NewHttpHandlers(log, castaiClient, imgScanCtrl)
 		httpMux.HandleFunc("/v1/image-scan/report", scanHandler.HandleImageMetadata)
 		httpMux.HandleFunc("/debug/images", scanHandler.HandleDebugGetImages)
+		httpMux.HandleFunc("/debug/images/details", scanHandler.HandleDebugGetImage)
 		blobsCache := blobscache.NewServer(log, blobscache.ServerConfig{})
 		blobsCache.RegisterHandlers(httpMux)
 	}

--- a/imagescan/controller.go
+++ b/imagescan/controller.go
@@ -12,8 +12,6 @@ import (
 	"github.com/castai/kvisor/castai"
 	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -77,8 +75,6 @@ type Controller struct {
 func (s *Controller) RequiredInformers() []reflect.Type {
 	rt := []reflect.Type{
 		reflect.TypeOf(&corev1.Pod{}),
-		reflect.TypeOf(&appsv1.ReplicaSet{}),
-		reflect.TypeOf(&batchv1.Job{}),
 		reflect.TypeOf(&corev1.Node{}),
 	}
 	return rt

--- a/imagescan/controller.go
+++ b/imagescan/controller.go
@@ -38,13 +38,14 @@ func NewController(
 	podOwnerGetter podOwnerGetter,
 ) *Controller {
 	ctx, cancel := context.WithCancel(context.Background())
+	log = log.WithField("component", "imagescan")
 	return &Controller{
 		ctx:               ctx,
 		cancel:            cancel,
 		imageScanner:      imageScanner,
 		client:            client,
 		delta:             newDeltaState(podOwnerGetter),
-		log:               log.WithField("component", "imagescan"),
+		log:               log,
 		cfg:               cfg,
 		k8sVersionMinor:   k8sVersionMinor,
 		timeGetter:        timeGetter(),
@@ -335,8 +336,7 @@ func (s *Controller) sendImagesResourcesChanges(ctx context.Context) {
 			ID:           img.id,
 			Architecture: img.architecture,
 			ResourcesChange: castai.ResourcesChange{
-				ResourceIDs:        img.ownerChanges.addedIDS,
-				RemovedResourceIDs: img.ownerChanges.removedIDs,
+				ResourceIDs: lo.Uniq(img.ownerChanges.addedIDS),
 			},
 		})
 	}

--- a/imagescan/controller_test.go
+++ b/imagescan/controller_test.go
@@ -256,7 +256,7 @@ func TestSubscriber(t *testing.T) {
 			return time.Now().UTC().Add(time.Hour)
 		}
 		delta := sub.delta
-		img := newImage("img1", "amd64")
+		img := newImage("img1amd64", "img1", "amd64")
 		img.name = "img"
 		img.nodes = map[string]*imageNode{
 			"node1": {},
@@ -321,7 +321,7 @@ func TestSubscriber(t *testing.T) {
 			return time.Now().UTC().Add(time.Hour)
 		}
 		delta := sub.delta
-		img := newImage("img1", "amd64")
+		img := newImage("img1amd64", "img1", "amd64")
 		img.name = "img"
 		img.containerRuntime = imgcollectorconfig.RuntimeContainerd
 		img.nodes = map[string]*imageNode{
@@ -385,7 +385,7 @@ func TestSubscriber(t *testing.T) {
 			return time.Now().UTC().Add(time.Hour)
 		}
 		delta := sub.delta
-		img := newImage("img1", "amd64")
+		img := newImage("img1amd64", "img1", "amd64")
 		img.name = "img"
 		img.containerRuntime = imgcollectorconfig.RuntimeContainerd
 		img.owners = map[string]*imageOwner{
@@ -505,14 +505,13 @@ func TestSubscriber(t *testing.T) {
 			return time.Now().UTC().Add(time.Hour)
 		}
 		delta := sub.delta
-		img := newImage("img1", "amd64")
+		img := newImage("img1amd64", "img1", "amd64")
 		img.name = "img"
 		img.owners = map[string]*imageOwner{
 			"r1": {},
 		}
 		img.ownerChanges = ownerChanges{
-			addedIDS:   []string{"r1"},
-			removedIDs: []string{"r2"},
+			addedIDS: []string{"r1"},
 		}
 		delta.images[img.cacheKey()] = img
 
@@ -545,7 +544,6 @@ func TestSubscriber(t *testing.T) {
 			r.Equal("img1", change2Img1.ID)
 			r.Equal("amd64", change2Img1.Architecture)
 			r.Equal([]string{"r1"}, change2Img1.ResourcesChange.ResourceIDs)
-			r.Equal([]string{"r2"}, change2Img1.ResourcesChange.RemovedResourceIDs)
 
 			return true
 		})
@@ -589,14 +587,14 @@ func TestSubscriber(t *testing.T) {
 			return time.Now().UTC().Add(time.Hour)
 		}
 		delta := sub.delta
-		img1 := newImage("img1", "amd64")
+		img1 := newImage("img1amd64", "img1", "amd64")
 		img1.name = "img1"
 		img1.owners = map[string]*imageOwner{
 			"r1": {},
 		}
 		delta.images[img1.cacheKey()] = img1
 
-		img2 := newImage("img2", "amd64")
+		img2 := newImage("img1amd64", "img2", "amd64")
 		img2.name = "img2"
 		img2.owners = map[string]*imageOwner{
 			"r2": {},

--- a/imagescan/delta.go
+++ b/imagescan/delta.go
@@ -146,7 +146,9 @@ func (d *deltaState) updateNodesUsageFromPod(v *corev1.Pod) {
 }
 
 func (d *deltaState) upsertImages(pod *corev1.Pod) {
-	// Skip pods which are not running. If pod is running this means that container image should be already downloaded.
+	if _, found := d.nodes[pod.Spec.NodeName]; !found {
+		return
+	}
 	containers := pod.Spec.Containers
 	containers = append(containers, pod.Spec.InitContainers...)
 	containerStatuses := pod.Status.ContainerStatuses

--- a/imagescan/delta.go
+++ b/imagescan/delta.go
@@ -118,13 +118,7 @@ func (d *deltaState) updateNodesUsageFromPod(v *corev1.Pod) {
 	case corev1.PodRunning, corev1.PodPending:
 		n, found := d.nodes[v.Spec.NodeName]
 		if !found {
-			n = &node{
-				name:           v.Spec.NodeName,
-				allocatableMem: &inf.Dec{},
-				allocatableCPU: &inf.Dec{},
-				pods:           make(map[types.UID]*pod),
-			}
-			d.nodes[v.Spec.NodeName] = n
+			return
 		}
 
 		p, found := n.pods[v.GetUID()]

--- a/imagescan/delta.go
+++ b/imagescan/delta.go
@@ -21,12 +21,15 @@ var (
 	errNoCandidates = errors.New("no candidates")
 )
 
+const defaultImageArch = "amd64"
+
 type podOwnerGetter interface {
 	GetPodOwnerID(pod *corev1.Pod) string
 }
 
-func newImage(imageID, architecture string) *image {
+func newImage(key, imageID, architecture string) *image {
 	return &image{
+		key:          key,
 		id:           imageID,
 		architecture: architecture,
 		owners:       map[string]*imageOwner{},
@@ -171,17 +174,12 @@ func (d *deltaState) upsertImages(pod *corev1.Pod) {
 			continue
 		}
 
-		arch := "amd64"
 		nodeName := pod.Spec.NodeName
-		n, ok := d.nodes[nodeName]
-		if ok {
-			arch = n.architecture
-		}
-
-		key := cs.ImageID + arch
+		arch := d.getPodArch(pod)
+		key := d.getImageKey(cs.ImageID, arch)
 		img, found := d.images[key]
 		if !found {
-			img = newImage(cs.ImageID, arch)
+			img = newImage(key, cs.ImageID, arch)
 		}
 		img.id = cs.ImageID
 		img.name = cont.Image
@@ -218,6 +216,10 @@ func (d *deltaState) upsertImages(pod *corev1.Pod) {
 
 func (d *deltaState) handlePodDelete(pod *corev1.Pod) {
 	for imgKey, img := range d.images {
+		if img.architecture != d.getPodArch(pod) {
+			continue
+		}
+
 		podID := string(pod.UID)
 		if n, found := img.nodes[pod.Spec.NodeName]; found {
 			delete(n.podIDs, podID)
@@ -228,10 +230,6 @@ func (d *deltaState) handlePodDelete(pod *corev1.Pod) {
 			delete(owner.podIDs, podID)
 			if len(owner.podIDs) == 0 {
 				delete(img.owners, ownerResourceID)
-				// Add changed owner.
-				if img.scanned {
-					img.ownerChanges.removedIDs = append(img.ownerChanges.removedIDs, ownerResourceID)
-				}
 			}
 		}
 
@@ -327,6 +325,19 @@ func (d *deltaState) setImageScanned(scannedImg castai.ScannedImage) {
 	}
 }
 
+func (d *deltaState) getImageKey(imageID, arch string) string {
+	key := imageID + arch
+	return key
+}
+
+func (d *deltaState) getPodArch(pod *corev1.Pod) string {
+	n, ok := d.nodes[pod.Spec.NodeName]
+	if ok && n.architecture != "" {
+		return n.architecture
+	}
+	return defaultImageArch
+}
+
 func getContainerRuntime(containerID string) imgcollectorconfig.Runtime {
 	parts := strings.Split(containerID, "://")
 	if len(parts) != 2 {
@@ -410,6 +421,8 @@ var (
 )
 
 type image struct {
+	key string
+
 	// id is ImageID from container status. It includes image name and digest.
 	//
 	// Note: ImageID's digest part could confuse you with actual image digest.
@@ -455,15 +468,13 @@ func (img *image) isUnused() bool {
 }
 
 type ownerChanges struct {
-	addedIDS   []string
-	removedIDs []string
+	addedIDS []string
 }
 
 func (c *ownerChanges) empty() bool {
-	return len(c.addedIDS) == 0 && len(c.removedIDs) == 0
+	return len(c.addedIDS) == 0
 }
 
 func (c *ownerChanges) clear() {
 	c.addedIDS = []string{}
-	c.removedIDs = []string{}
 }

--- a/imagescan/delta_test.go
+++ b/imagescan/delta_test.go
@@ -385,19 +385,17 @@ func TestDelta(t *testing.T) {
 		}
 
 		delta.upsert(pod)
-		img, found := delta.images["testid"]
+		img, found := delta.images["testidamd64"]
 		r.True(found)
 		r.Len(img.owners, 1)
 		r.Len(img.nodes, 1)
 
 		delta.delete(pod)
-
-		img, found = delta.images["testid"]
+		img, found = delta.images["testidamd64"]
 		r.True(found)
 		r.Len(img.owners, 0)
 
 		delta.delete(node)
-
 		_, found = delta.nodes["node1"]
 		r.False(found)
 	})

--- a/kube/controller.go
+++ b/kube/controller.go
@@ -262,18 +262,20 @@ func (c *Controller) eventsHandler(ctx context.Context, typ reflect.Type) cache.
 	}
 }
 
-func (c *Controller) handleEvent(obj any, eventType eventType, subs []subChannel) {
+func (c *Controller) handleEvent(eventObject any, eventType eventType, subs []subChannel) {
 	var actualObj Object
-	if deleted, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+	if deleted, ok := eventObject.(cache.DeletedFinalStateUnknown); ok {
 		obj, ok := deleted.Obj.(Object)
 		if !ok {
+			c.log.Errorf("expected kube.Object, got %T, key=%s", deleted.Obj, deleted.Key)
 			return
 		}
 		actualObj = obj
 		eventType = eventTypeDelete
 	} else {
-		obj, ok := obj.(Object)
+		obj, ok := eventObject.(Object)
 		if !ok {
+			c.log.Errorf("expected kube.Object, got %T", eventObject)
 			return
 		}
 		actualObj = obj

--- a/kube/controller.go
+++ b/kube/controller.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -62,6 +64,7 @@ func NewController(
 		informers:            typeInformerMap,
 		podsBuffSyncInterval: 5 * time.Second,
 		replicaSets:          make(map[types.UID]*appsv1.ReplicaSet),
+		deployments:          make(map[types.UID]*appsv1.Deployment),
 		jobs:                 make(map[types.UID]*batchv1.Job),
 	}
 	return c
@@ -78,6 +81,7 @@ type Controller struct {
 
 	deltasMu    sync.RWMutex
 	replicaSets map[types.UID]*appsv1.ReplicaSet
+	deployments map[types.UID]*appsv1.Deployment
 	jobs        map[types.UID]*batchv1.Job
 }
 
@@ -140,7 +144,20 @@ func (c *Controller) GetPodOwnerID(pod *corev1.Pod) string {
 
 		rs, found := c.replicaSets[ref.UID]
 		if found {
-			return string(findNextOwnerID(rs, "Deployment"))
+			// Fast path. Find Deployment from replica set.
+			if owner, found := findNextOwnerID(rs, "Deployment"); found {
+				return string(owner)
+			}
+		}
+
+		// Slow path. Find deployment by matching selectors.
+		// In this Deployment could be managed by some crd like ArgoRollouts.
+		if owner, found := findOwnerFromDeployments(c.deployments, pod); found {
+			return string(owner)
+		}
+
+		if found {
+			return string(rs.UID)
 		}
 	case "Job":
 		c.deltasMu.RLock()
@@ -148,7 +165,10 @@ func (c *Controller) GetPodOwnerID(pod *corev1.Pod) string {
 
 		job, found := c.jobs[ref.UID]
 		if found {
-			return string(findNextOwnerID(job, "CronJob"))
+			if owner, found := findNextOwnerID(job, "CronJob"); found {
+				return string(owner)
+			}
+			return string(job.UID)
 		}
 	}
 
@@ -281,6 +301,8 @@ func (c *Controller) handleDeltaUpsert(obj Object) {
 	switch v := obj.(type) {
 	case *appsv1.ReplicaSet:
 		c.replicaSets[v.UID] = v
+	case *appsv1.Deployment:
+		c.deployments[v.UID] = v
 	case *batchv1.Job:
 		c.jobs[v.UID] = v
 	}
@@ -293,6 +315,8 @@ func (c *Controller) handleDeltaDelete(obj Object) {
 	switch v := obj.(type) {
 	case *appsv1.ReplicaSet:
 		delete(c.replicaSets, v.UID)
+	case *appsv1.Deployment:
+		delete(c.deployments, v.UID)
 	case *batchv1.Job:
 		delete(c.jobs, v.UID)
 	}
@@ -386,17 +410,30 @@ func addObjectMeta(o Object) {
 	}
 }
 
-func findNextOwnerID(obj Object, expectedKind string) types.UID {
+func findNextOwnerID(obj Object, expectedKind string) (types.UID, bool) {
 	refs := obj.GetOwnerReferences()
 	if len(refs) == 0 {
-		return obj.GetUID()
+		return obj.GetUID(), true
 	}
 
 	for _, ref := range refs {
 		if ref.Kind == expectedKind {
-			return ref.UID
+			return ref.UID, true
 		}
 	}
 
-	return obj.GetUID()
+	return "", false
+}
+
+func findOwnerFromDeployments(items map[types.UID]*appsv1.Deployment, pod *corev1.Pod) (types.UID, bool) {
+	for _, deployment := range items {
+		sel, err := metav1.LabelSelectorAsSelector(deployment.Spec.Selector)
+		if err != nil {
+			continue
+		}
+		if sel.Matches(labels.Set(pod.Labels)) {
+			return deployment.UID, true
+		}
+	}
+	return "", false
 }


### PR DESCRIPTION
* If node is removed skip images upsert on pod event. Pod even could lag a bit. Once we remove node we cleanup references, but pod event was adding these node refs back.
* Find pod owner Deployment using label selectors if ReplicaSet points to custom crd.
* Add image details debug page.


http://localhost:6060/debug/images
<img width="1799" alt="Screenshot 2023-10-10 at 13 34 20" src="https://github.com/castai/kvisor/assets/3028012/589af3dc-cd70-4df0-9661-1764bf18fc1c">

