### PR TITLE
Remove `priority` set from image-scanner job

### DIFF
--- a/cmd/controller/state/imagescan/scanner.go
+++ b/cmd/controller/state/imagescan/scanner.go
@@ -418,7 +418,6 @@ func scanJobSpec(
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
-					Priority:           lo.ToPtr(int32(0)),
 					ServiceAccountName: cfg.ServiceAccount,
 					Affinity: &corev1.Affinity{
 						NodeAffinity: &corev1.NodeAffinity{

--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -86,7 +86,6 @@ func TestScanner(t *testing.T) {
 					},
 					Spec: corev1.PodSpec{
 						RestartPolicy: "Never",
-						Priority:      lo.ToPtr(int32(0)),
 						Affinity: &corev1.Affinity{
 							NodeAffinity: &corev1.NodeAffinity{
 								RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{


### PR DESCRIPTION
In order to prevent issues with an enabled priority admission controller, jobs created by the imagescanner subsystem no longer set it on the created jobs.