### PR TITLE
Increase write timeout of pprof servers to 1 minute

### DIFF
--- a/cmd/agent/daemon/app/app.go
+++ b/cmd/agent/daemon/app/app.go
@@ -330,7 +330,7 @@ func (a *App) runHTTPServer(ctx context.Context, log *logging.Logger) error {
 		Addr:         fmt.Sprintf(":%d", a.cfg.HTTPListenPort),
 		Handler:      mux,
 		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		WriteTimeout: 1 * time.Minute,
 	}
 
 	go func() {

--- a/cmd/controller/app/app.go
+++ b/cmd/controller/app/app.go
@@ -224,7 +224,7 @@ func (a *App) runHTTPServer(ctx context.Context, log *logging.Logger) error {
 		Addr:         fmt.Sprintf(":%d", a.cfg.HTTPListenPort),
 		Handler:      e,
 		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 10 * time.Second,
+		WriteTimeout: 1 * time.Minute,
 	}
 	go func() {
 		<-ctx.Done()


### PR DESCRIPTION
The profile endpoint of the pprof mux will fail, if the write timeout is smaller than the specified profile time. By default this profile time is 30 seconds.

To not run into issues when wanting to profile the agents performance, the write timeout of the pprof servers have been incresed to 1min.