### PR TITLE
Introduce own perf buffer for important events

### DIFF
--- a/charts/kvisor/values-local.yaml
+++ b/charts/kvisor/values-local.yaml
@@ -13,7 +13,7 @@ agent:
     log-level: debug
     container-stats-scrape-interval: 10s
     pyroscope-addr: http://kvisord-pyroscope:4040
-    enable-file-hash-enricher: true
+    file-hash-enricher-enabled: true
 
   containerSecurityContext:
     readOnlyRootFilesystem: false

--- a/cmd/agent/daemon/app/app.go
+++ b/cmd/agent/daemon/app/app.go
@@ -180,6 +180,7 @@ func (a *App) Run(ctx context.Context) error {
 		DefaultCgroupsVersion:   cgroupClient.DefaultCgroupVersion().String(),
 		ActualDestinationGetter: ct,
 		ContainerClient:         containersClient,
+		CgroupClient:            cgroupClient,
 		EnrichEvent:             enrichmentService.Enqueue,
 		MountNamespacePIDStore:  mountNamespacePIDStore,
 		HomePIDNS:               pidNSID,
@@ -190,7 +191,8 @@ func (a *App) Run(ctx context.Context) error {
 	policy := &ebpftracer.Policy{
 		SignatureEngine: signatureEngine,
 		SystemEvents: []events.ID{
-			events.CgroupRmdir,
+			events.SignalCgroupMkdir,
+			events.SignalCgroupRmdir,
 		},
 		Events: []*ebpftracer.EventPolicy{
 			{ID: events.SchedProcessExec},

--- a/pkg/castai/client_test.go
+++ b/pkg/castai/client_test.go
@@ -164,7 +164,7 @@ func (t *testServer) EventsWriteStream(server castaipb.RuntimeSecurityAgentAPI_E
 	if t.eventsWriteStreamHandler != nil {
 		return t.eventsWriteStreamHandler(server)
 	}
-	
+
 	md, ok := metadata.FromIncomingContext(server.Context())
 	if !ok {
 		return errors.New("no metadata")

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -9,11 +9,11 @@ import (
 )
 
 type Cgroup struct {
-	Id            uint64
-	Version       Version
+	Id               uint64
+	Version          Version
 	ContainerRuntime ContainerRuntimeID
-	ContainerID   string
-	Path          string
+	ContainerID      string
+	Path             string
 
 	subsystems map[string]string
 	cgRoot     string

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -11,7 +11,7 @@ import (
 type Cgroup struct {
 	Id            uint64
 	Version       Version
-	ContainerType ContainerType
+	ContainerRuntime ContainerRuntimeID
 	ContainerID   string
 	Path          string
 

--- a/pkg/cgroup/client_test.go
+++ b/pkg/cgroup/client_test.go
@@ -16,7 +16,7 @@ func TestNewFromProcessCgroupFile(t *testing.T) {
 	assert.Equal(t, "/system.slice/docker.service", cg.Id)
 	assert.Equal(t, V1, cg.Version)
 	assert.Equal(t, "/system.slice/docker.service", cg.ContainerID)
-	assert.Equal(t, ContainerTypeSystemdService, cg.ContainerType)
+	assert.Equal(t, DockerRuntime, cg.ContainerRuntime)
 
 	assert.Equal(t,
 		map[string]string{
@@ -42,21 +42,21 @@ func TestNewFromProcessCgroupFile(t *testing.T) {
 	assert.Equal(t, V1, cg.Version)
 	assert.Equal(t, "/docker/b43d92bf1e5c6f78bb9b7bc6f40721280299855ba692092716e3a1b6c0b86f3f", cg.Id)
 	assert.Equal(t, "b43d92bf1e5c6f78bb9b7bc6f40721280299855ba692092716e3a1b6c0b86f3f", cg.ContainerID)
-	assert.Equal(t, ContainerTypeDocker, cg.ContainerType)
+	assert.Equal(t, DockerRuntime, cg.ContainerRuntime)
 
 	cg, err = NewFromProcessCgroupFile(path.Join("fixtures/proc/300/cgroup"))
 	assert.Nil(t, err)
 	assert.Equal(t, V1, cg.Version)
 	assert.Equal(t, "/kubepods/burstable/pod6a4ce4a0-ba47-11ea-b2a7-0cc47ac5979e/17db96a24ae1e9dd57143e62b1cb0d2d35e693c65c774c7470e87b0572e07c1a", cg.Id)
 	assert.Equal(t, "17db96a24ae1e9dd57143e62b1cb0d2d35e693c65c774c7470e87b0572e07c1a", cg.ContainerID)
-	assert.Equal(t, ContainerTypeDocker, cg.ContainerType)
+	assert.Equal(t, DockerRuntime, cg.ContainerRuntime)
 
 	cg, err = NewFromProcessCgroupFile(path.Join("fixtures/proc/400/cgroup"))
 	assert.Nil(t, err)
 	assert.Equal(t, V2, cg.Version)
 	assert.Equal(t, "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod8712f785_1a3e_41ec_a00b_e2dcc77431cb.slice/docker-73051af271105c07e1f493b34856a77e665e3b0b4fc72f76c807dfbffeb881bd.scope", cg.Id)
 	assert.Equal(t, "73051af271105c07e1f493b34856a77e665e3b0b4fc72f76c807dfbffeb881bd", cg.ContainerID)
-	assert.Equal(t, ContainerTypeDocker, cg.ContainerType)
+	assert.Equal(t, DockerRuntime, cg.ContainerRuntime)
 
 	baseCgroupPath = "/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podc83d0428_58af_41eb_8dba_b9e6eddffe7b.slice/docker-0e612005fd07e7f47e2cd07df99a2b4e909446814d71d0b5e4efc7159dd51252.scope"
 	defer func() {
@@ -67,76 +67,47 @@ func TestNewFromProcessCgroupFile(t *testing.T) {
 	assert.Equal(t, V2, cg.Version)
 	assert.Equal(t, "/system.slice/docker-ba7b10d15d16e10e3de7a2dcd408a3d971169ae303f46cfad4c5453c6326fee2.scope", cg.Id)
 	assert.Equal(t, "ba7b10d15d16e10e3de7a2dcd408a3d971169ae303f46cfad4c5453c6326fee2", cg.ContainerID)
-	assert.Equal(t, ContainerTypeDocker, cg.ContainerType)
+	assert.Equal(t, DockerRuntime, cg.ContainerRuntime)
 }
 
 func TestContainerByCgroup(t *testing.T) {
 	as := assert.New(t)
 
-	typ, id, err := containerByCgroup("/kubepods/burstable/pod9729a196c4723b60ab401eaff722982d/d166c6190614efc91956b78e96d74c3fbc96ca8e91948c36de3bc5b0e7b27d48")
-	as.Equal(typ, ContainerTypeDocker)
+	id, typ := getContainerIdFromCgroup("/kubepods/burstable/pod9729a196c4723b60ab401eaff722982d/d166c6190614efc91956b78e96d74c3fbc96ca8e91948c36de3bc5b0e7b27d48")
+	as.Equal(DockerRuntime, typ)
 	as.Equal("d166c6190614efc91956b78e96d74c3fbc96ca8e91948c36de3bc5b0e7b27d48", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/kubepods/besteffort/pod0d08203e-255a-11e9-8cd9-0007cb0b2cc8/671a50f5d60566556912f61511d0ec9e4d5c78d53fbc4676727180438bbbbc55/kube-proxy")
-	as.Equal(typ, ContainerTypeDocker)
+	id, typ = getContainerIdFromCgroup("/kubepods/besteffort/pod0d08203e-255a-11e9-8cd9-0007cb0b2cc8/671a50f5d60566556912f61511d0ec9e4d5c78d53fbc4676727180438bbbbc55/kube-proxy")
+	as.Equal(DockerRuntime, typ)
 	as.Equal("671a50f5d60566556912f61511d0ec9e4d5c78d53fbc4676727180438bbbbc55", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/kubepods/poda38c12e8-255a-11e9-8cd9-0007cb0b2cc8/32c562ed81a2622b37b80cb216859820ba51bd694f60ee4cf10d07a4011266f8")
-	as.Equal(typ, ContainerTypeDocker)
+	id, typ = getContainerIdFromCgroup("/kubepods/poda38c12e8-255a-11e9-8cd9-0007cb0b2cc8/32c562ed81a2622b37b80cb216859820ba51bd694f60ee4cf10d07a4011266f8")
+	as.Equal(DockerRuntime, typ)
 	as.Equal("32c562ed81a2622b37b80cb216859820ba51bd694f60ee4cf10d07a4011266f8", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/docker/63425c4a8b4291744a79dd9011fddc7a1f8ffda61f65d72196aa01d00cae2e2d")
-	as.Equal(typ, ContainerTypeDocker)
+	id, typ = getContainerIdFromCgroup("/docker/63425c4a8b4291744a79dd9011fddc7a1f8ffda61f65d72196aa01d00cae2e2d")
+	as.Equal(DockerRuntime, typ)
 	as.Equal("63425c4a8b4291744a79dd9011fddc7a1f8ffda61f65d72196aa01d00cae2e2d", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/lxc/mysql-primary-db")
-	as.Equal(typ, ContainerTypeLxc)
-	as.Equal("mysql-primary-db", id)
-	as.Nil(err)
-
-	typ, id, err = containerByCgroup("/kubepods/poda48c12e8-255a-11e9-8cd9-0007cb0b2cc8/crio-63425c4a8b4291744a79dd9011fddc7a1f8ffda61f65d72196aa01d00cae2e2e")
-	as.Equal(typ, ContainerTypeCrio)
+	id, typ = getContainerIdFromCgroup("/kubepods/poda48c12e8-255a-11e9-8cd9-0007cb0b2cc8/crio-63425c4a8b4291744a79dd9011fddc7a1f8ffda61f65d72196aa01d00cae2e2e")
+	as.Equal(CrioRuntime, typ)
 	as.Equal("63425c4a8b4291744a79dd9011fddc7a1f8ffda61f65d72196aa01d00cae2e2e", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2942c55e_c9cb_428a_93f4_eaf89c1f3ce0.slice/crio-49f9e8e5395d57c1083996c09e2e6f042d5fe1ec0310facab32f94912b35ce59.scope")
-	as.Equal(typ, ContainerTypeCrio)
+	id, typ = getContainerIdFromCgroup("/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod2942c55e_c9cb_428a_93f4_eaf89c1f3ce0.slice/crio-49f9e8e5395d57c1083996c09e2e6f042d5fe1ec0310facab32f94912b35ce59.scope")
+	as.Equal(CrioRuntime, typ)
 	as.Equal("49f9e8e5395d57c1083996c09e2e6f042d5fe1ec0310facab32f94912b35ce59", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod3e61c214bc3ed9ff81e21474dd6cba17.slice/cri-containerd-c74b0f5062f0bc726cae1e9369ad4a95deed6b298d247f0407475adb23fa3190")
-	as.Equal(typ, ContainerTypeContainerd)
+	id, typ = getContainerIdFromCgroup("/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod3e61c214bc3ed9ff81e21474dd6cba17.slice/cri-containerd-c74b0f5062f0bc726cae1e9369ad4a95deed6b298d247f0407475adb23fa3190")
+	as.Equal(ContainerdRuntime, typ)
 	as.Equal("c74b0f5062f0bc726cae1e9369ad4a95deed6b298d247f0407475adb23fa3190", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/unified/kubepods/burstable/podaacce108-eb34-4a36-ad41-a9f9d36b3a8f/df4f60dd7f7c9fdc110082804729e637c21c2bca7856b9a6d4bf36cfaef6a2d3")
-	as.Equal(typ, ContainerTypeDocker)
+	id, typ = getContainerIdFromCgroup("/unified/kubepods/burstable/podaacce108-eb34-4a36-ad41-a9f9d36b3a8f/df4f60dd7f7c9fdc110082804729e637c21c2bca7856b9a6d4bf36cfaef6a2d3")
+	as.Equal(DockerRuntime, typ)
 	as.Equal("df4f60dd7f7c9fdc110082804729e637c21c2bca7856b9a6d4bf36cfaef6a2d3", id)
-	as.Nil(err)
 
-	typ, id, err = containerByCgroup("/system.slice/system-serial\\x2dgetty.slice")
-	as.Equal(typ, ContainerTypeSystemdService)
-	as.Equal("/system.slice/system-serial\\x2dgetty.slice", id)
-	as.Nil(err)
-
-	typ, id, err = containerByCgroup("/runtime.slice/kubelet.service")
-	as.Equal(typ, ContainerTypeSystemdService)
-	as.Equal("/runtime.slice/kubelet.service", id)
-	as.Nil(err)
-
-	typ, id, err = containerByCgroup("/system.slice/system-postgresql.slice/postgresql@9.4-main.service")
-	as.Equal(typ, ContainerTypeSystemdService)
-	as.Equal("/system.slice/system-postgresql.slice", id)
-	as.Nil(err)
-
-	typ, id, err = containerByCgroup("/system.slice/containerd.service/kubepods-burstable-pod4ed02c0b_0df8_4d14_a30e_fd589ee4143a.slice:cri-containerd:d4a9f9195eaf7e4a729f24151101e1de61f1398677e7b82acfb936dff0b4ce55")
-	as.Equal(typ, ContainerTypeContainerd)
+	id, typ = getContainerIdFromCgroup("/system.slice/containerd.service/kubepods-burstable-pod4ed02c0b_0df8_4d14_a30e_fd589ee4143a.slice:cri-containerd:d4a9f9195eaf7e4a729f24151101e1de61f1398677e7b82acfb936dff0b4ce55")
+	as.Equal(ContainerdRuntime, typ)
 	as.Equal("d4a9f9195eaf7e4a729f24151101e1de61f1398677e7b82acfb936dff0b4ce55", id)
-	as.Nil(err)
 }
 
 func newTestClient() *Client {

--- a/pkg/ebpftracer/c/headers/types.h
+++ b/pkg/ebpftracer/c/headers/types.h
@@ -125,6 +125,12 @@ enum event_id_e {
     PROCESS_OOM_KILLED,
 };
 
+enum signal_event_id_e
+{
+    SIGNAL_CGROUP_MKDIR = 5000,
+    SIGNAL_CGROUP_RMDIR,
+};
+
 typedef struct args {
     unsigned long args[6];
 } args_t;

--- a/pkg/ebpftracer/c/tracee.bpf.c
+++ b/pkg/ebpftracer/c/tracee.bpf.c
@@ -6082,7 +6082,7 @@ int cgroup_mkdir_signal(struct bpf_raw_tracepoint_args *ctx)
     save_to_submit_buf(&signal->args_buf, &cgroup_id, sizeof(u64), 0);
     save_str_to_buf(&signal->args_buf, path, 1);
     save_to_submit_buf(&signal->args_buf, &hierarchy_id, sizeof(u32), 2);
-    signal_perf_submit(ctx, signal, CGROUP_MKDIR);
+    signal_perf_submit(ctx, signal, SIGNAL_CGROUP_MKDIR);
 
     return 0;
 }
@@ -6115,7 +6115,7 @@ int cgroup_rmdir_signal(struct bpf_raw_tracepoint_args *ctx)
     save_to_submit_buf(&signal->args_buf, &cgroup_id, sizeof(u64), 0);
     save_str_to_buf(&signal->args_buf, path, 1);
     save_to_submit_buf(&signal->args_buf, &hierarchy_id, sizeof(u32), 2);
-    signal_perf_submit(ctx, signal, CGROUP_RMDIR);
+    signal_perf_submit(ctx, signal, SIGNAL_CGROUP_RMDIR);
 
     return 0;
 }

--- a/pkg/ebpftracer/decoder/args_decoder.go
+++ b/pkg/ebpftracer/decoder/args_decoder.go
@@ -3,21134 +3,21134 @@
 package decoder
 
 import (
-  "errors"
+	"errors"
 
-  "github.com/castai/kvisor/pkg/ebpftracer/events"
-  "github.com/castai/kvisor/pkg/ebpftracer/types"
+	"github.com/castai/kvisor/pkg/ebpftracer/events"
+	"github.com/castai/kvisor/pkg/ebpftracer/types"
 )
 
 var (
-  ErrUnknownArgsType error = errors.New("unknown args type")
+	ErrUnknownArgsType error = errors.New("unknown args type")
 )
 
 // eventMaxByteSliceBufferSize is used to determine the max slice size allowed for different
 // event types. For example, most events have a max size of 4096, but for network related events
 // there is no max size (this is represented as -1).
 func eventMaxByteSliceBufferSize(id events.ID) int {
-  // For non network event, we have a max byte slice size of 4096
-  if id < events.NetPacketBase || id > events.MaxNetID {
-    return 4096
-  }
+	// For non network event, we have a max byte slice size of 4096
+	if id < events.NetPacketBase || id > events.MaxNetID {
+		return 4096
+	}
 
-  // Network events do not have a max buffer size.
-  return -1
+	// Network events do not have a max buffer size.
+	return -1
 }
 
 func ParseReadArgs(decoder *Decoder) (types.ReadArgs, error) {
-  var result types.ReadArgs
-  var err error
+	var result types.ReadArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ReadArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ReadArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ReadArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ReadArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.ReadArgs{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.ReadArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    case 2:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.ReadArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.ReadArgs{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.ReadArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		case 2:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.ReadArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseWriteArgs(decoder *Decoder) (types.WriteArgs, error) {
-  var result types.WriteArgs
-  var err error
+	var result types.WriteArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.WriteArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.WriteArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.WriteArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.WriteArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.WriteArgs{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.WriteArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    case 2:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.WriteArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.WriteArgs{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.WriteArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		case 2:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.WriteArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseOpenArgs(decoder *Decoder) (types.OpenArgs, error) {
-  var result types.OpenArgs
-  var err error
+	var result types.OpenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OpenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OpenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OpenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OpenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.OpenArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.OpenArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.OpenArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.OpenArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.OpenArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.OpenArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCloseArgs(decoder *Decoder) (types.CloseArgs, error) {
-  var result types.CloseArgs
-  var err error
+	var result types.CloseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CloseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CloseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CloseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CloseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.CloseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.CloseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseStatArgs(decoder *Decoder) (types.StatArgs, error) {
-  var result types.StatArgs
-  var err error
+	var result types.StatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.StatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.StatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.StatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.StatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.StatArgs{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.StatArgs{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.StatArgs{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.StatArgs{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseFstatArgs(decoder *Decoder) (types.FstatArgs, error) {
-  var result types.FstatArgs
-  var err error
+	var result types.FstatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FstatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FstatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FstatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FstatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FstatArgs{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.FstatArgs{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FstatArgs{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.FstatArgs{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseLstatArgs(decoder *Decoder) (types.LstatArgs, error) {
-  var result types.LstatArgs
-  var err error
+	var result types.LstatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LstatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LstatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LstatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LstatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LstatArgs{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.LstatArgs{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LstatArgs{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.LstatArgs{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParsePollArgs(decoder *Decoder) (types.PollArgs, error) {
-  var result types.PollArgs
-  var err error
+	var result types.PollArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PollArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PollArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PollArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PollArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataFds uint64
-      err = decoder.DecodeUint64(&dataFds)
-      if err != nil {
-        return types.PollArgs{}, err
-      }
-      result.Fds = uintptr(dataFds)
-    case 1:
-      err = decoder.DecodeUint32(&result.Nfds)
-      if err != nil {
-        return types.PollArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Timeout)
-      if err != nil {
-        return types.PollArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataFds uint64
+			err = decoder.DecodeUint64(&dataFds)
+			if err != nil {
+				return types.PollArgs{}, err
+			}
+			result.Fds = uintptr(dataFds)
+		case 1:
+			err = decoder.DecodeUint32(&result.Nfds)
+			if err != nil {
+				return types.PollArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Timeout)
+			if err != nil {
+				return types.PollArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLseekArgs(decoder *Decoder) (types.LseekArgs, error) {
-  var result types.LseekArgs
-  var err error
+	var result types.LseekArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LseekArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LseekArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LseekArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LseekArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.LseekArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.LseekArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Whence)
-      if err != nil {
-        return types.LseekArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.LseekArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.LseekArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Whence)
+			if err != nil {
+				return types.LseekArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMmapArgs(decoder *Decoder) (types.MmapArgs, error) {
-  var result types.MmapArgs
-  var err error
+	var result types.MmapArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MmapArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MmapArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MmapArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MmapArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MmapArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.MmapArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Prot)
-      if err != nil {
-        return types.MmapArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.MmapArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.MmapArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.Off)
-      if err != nil {
-        return types.MmapArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MmapArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.MmapArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Prot)
+			if err != nil {
+				return types.MmapArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.MmapArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.MmapArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.Off)
+			if err != nil {
+				return types.MmapArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMprotectArgs(decoder *Decoder) (types.MprotectArgs, error) {
-  var result types.MprotectArgs
-  var err error
+	var result types.MprotectArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MprotectArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MprotectArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MprotectArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MprotectArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MprotectArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.MprotectArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Prot)
-      if err != nil {
-        return types.MprotectArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MprotectArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.MprotectArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Prot)
+			if err != nil {
+				return types.MprotectArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMunmapArgs(decoder *Decoder) (types.MunmapArgs, error) {
-  var result types.MunmapArgs
-  var err error
+	var result types.MunmapArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MunmapArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MunmapArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MunmapArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MunmapArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MunmapArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.MunmapArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MunmapArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.MunmapArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseBrkArgs(decoder *Decoder) (types.BrkArgs, error) {
-  var result types.BrkArgs
-  var err error
+	var result types.BrkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.BrkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.BrkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.BrkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.BrkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.BrkArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.BrkArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigactionArgs(decoder *Decoder) (types.RtSigactionArgs, error) {
-  var result types.RtSigactionArgs
-  var err error
+	var result types.RtSigactionArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtSigactionArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtSigactionArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtSigactionArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtSigactionArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Signum)
-      if err != nil {
-        return types.RtSigactionArgs{}, err
-      }
-    case 1:
-      var dataAct uint64
-      err = decoder.DecodeUint64(&dataAct)
-      if err != nil {
-        return types.RtSigactionArgs{}, err
-      }
-      result.Act = uintptr(dataAct)
-    case 2:
-      var dataOldact uint64
-      err = decoder.DecodeUint64(&dataOldact)
-      if err != nil {
-        return types.RtSigactionArgs{}, err
-      }
-      result.Oldact = uintptr(dataOldact)
-    case 3:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.RtSigactionArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Signum)
+			if err != nil {
+				return types.RtSigactionArgs{}, err
+			}
+		case 1:
+			var dataAct uint64
+			err = decoder.DecodeUint64(&dataAct)
+			if err != nil {
+				return types.RtSigactionArgs{}, err
+			}
+			result.Act = uintptr(dataAct)
+		case 2:
+			var dataOldact uint64
+			err = decoder.DecodeUint64(&dataOldact)
+			if err != nil {
+				return types.RtSigactionArgs{}, err
+			}
+			result.Oldact = uintptr(dataOldact)
+		case 3:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.RtSigactionArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigprocmaskArgs(decoder *Decoder) (types.RtSigprocmaskArgs, error) {
-  var result types.RtSigprocmaskArgs
-  var err error
+	var result types.RtSigprocmaskArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtSigprocmaskArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtSigprocmaskArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtSigprocmaskArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtSigprocmaskArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.How)
-      if err != nil {
-        return types.RtSigprocmaskArgs{}, err
-      }
-    case 1:
-      var dataSet uint64
-      err = decoder.DecodeUint64(&dataSet)
-      if err != nil {
-        return types.RtSigprocmaskArgs{}, err
-      }
-      result.Set = uintptr(dataSet)
-    case 2:
-      var dataOldset uint64
-      err = decoder.DecodeUint64(&dataOldset)
-      if err != nil {
-        return types.RtSigprocmaskArgs{}, err
-      }
-      result.Oldset = uintptr(dataOldset)
-    case 3:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.RtSigprocmaskArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.How)
+			if err != nil {
+				return types.RtSigprocmaskArgs{}, err
+			}
+		case 1:
+			var dataSet uint64
+			err = decoder.DecodeUint64(&dataSet)
+			if err != nil {
+				return types.RtSigprocmaskArgs{}, err
+			}
+			result.Set = uintptr(dataSet)
+		case 2:
+			var dataOldset uint64
+			err = decoder.DecodeUint64(&dataOldset)
+			if err != nil {
+				return types.RtSigprocmaskArgs{}, err
+			}
+			result.Oldset = uintptr(dataOldset)
+		case 3:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.RtSigprocmaskArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigreturnArgs(decoder *Decoder) (types.RtSigreturnArgs, error) {
-  return types.RtSigreturnArgs{}, nil
+	return types.RtSigreturnArgs{}, nil
 }
 
 func ParseIoctlArgs(decoder *Decoder) (types.IoctlArgs, error) {
-  var result types.IoctlArgs
-  var err error
+	var result types.IoctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.IoctlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Request)
-      if err != nil {
-        return types.IoctlArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Arg)
-      if err != nil {
-        return types.IoctlArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.IoctlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Request)
+			if err != nil {
+				return types.IoctlArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Arg)
+			if err != nil {
+				return types.IoctlArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePread64Args(decoder *Decoder) (types.Pread64Args, error) {
-  var result types.Pread64Args
-  var err error
+	var result types.Pread64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Pread64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Pread64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Pread64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Pread64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Pread64Args{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.Pread64Args{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    case 2:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.Pread64Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.Pread64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Pread64Args{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.Pread64Args{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		case 2:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.Pread64Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.Pread64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePwrite64Args(decoder *Decoder) (types.Pwrite64Args, error) {
-  var result types.Pwrite64Args
-  var err error
+	var result types.Pwrite64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Pwrite64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Pwrite64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Pwrite64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Pwrite64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Pwrite64Args{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.Pwrite64Args{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    case 2:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.Pwrite64Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.Pwrite64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Pwrite64Args{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.Pwrite64Args{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		case 2:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.Pwrite64Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.Pwrite64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseReadvArgs(decoder *Decoder) (types.ReadvArgs, error) {
-  var result types.ReadvArgs
-  var err error
+	var result types.ReadvArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ReadvArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ReadvArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ReadvArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ReadvArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.ReadvArgs{}, err
-      }
-    case 1:
-      var dataIov uint64
-      err = decoder.DecodeUint64(&dataIov)
-      if err != nil {
-        return types.ReadvArgs{}, err
-      }
-      result.Iov = uintptr(dataIov)
-    case 2:
-      err = decoder.DecodeInt32(&result.Iovcnt)
-      if err != nil {
-        return types.ReadvArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.ReadvArgs{}, err
+			}
+		case 1:
+			var dataIov uint64
+			err = decoder.DecodeUint64(&dataIov)
+			if err != nil {
+				return types.ReadvArgs{}, err
+			}
+			result.Iov = uintptr(dataIov)
+		case 2:
+			err = decoder.DecodeInt32(&result.Iovcnt)
+			if err != nil {
+				return types.ReadvArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseWritevArgs(decoder *Decoder) (types.WritevArgs, error) {
-  var result types.WritevArgs
-  var err error
+	var result types.WritevArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.WritevArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.WritevArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.WritevArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.WritevArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.WritevArgs{}, err
-      }
-    case 1:
-      var dataIov uint64
-      err = decoder.DecodeUint64(&dataIov)
-      if err != nil {
-        return types.WritevArgs{}, err
-      }
-      result.Iov = uintptr(dataIov)
-    case 2:
-      err = decoder.DecodeInt32(&result.Iovcnt)
-      if err != nil {
-        return types.WritevArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.WritevArgs{}, err
+			}
+		case 1:
+			var dataIov uint64
+			err = decoder.DecodeUint64(&dataIov)
+			if err != nil {
+				return types.WritevArgs{}, err
+			}
+			result.Iov = uintptr(dataIov)
+		case 2:
+			err = decoder.DecodeInt32(&result.Iovcnt)
+			if err != nil {
+				return types.WritevArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseAccessArgs(decoder *Decoder) (types.AccessArgs, error) {
-  var result types.AccessArgs
-  var err error
+	var result types.AccessArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.AccessArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.AccessArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.AccessArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.AccessArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.AccessArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Mode)
-      if err != nil {
-        return types.AccessArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.AccessArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Mode)
+			if err != nil {
+				return types.AccessArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePipeArgs(decoder *Decoder) (types.PipeArgs, error) {
-  var result types.PipeArgs
-  var err error
+	var result types.PipeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PipeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PipeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PipeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PipeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeIntArray(result.Pipefd[:], 2)
-      if err != nil {
-        return types.PipeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeIntArray(result.Pipefd[:], 2)
+			if err != nil {
+				return types.PipeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSelectArgs(decoder *Decoder) (types.SelectArgs, error) {
-  var result types.SelectArgs
-  var err error
+	var result types.SelectArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SelectArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SelectArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SelectArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SelectArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Nfds)
-      if err != nil {
-        return types.SelectArgs{}, err
-      }
-    case 1:
-      var dataReadfds uint64
-      err = decoder.DecodeUint64(&dataReadfds)
-      if err != nil {
-        return types.SelectArgs{}, err
-      }
-      result.Readfds = uintptr(dataReadfds)
-    case 2:
-      var dataWritefds uint64
-      err = decoder.DecodeUint64(&dataWritefds)
-      if err != nil {
-        return types.SelectArgs{}, err
-      }
-      result.Writefds = uintptr(dataWritefds)
-    case 3:
-      var dataExceptfds uint64
-      err = decoder.DecodeUint64(&dataExceptfds)
-      if err != nil {
-        return types.SelectArgs{}, err
-      }
-      result.Exceptfds = uintptr(dataExceptfds)
-    case 4:
-      var dataTimeout uint64
-      err = decoder.DecodeUint64(&dataTimeout)
-      if err != nil {
-        return types.SelectArgs{}, err
-      }
-      result.Timeout = uintptr(dataTimeout)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Nfds)
+			if err != nil {
+				return types.SelectArgs{}, err
+			}
+		case 1:
+			var dataReadfds uint64
+			err = decoder.DecodeUint64(&dataReadfds)
+			if err != nil {
+				return types.SelectArgs{}, err
+			}
+			result.Readfds = uintptr(dataReadfds)
+		case 2:
+			var dataWritefds uint64
+			err = decoder.DecodeUint64(&dataWritefds)
+			if err != nil {
+				return types.SelectArgs{}, err
+			}
+			result.Writefds = uintptr(dataWritefds)
+		case 3:
+			var dataExceptfds uint64
+			err = decoder.DecodeUint64(&dataExceptfds)
+			if err != nil {
+				return types.SelectArgs{}, err
+			}
+			result.Exceptfds = uintptr(dataExceptfds)
+		case 4:
+			var dataTimeout uint64
+			err = decoder.DecodeUint64(&dataTimeout)
+			if err != nil {
+				return types.SelectArgs{}, err
+			}
+			result.Timeout = uintptr(dataTimeout)
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedYieldArgs(decoder *Decoder) (types.SchedYieldArgs, error) {
-  return types.SchedYieldArgs{}, nil
+	return types.SchedYieldArgs{}, nil
 }
 
 func ParseMremapArgs(decoder *Decoder) (types.MremapArgs, error) {
-  var result types.MremapArgs
-  var err error
+	var result types.MremapArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MremapArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MremapArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MremapArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MremapArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataOldAddress uint64
-      err = decoder.DecodeUint64(&dataOldAddress)
-      if err != nil {
-        return types.MremapArgs{}, err
-      }
-      result.OldAddress = uintptr(dataOldAddress)
-    case 1:
-      err = decoder.DecodeUint64(&result.OldSize)
-      if err != nil {
-        return types.MremapArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.NewSize)
-      if err != nil {
-        return types.MremapArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.MremapArgs{}, err
-      }
-    case 4:
-      var dataNewAddress uint64
-      err = decoder.DecodeUint64(&dataNewAddress)
-      if err != nil {
-        return types.MremapArgs{}, err
-      }
-      result.NewAddress = uintptr(dataNewAddress)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataOldAddress uint64
+			err = decoder.DecodeUint64(&dataOldAddress)
+			if err != nil {
+				return types.MremapArgs{}, err
+			}
+			result.OldAddress = uintptr(dataOldAddress)
+		case 1:
+			err = decoder.DecodeUint64(&result.OldSize)
+			if err != nil {
+				return types.MremapArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.NewSize)
+			if err != nil {
+				return types.MremapArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.MremapArgs{}, err
+			}
+		case 4:
+			var dataNewAddress uint64
+			err = decoder.DecodeUint64(&dataNewAddress)
+			if err != nil {
+				return types.MremapArgs{}, err
+			}
+			result.NewAddress = uintptr(dataNewAddress)
+		}
+	}
+	return result, nil
 }
 
 func ParseMsyncArgs(decoder *Decoder) (types.MsyncArgs, error) {
-  var result types.MsyncArgs
-  var err error
+	var result types.MsyncArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MsyncArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MsyncArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MsyncArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MsyncArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MsyncArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.MsyncArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.MsyncArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MsyncArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.MsyncArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.MsyncArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMincoreArgs(decoder *Decoder) (types.MincoreArgs, error) {
-  var result types.MincoreArgs
-  var err error
+	var result types.MincoreArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MincoreArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MincoreArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MincoreArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MincoreArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MincoreArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.MincoreArgs{}, err
-      }
-    case 2:
-      var dataVec uint64
-      err = decoder.DecodeUint64(&dataVec)
-      if err != nil {
-        return types.MincoreArgs{}, err
-      }
-      result.Vec = uintptr(dataVec)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MincoreArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.MincoreArgs{}, err
+			}
+		case 2:
+			var dataVec uint64
+			err = decoder.DecodeUint64(&dataVec)
+			if err != nil {
+				return types.MincoreArgs{}, err
+			}
+			result.Vec = uintptr(dataVec)
+		}
+	}
+	return result, nil
 }
 
 func ParseMadviseArgs(decoder *Decoder) (types.MadviseArgs, error) {
-  var result types.MadviseArgs
-  var err error
+	var result types.MadviseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MadviseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MadviseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MadviseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MadviseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MadviseArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.MadviseArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Advice)
-      if err != nil {
-        return types.MadviseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MadviseArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.MadviseArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Advice)
+			if err != nil {
+				return types.MadviseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseShmgetArgs(decoder *Decoder) (types.ShmgetArgs, error) {
-  var result types.ShmgetArgs
-  var err error
+	var result types.ShmgetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ShmgetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ShmgetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ShmgetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ShmgetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Key)
-      if err != nil {
-        return types.ShmgetArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.ShmgetArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Shmflg)
-      if err != nil {
-        return types.ShmgetArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Key)
+			if err != nil {
+				return types.ShmgetArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.ShmgetArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Shmflg)
+			if err != nil {
+				return types.ShmgetArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseShmatArgs(decoder *Decoder) (types.ShmatArgs, error) {
-  var result types.ShmatArgs
-  var err error
+	var result types.ShmatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ShmatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ShmatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ShmatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ShmatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Shmid)
-      if err != nil {
-        return types.ShmatArgs{}, err
-      }
-    case 1:
-      var dataShmaddr uint64
-      err = decoder.DecodeUint64(&dataShmaddr)
-      if err != nil {
-        return types.ShmatArgs{}, err
-      }
-      result.Shmaddr = uintptr(dataShmaddr)
-    case 2:
-      err = decoder.DecodeInt32(&result.Shmflg)
-      if err != nil {
-        return types.ShmatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Shmid)
+			if err != nil {
+				return types.ShmatArgs{}, err
+			}
+		case 1:
+			var dataShmaddr uint64
+			err = decoder.DecodeUint64(&dataShmaddr)
+			if err != nil {
+				return types.ShmatArgs{}, err
+			}
+			result.Shmaddr = uintptr(dataShmaddr)
+		case 2:
+			err = decoder.DecodeInt32(&result.Shmflg)
+			if err != nil {
+				return types.ShmatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseShmctlArgs(decoder *Decoder) (types.ShmctlArgs, error) {
-  var result types.ShmctlArgs
-  var err error
+	var result types.ShmctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ShmctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ShmctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ShmctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ShmctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Shmid)
-      if err != nil {
-        return types.ShmctlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.ShmctlArgs{}, err
-      }
-    case 2:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.ShmctlArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Shmid)
+			if err != nil {
+				return types.ShmctlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.ShmctlArgs{}, err
+			}
+		case 2:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.ShmctlArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseDupArgs(decoder *Decoder) (types.DupArgs, error) {
-  var result types.DupArgs
-  var err error
+	var result types.DupArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DupArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DupArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DupArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DupArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Oldfd)
-      if err != nil {
-        return types.DupArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Oldfd)
+			if err != nil {
+				return types.DupArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDup2Args(decoder *Decoder) (types.Dup2Args, error) {
-  var result types.Dup2Args
-  var err error
+	var result types.Dup2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Dup2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Dup2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Dup2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Dup2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Oldfd)
-      if err != nil {
-        return types.Dup2Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Newfd)
-      if err != nil {
-        return types.Dup2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Oldfd)
+			if err != nil {
+				return types.Dup2Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Newfd)
+			if err != nil {
+				return types.Dup2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePauseArgs(decoder *Decoder) (types.PauseArgs, error) {
-  return types.PauseArgs{}, nil
+	return types.PauseArgs{}, nil
 }
 
 func ParseNanosleepArgs(decoder *Decoder) (types.NanosleepArgs, error) {
-  var result types.NanosleepArgs
-  var err error
+	var result types.NanosleepArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NanosleepArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NanosleepArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NanosleepArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NanosleepArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Req, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.NanosleepArgs{}, err
-      }
-    case 1:
-      result.Rem, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.NanosleepArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Req, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.NanosleepArgs{}, err
+			}
+		case 1:
+			result.Rem, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.NanosleepArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetitimerArgs(decoder *Decoder) (types.GetitimerArgs, error) {
-  var result types.GetitimerArgs
-  var err error
+	var result types.GetitimerArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetitimerArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetitimerArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetitimerArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetitimerArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Which)
-      if err != nil {
-        return types.GetitimerArgs{}, err
-      }
-    case 1:
-      var dataCurrValue uint64
-      err = decoder.DecodeUint64(&dataCurrValue)
-      if err != nil {
-        return types.GetitimerArgs{}, err
-      }
-      result.CurrValue = uintptr(dataCurrValue)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Which)
+			if err != nil {
+				return types.GetitimerArgs{}, err
+			}
+		case 1:
+			var dataCurrValue uint64
+			err = decoder.DecodeUint64(&dataCurrValue)
+			if err != nil {
+				return types.GetitimerArgs{}, err
+			}
+			result.CurrValue = uintptr(dataCurrValue)
+		}
+	}
+	return result, nil
 }
 
 func ParseAlarmArgs(decoder *Decoder) (types.AlarmArgs, error) {
-  var result types.AlarmArgs
-  var err error
+	var result types.AlarmArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.AlarmArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.AlarmArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.AlarmArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.AlarmArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Seconds)
-      if err != nil {
-        return types.AlarmArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Seconds)
+			if err != nil {
+				return types.AlarmArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetitimerArgs(decoder *Decoder) (types.SetitimerArgs, error) {
-  var result types.SetitimerArgs
-  var err error
+	var result types.SetitimerArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetitimerArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetitimerArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetitimerArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetitimerArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Which)
-      if err != nil {
-        return types.SetitimerArgs{}, err
-      }
-    case 1:
-      var dataNewValue uint64
-      err = decoder.DecodeUint64(&dataNewValue)
-      if err != nil {
-        return types.SetitimerArgs{}, err
-      }
-      result.NewValue = uintptr(dataNewValue)
-    case 2:
-      var dataOldValue uint64
-      err = decoder.DecodeUint64(&dataOldValue)
-      if err != nil {
-        return types.SetitimerArgs{}, err
-      }
-      result.OldValue = uintptr(dataOldValue)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Which)
+			if err != nil {
+				return types.SetitimerArgs{}, err
+			}
+		case 1:
+			var dataNewValue uint64
+			err = decoder.DecodeUint64(&dataNewValue)
+			if err != nil {
+				return types.SetitimerArgs{}, err
+			}
+			result.NewValue = uintptr(dataNewValue)
+		case 2:
+			var dataOldValue uint64
+			err = decoder.DecodeUint64(&dataOldValue)
+			if err != nil {
+				return types.SetitimerArgs{}, err
+			}
+			result.OldValue = uintptr(dataOldValue)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetpidArgs(decoder *Decoder) (types.GetpidArgs, error) {
-  return types.GetpidArgs{}, nil
+	return types.GetpidArgs{}, nil
 }
 
 func ParseSendfileArgs(decoder *Decoder) (types.SendfileArgs, error) {
-  var result types.SendfileArgs
-  var err error
+	var result types.SendfileArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SendfileArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SendfileArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SendfileArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SendfileArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.OutFd)
-      if err != nil {
-        return types.SendfileArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.InFd)
-      if err != nil {
-        return types.SendfileArgs{}, err
-      }
-    case 2:
-      var dataOffset uint64
-      err = decoder.DecodeUint64(&dataOffset)
-      if err != nil {
-        return types.SendfileArgs{}, err
-      }
-      result.Offset = uintptr(dataOffset)
-    case 3:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.SendfileArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.OutFd)
+			if err != nil {
+				return types.SendfileArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.InFd)
+			if err != nil {
+				return types.SendfileArgs{}, err
+			}
+		case 2:
+			var dataOffset uint64
+			err = decoder.DecodeUint64(&dataOffset)
+			if err != nil {
+				return types.SendfileArgs{}, err
+			}
+			result.Offset = uintptr(dataOffset)
+		case 3:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.SendfileArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSocketArgs(decoder *Decoder) (types.SocketArgs, error) {
-  var result types.SocketArgs
-  var err error
+	var result types.SocketArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SocketArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SocketArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SocketArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SocketArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Domain)
-      if err != nil {
-        return types.SocketArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.SocketArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Protocol)
-      if err != nil {
-        return types.SocketArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Domain)
+			if err != nil {
+				return types.SocketArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.SocketArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Protocol)
+			if err != nil {
+				return types.SocketArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseConnectArgs(decoder *Decoder) (types.ConnectArgs, error) {
-  var result types.ConnectArgs
-  var err error
+	var result types.ConnectArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ConnectArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ConnectArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ConnectArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ConnectArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.ConnectArgs{}, err
-      }
-    case 1:
-      result.Addr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.ConnectArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Addrlen)
-      if err != nil {
-        return types.ConnectArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.ConnectArgs{}, err
+			}
+		case 1:
+			result.Addr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.ConnectArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Addrlen)
+			if err != nil {
+				return types.ConnectArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseAcceptArgs(decoder *Decoder) (types.AcceptArgs, error) {
-  var result types.AcceptArgs
-  var err error
+	var result types.AcceptArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.AcceptArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.AcceptArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.AcceptArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.AcceptArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.AcceptArgs{}, err
-      }
-    case 1:
-      result.Addr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.AcceptArgs{}, err
-      }
-    case 2:
-      var dataAddrlen uint64
-      err = decoder.DecodeUint64(&dataAddrlen)
-      if err != nil {
-        return types.AcceptArgs{}, err
-      }
-      result.Addrlen = uintptr(dataAddrlen)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.AcceptArgs{}, err
+			}
+		case 1:
+			result.Addr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.AcceptArgs{}, err
+			}
+		case 2:
+			var dataAddrlen uint64
+			err = decoder.DecodeUint64(&dataAddrlen)
+			if err != nil {
+				return types.AcceptArgs{}, err
+			}
+			result.Addrlen = uintptr(dataAddrlen)
+		}
+	}
+	return result, nil
 }
 
 func ParseSendtoArgs(decoder *Decoder) (types.SendtoArgs, error) {
-  var result types.SendtoArgs
-  var err error
+	var result types.SendtoArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SendtoArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SendtoArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SendtoArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SendtoArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SendtoArgs{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.SendtoArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    case 2:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.SendtoArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SendtoArgs{}, err
-      }
-    case 4:
-      result.DestAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SendtoArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeInt32(&result.Addrlen)
-      if err != nil {
-        return types.SendtoArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SendtoArgs{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.SendtoArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		case 2:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.SendtoArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SendtoArgs{}, err
+			}
+		case 4:
+			result.DestAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SendtoArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeInt32(&result.Addrlen)
+			if err != nil {
+				return types.SendtoArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRecvfromArgs(decoder *Decoder) (types.RecvfromArgs, error) {
-  var result types.RecvfromArgs
-  var err error
+	var result types.RecvfromArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RecvfromArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RecvfromArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RecvfromArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RecvfromArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.RecvfromArgs{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.RecvfromArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    case 2:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.RecvfromArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.RecvfromArgs{}, err
-      }
-    case 4:
-      result.SrcAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.RecvfromArgs{}, err
-      }
-    case 5:
-      var dataAddrlen uint64
-      err = decoder.DecodeUint64(&dataAddrlen)
-      if err != nil {
-        return types.RecvfromArgs{}, err
-      }
-      result.Addrlen = uintptr(dataAddrlen)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.RecvfromArgs{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.RecvfromArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		case 2:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.RecvfromArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.RecvfromArgs{}, err
+			}
+		case 4:
+			result.SrcAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.RecvfromArgs{}, err
+			}
+		case 5:
+			var dataAddrlen uint64
+			err = decoder.DecodeUint64(&dataAddrlen)
+			if err != nil {
+				return types.RecvfromArgs{}, err
+			}
+			result.Addrlen = uintptr(dataAddrlen)
+		}
+	}
+	return result, nil
 }
 
 func ParseSendmsgArgs(decoder *Decoder) (types.SendmsgArgs, error) {
-  var result types.SendmsgArgs
-  var err error
+	var result types.SendmsgArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SendmsgArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SendmsgArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SendmsgArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SendmsgArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SendmsgArgs{}, err
-      }
-    case 1:
-      var dataMsg uint64
-      err = decoder.DecodeUint64(&dataMsg)
-      if err != nil {
-        return types.SendmsgArgs{}, err
-      }
-      result.Msg = uintptr(dataMsg)
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SendmsgArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SendmsgArgs{}, err
+			}
+		case 1:
+			var dataMsg uint64
+			err = decoder.DecodeUint64(&dataMsg)
+			if err != nil {
+				return types.SendmsgArgs{}, err
+			}
+			result.Msg = uintptr(dataMsg)
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SendmsgArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRecvmsgArgs(decoder *Decoder) (types.RecvmsgArgs, error) {
-  var result types.RecvmsgArgs
-  var err error
+	var result types.RecvmsgArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RecvmsgArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RecvmsgArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RecvmsgArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RecvmsgArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.RecvmsgArgs{}, err
-      }
-    case 1:
-      var dataMsg uint64
-      err = decoder.DecodeUint64(&dataMsg)
-      if err != nil {
-        return types.RecvmsgArgs{}, err
-      }
-      result.Msg = uintptr(dataMsg)
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.RecvmsgArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.RecvmsgArgs{}, err
+			}
+		case 1:
+			var dataMsg uint64
+			err = decoder.DecodeUint64(&dataMsg)
+			if err != nil {
+				return types.RecvmsgArgs{}, err
+			}
+			result.Msg = uintptr(dataMsg)
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.RecvmsgArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseShutdownArgs(decoder *Decoder) (types.ShutdownArgs, error) {
-  var result types.ShutdownArgs
-  var err error
+	var result types.ShutdownArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ShutdownArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ShutdownArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ShutdownArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ShutdownArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.ShutdownArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.How)
-      if err != nil {
-        return types.ShutdownArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.ShutdownArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.How)
+			if err != nil {
+				return types.ShutdownArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseBindArgs(decoder *Decoder) (types.BindArgs, error) {
-  var result types.BindArgs
-  var err error
+	var result types.BindArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.BindArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.BindArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.BindArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.BindArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.BindArgs{}, err
-      }
-    case 1:
-      result.Addr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.BindArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Addrlen)
-      if err != nil {
-        return types.BindArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.BindArgs{}, err
+			}
+		case 1:
+			result.Addr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.BindArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Addrlen)
+			if err != nil {
+				return types.BindArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseListenArgs(decoder *Decoder) (types.ListenArgs, error) {
-  var result types.ListenArgs
-  var err error
+	var result types.ListenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ListenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ListenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ListenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ListenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.ListenArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Backlog)
-      if err != nil {
-        return types.ListenArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.ListenArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Backlog)
+			if err != nil {
+				return types.ListenArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetsocknameArgs(decoder *Decoder) (types.GetsocknameArgs, error) {
-  var result types.GetsocknameArgs
-  var err error
+	var result types.GetsocknameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetsocknameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetsocknameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetsocknameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetsocknameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.GetsocknameArgs{}, err
-      }
-    case 1:
-      result.Addr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.GetsocknameArgs{}, err
-      }
-    case 2:
-      var dataAddrlen uint64
-      err = decoder.DecodeUint64(&dataAddrlen)
-      if err != nil {
-        return types.GetsocknameArgs{}, err
-      }
-      result.Addrlen = uintptr(dataAddrlen)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.GetsocknameArgs{}, err
+			}
+		case 1:
+			result.Addr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.GetsocknameArgs{}, err
+			}
+		case 2:
+			var dataAddrlen uint64
+			err = decoder.DecodeUint64(&dataAddrlen)
+			if err != nil {
+				return types.GetsocknameArgs{}, err
+			}
+			result.Addrlen = uintptr(dataAddrlen)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetpeernameArgs(decoder *Decoder) (types.GetpeernameArgs, error) {
-  var result types.GetpeernameArgs
-  var err error
+	var result types.GetpeernameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetpeernameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetpeernameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetpeernameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetpeernameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.GetpeernameArgs{}, err
-      }
-    case 1:
-      result.Addr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.GetpeernameArgs{}, err
-      }
-    case 2:
-      var dataAddrlen uint64
-      err = decoder.DecodeUint64(&dataAddrlen)
-      if err != nil {
-        return types.GetpeernameArgs{}, err
-      }
-      result.Addrlen = uintptr(dataAddrlen)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.GetpeernameArgs{}, err
+			}
+		case 1:
+			result.Addr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.GetpeernameArgs{}, err
+			}
+		case 2:
+			var dataAddrlen uint64
+			err = decoder.DecodeUint64(&dataAddrlen)
+			if err != nil {
+				return types.GetpeernameArgs{}, err
+			}
+			result.Addrlen = uintptr(dataAddrlen)
+		}
+	}
+	return result, nil
 }
 
 func ParseSocketpairArgs(decoder *Decoder) (types.SocketpairArgs, error) {
-  var result types.SocketpairArgs
-  var err error
+	var result types.SocketpairArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SocketpairArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SocketpairArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SocketpairArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SocketpairArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Domain)
-      if err != nil {
-        return types.SocketpairArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.SocketpairArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Protocol)
-      if err != nil {
-        return types.SocketpairArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeIntArray(result.Sv[:], 2)
-      if err != nil {
-        return types.SocketpairArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Domain)
+			if err != nil {
+				return types.SocketpairArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.SocketpairArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Protocol)
+			if err != nil {
+				return types.SocketpairArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeIntArray(result.Sv[:], 2)
+			if err != nil {
+				return types.SocketpairArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetsockoptArgs(decoder *Decoder) (types.SetsockoptArgs, error) {
-  var result types.SetsockoptArgs
-  var err error
+	var result types.SetsockoptArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetsockoptArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetsockoptArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetsockoptArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetsockoptArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SetsockoptArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Level)
-      if err != nil {
-        return types.SetsockoptArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Optname)
-      if err != nil {
-        return types.SetsockoptArgs{}, err
-      }
-    case 3:
-      var dataOptval uint64
-      err = decoder.DecodeUint64(&dataOptval)
-      if err != nil {
-        return types.SetsockoptArgs{}, err
-      }
-      result.Optval = uintptr(dataOptval)
-    case 4:
-      err = decoder.DecodeInt32(&result.Optlen)
-      if err != nil {
-        return types.SetsockoptArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SetsockoptArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Level)
+			if err != nil {
+				return types.SetsockoptArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Optname)
+			if err != nil {
+				return types.SetsockoptArgs{}, err
+			}
+		case 3:
+			var dataOptval uint64
+			err = decoder.DecodeUint64(&dataOptval)
+			if err != nil {
+				return types.SetsockoptArgs{}, err
+			}
+			result.Optval = uintptr(dataOptval)
+		case 4:
+			err = decoder.DecodeInt32(&result.Optlen)
+			if err != nil {
+				return types.SetsockoptArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetsockoptArgs(decoder *Decoder) (types.GetsockoptArgs, error) {
-  var result types.GetsockoptArgs
-  var err error
+	var result types.GetsockoptArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetsockoptArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetsockoptArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetsockoptArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetsockoptArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.GetsockoptArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Level)
-      if err != nil {
-        return types.GetsockoptArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Optname)
-      if err != nil {
-        return types.GetsockoptArgs{}, err
-      }
-    case 3:
-      var dataOptval uint64
-      err = decoder.DecodeUint64(&dataOptval)
-      if err != nil {
-        return types.GetsockoptArgs{}, err
-      }
-      result.Optval = uintptr(dataOptval)
-    case 4:
-      var dataOptlen uint64
-      err = decoder.DecodeUint64(&dataOptlen)
-      if err != nil {
-        return types.GetsockoptArgs{}, err
-      }
-      result.Optlen = uintptr(dataOptlen)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.GetsockoptArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Level)
+			if err != nil {
+				return types.GetsockoptArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Optname)
+			if err != nil {
+				return types.GetsockoptArgs{}, err
+			}
+		case 3:
+			var dataOptval uint64
+			err = decoder.DecodeUint64(&dataOptval)
+			if err != nil {
+				return types.GetsockoptArgs{}, err
+			}
+			result.Optval = uintptr(dataOptval)
+		case 4:
+			var dataOptlen uint64
+			err = decoder.DecodeUint64(&dataOptlen)
+			if err != nil {
+				return types.GetsockoptArgs{}, err
+			}
+			result.Optlen = uintptr(dataOptlen)
+		}
+	}
+	return result, nil
 }
 
 func ParseCloneArgs(decoder *Decoder) (types.CloneArgs, error) {
-  var result types.CloneArgs
-  var err error
+	var result types.CloneArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CloneArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CloneArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CloneArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CloneArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.CloneArgs{}, err
-      }
-    case 1:
-      var dataStack uint64
-      err = decoder.DecodeUint64(&dataStack)
-      if err != nil {
-        return types.CloneArgs{}, err
-      }
-      result.Stack = uintptr(dataStack)
-    case 2:
-      var dataParentTid uint64
-      err = decoder.DecodeUint64(&dataParentTid)
-      if err != nil {
-        return types.CloneArgs{}, err
-      }
-      result.ParentTid = uintptr(dataParentTid)
-    case 3:
-      var dataChildTid uint64
-      err = decoder.DecodeUint64(&dataChildTid)
-      if err != nil {
-        return types.CloneArgs{}, err
-      }
-      result.ChildTid = uintptr(dataChildTid)
-    case 4:
-      err = decoder.DecodeUint64(&result.Tls)
-      if err != nil {
-        return types.CloneArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.CloneArgs{}, err
+			}
+		case 1:
+			var dataStack uint64
+			err = decoder.DecodeUint64(&dataStack)
+			if err != nil {
+				return types.CloneArgs{}, err
+			}
+			result.Stack = uintptr(dataStack)
+		case 2:
+			var dataParentTid uint64
+			err = decoder.DecodeUint64(&dataParentTid)
+			if err != nil {
+				return types.CloneArgs{}, err
+			}
+			result.ParentTid = uintptr(dataParentTid)
+		case 3:
+			var dataChildTid uint64
+			err = decoder.DecodeUint64(&dataChildTid)
+			if err != nil {
+				return types.CloneArgs{}, err
+			}
+			result.ChildTid = uintptr(dataChildTid)
+		case 4:
+			err = decoder.DecodeUint64(&result.Tls)
+			if err != nil {
+				return types.CloneArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseForkArgs(decoder *Decoder) (types.ForkArgs, error) {
-  return types.ForkArgs{}, nil
+	return types.ForkArgs{}, nil
 }
 
 func ParseVforkArgs(decoder *Decoder) (types.VforkArgs, error) {
-  return types.VforkArgs{}, nil
+	return types.VforkArgs{}, nil
 }
 
 func ParseExecveArgs(decoder *Decoder) (types.ExecveArgs, error) {
-  var result types.ExecveArgs
-  var err error
+	var result types.ExecveArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ExecveArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ExecveArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ExecveArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ExecveArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExecveArgs{}, err
-      }
-    case 1:
-      result.Argv, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.ExecveArgs{}, err
-      }
-    case 2:
-      result.Envp, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.ExecveArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExecveArgs{}, err
+			}
+		case 1:
+			result.Argv, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.ExecveArgs{}, err
+			}
+		case 2:
+			result.Envp, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.ExecveArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseExitArgs(decoder *Decoder) (types.ExitArgs, error) {
-  var result types.ExitArgs
-  var err error
+	var result types.ExitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ExitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ExitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ExitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ExitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Status)
-      if err != nil {
-        return types.ExitArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Status)
+			if err != nil {
+				return types.ExitArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseWait4Args(decoder *Decoder) (types.Wait4Args, error) {
-  var result types.Wait4Args
-  var err error
+	var result types.Wait4Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Wait4Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Wait4Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Wait4Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Wait4Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.Wait4Args{}, err
-      }
-    case 1:
-      var dataWstatus uint64
-      err = decoder.DecodeUint64(&dataWstatus)
-      if err != nil {
-        return types.Wait4Args{}, err
-      }
-      result.Wstatus = uintptr(dataWstatus)
-    case 2:
-      err = decoder.DecodeInt32(&result.Options)
-      if err != nil {
-        return types.Wait4Args{}, err
-      }
-    case 3:
-      var dataRusage uint64
-      err = decoder.DecodeUint64(&dataRusage)
-      if err != nil {
-        return types.Wait4Args{}, err
-      }
-      result.Rusage = uintptr(dataRusage)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.Wait4Args{}, err
+			}
+		case 1:
+			var dataWstatus uint64
+			err = decoder.DecodeUint64(&dataWstatus)
+			if err != nil {
+				return types.Wait4Args{}, err
+			}
+			result.Wstatus = uintptr(dataWstatus)
+		case 2:
+			err = decoder.DecodeInt32(&result.Options)
+			if err != nil {
+				return types.Wait4Args{}, err
+			}
+		case 3:
+			var dataRusage uint64
+			err = decoder.DecodeUint64(&dataRusage)
+			if err != nil {
+				return types.Wait4Args{}, err
+			}
+			result.Rusage = uintptr(dataRusage)
+		}
+	}
+	return result, nil
 }
 
 func ParseKillArgs(decoder *Decoder) (types.KillArgs, error) {
-  var result types.KillArgs
-  var err error
+	var result types.KillArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KillArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KillArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KillArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KillArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.KillArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.KillArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.KillArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.KillArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUnameArgs(decoder *Decoder) (types.UnameArgs, error) {
-  var result types.UnameArgs
-  var err error
+	var result types.UnameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UnameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UnameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UnameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UnameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.UnameArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.UnameArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseSemgetArgs(decoder *Decoder) (types.SemgetArgs, error) {
-  var result types.SemgetArgs
-  var err error
+	var result types.SemgetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SemgetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SemgetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SemgetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SemgetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Key)
-      if err != nil {
-        return types.SemgetArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Nsems)
-      if err != nil {
-        return types.SemgetArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Semflg)
-      if err != nil {
-        return types.SemgetArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Key)
+			if err != nil {
+				return types.SemgetArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Nsems)
+			if err != nil {
+				return types.SemgetArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Semflg)
+			if err != nil {
+				return types.SemgetArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSemopArgs(decoder *Decoder) (types.SemopArgs, error) {
-  var result types.SemopArgs
-  var err error
+	var result types.SemopArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SemopArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SemopArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SemopArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SemopArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Semid)
-      if err != nil {
-        return types.SemopArgs{}, err
-      }
-    case 1:
-      var dataSops uint64
-      err = decoder.DecodeUint64(&dataSops)
-      if err != nil {
-        return types.SemopArgs{}, err
-      }
-      result.Sops = uintptr(dataSops)
-    case 2:
-      err = decoder.DecodeUint64(&result.Nsops)
-      if err != nil {
-        return types.SemopArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Semid)
+			if err != nil {
+				return types.SemopArgs{}, err
+			}
+		case 1:
+			var dataSops uint64
+			err = decoder.DecodeUint64(&dataSops)
+			if err != nil {
+				return types.SemopArgs{}, err
+			}
+			result.Sops = uintptr(dataSops)
+		case 2:
+			err = decoder.DecodeUint64(&result.Nsops)
+			if err != nil {
+				return types.SemopArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSemctlArgs(decoder *Decoder) (types.SemctlArgs, error) {
-  var result types.SemctlArgs
-  var err error
+	var result types.SemctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SemctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SemctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SemctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SemctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Semid)
-      if err != nil {
-        return types.SemctlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Semnum)
-      if err != nil {
-        return types.SemctlArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.SemctlArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Arg)
-      if err != nil {
-        return types.SemctlArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Semid)
+			if err != nil {
+				return types.SemctlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Semnum)
+			if err != nil {
+				return types.SemctlArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.SemctlArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Arg)
+			if err != nil {
+				return types.SemctlArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseShmdtArgs(decoder *Decoder) (types.ShmdtArgs, error) {
-  var result types.ShmdtArgs
-  var err error
+	var result types.ShmdtArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ShmdtArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ShmdtArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ShmdtArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ShmdtArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataShmaddr uint64
-      err = decoder.DecodeUint64(&dataShmaddr)
-      if err != nil {
-        return types.ShmdtArgs{}, err
-      }
-      result.Shmaddr = uintptr(dataShmaddr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataShmaddr uint64
+			err = decoder.DecodeUint64(&dataShmaddr)
+			if err != nil {
+				return types.ShmdtArgs{}, err
+			}
+			result.Shmaddr = uintptr(dataShmaddr)
+		}
+	}
+	return result, nil
 }
 
 func ParseMsggetArgs(decoder *Decoder) (types.MsggetArgs, error) {
-  var result types.MsggetArgs
-  var err error
+	var result types.MsggetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MsggetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MsggetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MsggetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MsggetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Key)
-      if err != nil {
-        return types.MsggetArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Msgflg)
-      if err != nil {
-        return types.MsggetArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Key)
+			if err != nil {
+				return types.MsggetArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Msgflg)
+			if err != nil {
+				return types.MsggetArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMsgsndArgs(decoder *Decoder) (types.MsgsndArgs, error) {
-  var result types.MsgsndArgs
-  var err error
+	var result types.MsgsndArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MsgsndArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MsgsndArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MsgsndArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MsgsndArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Msqid)
-      if err != nil {
-        return types.MsgsndArgs{}, err
-      }
-    case 1:
-      var dataMsgp uint64
-      err = decoder.DecodeUint64(&dataMsgp)
-      if err != nil {
-        return types.MsgsndArgs{}, err
-      }
-      result.Msgp = uintptr(dataMsgp)
-    case 2:
-      err = decoder.DecodeUint64(&result.Msgsz)
-      if err != nil {
-        return types.MsgsndArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Msgflg)
-      if err != nil {
-        return types.MsgsndArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Msqid)
+			if err != nil {
+				return types.MsgsndArgs{}, err
+			}
+		case 1:
+			var dataMsgp uint64
+			err = decoder.DecodeUint64(&dataMsgp)
+			if err != nil {
+				return types.MsgsndArgs{}, err
+			}
+			result.Msgp = uintptr(dataMsgp)
+		case 2:
+			err = decoder.DecodeUint64(&result.Msgsz)
+			if err != nil {
+				return types.MsgsndArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Msgflg)
+			if err != nil {
+				return types.MsgsndArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMsgrcvArgs(decoder *Decoder) (types.MsgrcvArgs, error) {
-  var result types.MsgrcvArgs
-  var err error
+	var result types.MsgrcvArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MsgrcvArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MsgrcvArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MsgrcvArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MsgrcvArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Msqid)
-      if err != nil {
-        return types.MsgrcvArgs{}, err
-      }
-    case 1:
-      var dataMsgp uint64
-      err = decoder.DecodeUint64(&dataMsgp)
-      if err != nil {
-        return types.MsgrcvArgs{}, err
-      }
-      result.Msgp = uintptr(dataMsgp)
-    case 2:
-      err = decoder.DecodeUint64(&result.Msgsz)
-      if err != nil {
-        return types.MsgrcvArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt64(&result.Msgtyp)
-      if err != nil {
-        return types.MsgrcvArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Msgflg)
-      if err != nil {
-        return types.MsgrcvArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Msqid)
+			if err != nil {
+				return types.MsgrcvArgs{}, err
+			}
+		case 1:
+			var dataMsgp uint64
+			err = decoder.DecodeUint64(&dataMsgp)
+			if err != nil {
+				return types.MsgrcvArgs{}, err
+			}
+			result.Msgp = uintptr(dataMsgp)
+		case 2:
+			err = decoder.DecodeUint64(&result.Msgsz)
+			if err != nil {
+				return types.MsgrcvArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt64(&result.Msgtyp)
+			if err != nil {
+				return types.MsgrcvArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Msgflg)
+			if err != nil {
+				return types.MsgrcvArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMsgctlArgs(decoder *Decoder) (types.MsgctlArgs, error) {
-  var result types.MsgctlArgs
-  var err error
+	var result types.MsgctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MsgctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MsgctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MsgctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MsgctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Msqid)
-      if err != nil {
-        return types.MsgctlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.MsgctlArgs{}, err
-      }
-    case 2:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.MsgctlArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Msqid)
+			if err != nil {
+				return types.MsgctlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.MsgctlArgs{}, err
+			}
+		case 2:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.MsgctlArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseFcntlArgs(decoder *Decoder) (types.FcntlArgs, error) {
-  var result types.FcntlArgs
-  var err error
+	var result types.FcntlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FcntlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FcntlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FcntlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FcntlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FcntlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.FcntlArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Arg)
-      if err != nil {
-        return types.FcntlArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FcntlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.FcntlArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Arg)
+			if err != nil {
+				return types.FcntlArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFlockArgs(decoder *Decoder) (types.FlockArgs, error) {
-  var result types.FlockArgs
-  var err error
+	var result types.FlockArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FlockArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FlockArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FlockArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FlockArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FlockArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Operation)
-      if err != nil {
-        return types.FlockArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FlockArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Operation)
+			if err != nil {
+				return types.FlockArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFsyncArgs(decoder *Decoder) (types.FsyncArgs, error) {
-  var result types.FsyncArgs
-  var err error
+	var result types.FsyncArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FsyncArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FsyncArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FsyncArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FsyncArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FsyncArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FsyncArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFdatasyncArgs(decoder *Decoder) (types.FdatasyncArgs, error) {
-  var result types.FdatasyncArgs
-  var err error
+	var result types.FdatasyncArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FdatasyncArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FdatasyncArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FdatasyncArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FdatasyncArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FdatasyncArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FdatasyncArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTruncateArgs(decoder *Decoder) (types.TruncateArgs, error) {
-  var result types.TruncateArgs
-  var err error
+	var result types.TruncateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TruncateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TruncateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TruncateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TruncateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.TruncateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.TruncateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.TruncateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.TruncateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFtruncateArgs(decoder *Decoder) (types.FtruncateArgs, error) {
-  var result types.FtruncateArgs
-  var err error
+	var result types.FtruncateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FtruncateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FtruncateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FtruncateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FtruncateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FtruncateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.FtruncateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FtruncateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.FtruncateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetdentsArgs(decoder *Decoder) (types.GetdentsArgs, error) {
-  var result types.GetdentsArgs
-  var err error
+	var result types.GetdentsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetdentsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetdentsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetdentsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetdentsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.GetdentsArgs{}, err
-      }
-    case 1:
-      var dataDirp uint64
-      err = decoder.DecodeUint64(&dataDirp)
-      if err != nil {
-        return types.GetdentsArgs{}, err
-      }
-      result.Dirp = uintptr(dataDirp)
-    case 2:
-      err = decoder.DecodeUint32(&result.Count)
-      if err != nil {
-        return types.GetdentsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.GetdentsArgs{}, err
+			}
+		case 1:
+			var dataDirp uint64
+			err = decoder.DecodeUint64(&dataDirp)
+			if err != nil {
+				return types.GetdentsArgs{}, err
+			}
+			result.Dirp = uintptr(dataDirp)
+		case 2:
+			err = decoder.DecodeUint32(&result.Count)
+			if err != nil {
+				return types.GetdentsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetcwdArgs(decoder *Decoder) (types.GetcwdArgs, error) {
-  var result types.GetcwdArgs
-  var err error
+	var result types.GetcwdArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetcwdArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetcwdArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetcwdArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetcwdArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Buf, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.GetcwdArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.GetcwdArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Buf, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.GetcwdArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.GetcwdArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseChdirArgs(decoder *Decoder) (types.ChdirArgs, error) {
-  var result types.ChdirArgs
-  var err error
+	var result types.ChdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ChdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ChdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ChdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ChdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ChdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ChdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFchdirArgs(decoder *Decoder) (types.FchdirArgs, error) {
-  var result types.FchdirArgs
-  var err error
+	var result types.FchdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FchdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FchdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FchdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FchdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FchdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FchdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRenameArgs(decoder *Decoder) (types.RenameArgs, error) {
-  var result types.RenameArgs
-  var err error
+	var result types.RenameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RenameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RenameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RenameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RenameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Oldpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RenameArgs{}, err
-      }
-    case 1:
-      result.Newpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RenameArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Oldpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RenameArgs{}, err
+			}
+		case 1:
+			result.Newpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RenameArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMkdirArgs(decoder *Decoder) (types.MkdirArgs, error) {
-  var result types.MkdirArgs
-  var err error
+	var result types.MkdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MkdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MkdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MkdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MkdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MkdirArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.MkdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MkdirArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.MkdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRmdirArgs(decoder *Decoder) (types.RmdirArgs, error) {
-  var result types.RmdirArgs
-  var err error
+	var result types.RmdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RmdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RmdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RmdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RmdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RmdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RmdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCreatArgs(decoder *Decoder) (types.CreatArgs, error) {
-  var result types.CreatArgs
-  var err error
+	var result types.CreatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CreatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CreatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CreatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CreatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.CreatArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.CreatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.CreatArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.CreatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLinkArgs(decoder *Decoder) (types.LinkArgs, error) {
-  var result types.LinkArgs
-  var err error
+	var result types.LinkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LinkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LinkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LinkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LinkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Oldpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LinkArgs{}, err
-      }
-    case 1:
-      result.Newpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LinkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Oldpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LinkArgs{}, err
+			}
+		case 1:
+			result.Newpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LinkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUnlinkArgs(decoder *Decoder) (types.UnlinkArgs, error) {
-  var result types.UnlinkArgs
-  var err error
+	var result types.UnlinkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UnlinkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UnlinkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UnlinkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UnlinkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UnlinkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UnlinkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSymlinkArgs(decoder *Decoder) (types.SymlinkArgs, error) {
-  var result types.SymlinkArgs
-  var err error
+	var result types.SymlinkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SymlinkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SymlinkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SymlinkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SymlinkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Target, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SymlinkArgs{}, err
-      }
-    case 1:
-      result.Linkpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SymlinkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Target, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SymlinkArgs{}, err
+			}
+		case 1:
+			result.Linkpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SymlinkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseReadlinkArgs(decoder *Decoder) (types.ReadlinkArgs, error) {
-  var result types.ReadlinkArgs
-  var err error
+	var result types.ReadlinkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ReadlinkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ReadlinkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ReadlinkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ReadlinkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ReadlinkArgs{}, err
-      }
-    case 1:
-      result.Buf, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ReadlinkArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Bufsiz)
-      if err != nil {
-        return types.ReadlinkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ReadlinkArgs{}, err
+			}
+		case 1:
+			result.Buf, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ReadlinkArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Bufsiz)
+			if err != nil {
+				return types.ReadlinkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseChmodArgs(decoder *Decoder) (types.ChmodArgs, error) {
-  var result types.ChmodArgs
-  var err error
+	var result types.ChmodArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ChmodArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ChmodArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ChmodArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ChmodArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ChmodArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.ChmodArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ChmodArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.ChmodArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFchmodArgs(decoder *Decoder) (types.FchmodArgs, error) {
-  var result types.FchmodArgs
-  var err error
+	var result types.FchmodArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FchmodArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FchmodArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FchmodArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FchmodArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FchmodArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.FchmodArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FchmodArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.FchmodArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseChownArgs(decoder *Decoder) (types.ChownArgs, error) {
-  var result types.ChownArgs
-  var err error
+	var result types.ChownArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ChownArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ChownArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ChownArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ChownArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ChownArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Owner)
-      if err != nil {
-        return types.ChownArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Group)
-      if err != nil {
-        return types.ChownArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ChownArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Owner)
+			if err != nil {
+				return types.ChownArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Group)
+			if err != nil {
+				return types.ChownArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFchownArgs(decoder *Decoder) (types.FchownArgs, error) {
-  var result types.FchownArgs
-  var err error
+	var result types.FchownArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FchownArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FchownArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FchownArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FchownArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FchownArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Owner)
-      if err != nil {
-        return types.FchownArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Group)
-      if err != nil {
-        return types.FchownArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FchownArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Owner)
+			if err != nil {
+				return types.FchownArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Group)
+			if err != nil {
+				return types.FchownArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLchownArgs(decoder *Decoder) (types.LchownArgs, error) {
-  var result types.LchownArgs
-  var err error
+	var result types.LchownArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LchownArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LchownArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LchownArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LchownArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LchownArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Owner)
-      if err != nil {
-        return types.LchownArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Group)
-      if err != nil {
-        return types.LchownArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LchownArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Owner)
+			if err != nil {
+				return types.LchownArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Group)
+			if err != nil {
+				return types.LchownArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUmaskArgs(decoder *Decoder) (types.UmaskArgs, error) {
-  var result types.UmaskArgs
-  var err error
+	var result types.UmaskArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UmaskArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UmaskArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UmaskArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UmaskArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Mask)
-      if err != nil {
-        return types.UmaskArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Mask)
+			if err != nil {
+				return types.UmaskArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGettimeofdayArgs(decoder *Decoder) (types.GettimeofdayArgs, error) {
-  var result types.GettimeofdayArgs
-  var err error
+	var result types.GettimeofdayArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GettimeofdayArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GettimeofdayArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GettimeofdayArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GettimeofdayArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataTv uint64
-      err = decoder.DecodeUint64(&dataTv)
-      if err != nil {
-        return types.GettimeofdayArgs{}, err
-      }
-      result.Tv = uintptr(dataTv)
-    case 1:
-      var dataTz uint64
-      err = decoder.DecodeUint64(&dataTz)
-      if err != nil {
-        return types.GettimeofdayArgs{}, err
-      }
-      result.Tz = uintptr(dataTz)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataTv uint64
+			err = decoder.DecodeUint64(&dataTv)
+			if err != nil {
+				return types.GettimeofdayArgs{}, err
+			}
+			result.Tv = uintptr(dataTv)
+		case 1:
+			var dataTz uint64
+			err = decoder.DecodeUint64(&dataTz)
+			if err != nil {
+				return types.GettimeofdayArgs{}, err
+			}
+			result.Tz = uintptr(dataTz)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetrlimitArgs(decoder *Decoder) (types.GetrlimitArgs, error) {
-  var result types.GetrlimitArgs
-  var err error
+	var result types.GetrlimitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetrlimitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetrlimitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetrlimitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetrlimitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Resource)
-      if err != nil {
-        return types.GetrlimitArgs{}, err
-      }
-    case 1:
-      var dataRlim uint64
-      err = decoder.DecodeUint64(&dataRlim)
-      if err != nil {
-        return types.GetrlimitArgs{}, err
-      }
-      result.Rlim = uintptr(dataRlim)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Resource)
+			if err != nil {
+				return types.GetrlimitArgs{}, err
+			}
+		case 1:
+			var dataRlim uint64
+			err = decoder.DecodeUint64(&dataRlim)
+			if err != nil {
+				return types.GetrlimitArgs{}, err
+			}
+			result.Rlim = uintptr(dataRlim)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetrusageArgs(decoder *Decoder) (types.GetrusageArgs, error) {
-  var result types.GetrusageArgs
-  var err error
+	var result types.GetrusageArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetrusageArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetrusageArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetrusageArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetrusageArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Who)
-      if err != nil {
-        return types.GetrusageArgs{}, err
-      }
-    case 1:
-      var dataUsage uint64
-      err = decoder.DecodeUint64(&dataUsage)
-      if err != nil {
-        return types.GetrusageArgs{}, err
-      }
-      result.Usage = uintptr(dataUsage)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Who)
+			if err != nil {
+				return types.GetrusageArgs{}, err
+			}
+		case 1:
+			var dataUsage uint64
+			err = decoder.DecodeUint64(&dataUsage)
+			if err != nil {
+				return types.GetrusageArgs{}, err
+			}
+			result.Usage = uintptr(dataUsage)
+		}
+	}
+	return result, nil
 }
 
 func ParseSysinfoArgs(decoder *Decoder) (types.SysinfoArgs, error) {
-  var result types.SysinfoArgs
-  var err error
+	var result types.SysinfoArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SysinfoArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SysinfoArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SysinfoArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SysinfoArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataInfo uint64
-      err = decoder.DecodeUint64(&dataInfo)
-      if err != nil {
-        return types.SysinfoArgs{}, err
-      }
-      result.Info = uintptr(dataInfo)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataInfo uint64
+			err = decoder.DecodeUint64(&dataInfo)
+			if err != nil {
+				return types.SysinfoArgs{}, err
+			}
+			result.Info = uintptr(dataInfo)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimesArgs(decoder *Decoder) (types.TimesArgs, error) {
-  var result types.TimesArgs
-  var err error
+	var result types.TimesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.TimesArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.TimesArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParsePtraceArgs(decoder *Decoder) (types.PtraceArgs, error) {
-  var result types.PtraceArgs
-  var err error
+	var result types.PtraceArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PtraceArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PtraceArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PtraceArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PtraceArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt64(&result.Request)
-      if err != nil {
-        return types.PtraceArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.PtraceArgs{}, err
-      }
-    case 2:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.PtraceArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 3:
-      var dataData uint64
-      err = decoder.DecodeUint64(&dataData)
-      if err != nil {
-        return types.PtraceArgs{}, err
-      }
-      result.Data = uintptr(dataData)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt64(&result.Request)
+			if err != nil {
+				return types.PtraceArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.PtraceArgs{}, err
+			}
+		case 2:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.PtraceArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 3:
+			var dataData uint64
+			err = decoder.DecodeUint64(&dataData)
+			if err != nil {
+				return types.PtraceArgs{}, err
+			}
+			result.Data = uintptr(dataData)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetuidArgs(decoder *Decoder) (types.GetuidArgs, error) {
-  return types.GetuidArgs{}, nil
+	return types.GetuidArgs{}, nil
 }
 
 func ParseSyslogArgs(decoder *Decoder) (types.SyslogArgs, error) {
-  var result types.SyslogArgs
-  var err error
+	var result types.SyslogArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SyslogArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SyslogArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SyslogArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SyslogArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.SyslogArgs{}, err
-      }
-    case 1:
-      result.Bufp, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SyslogArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Len)
-      if err != nil {
-        return types.SyslogArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.SyslogArgs{}, err
+			}
+		case 1:
+			result.Bufp, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SyslogArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Len)
+			if err != nil {
+				return types.SyslogArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetgidArgs(decoder *Decoder) (types.GetgidArgs, error) {
-  return types.GetgidArgs{}, nil
+	return types.GetgidArgs{}, nil
 }
 
 func ParseSetuidArgs(decoder *Decoder) (types.SetuidArgs, error) {
-  var result types.SetuidArgs
-  var err error
+	var result types.SetuidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetuidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetuidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetuidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetuidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Uid)
-      if err != nil {
-        return types.SetuidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Uid)
+			if err != nil {
+				return types.SetuidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetgidArgs(decoder *Decoder) (types.SetgidArgs, error) {
-  var result types.SetgidArgs
-  var err error
+	var result types.SetgidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetgidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetgidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetgidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetgidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Gid)
-      if err != nil {
-        return types.SetgidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Gid)
+			if err != nil {
+				return types.SetgidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGeteuidArgs(decoder *Decoder) (types.GeteuidArgs, error) {
-  return types.GeteuidArgs{}, nil
+	return types.GeteuidArgs{}, nil
 }
 
 func ParseGetegidArgs(decoder *Decoder) (types.GetegidArgs, error) {
-  return types.GetegidArgs{}, nil
+	return types.GetegidArgs{}, nil
 }
 
 func ParseSetpgidArgs(decoder *Decoder) (types.SetpgidArgs, error) {
-  var result types.SetpgidArgs
-  var err error
+	var result types.SetpgidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetpgidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetpgidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetpgidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetpgidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SetpgidArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Pgid)
-      if err != nil {
-        return types.SetpgidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SetpgidArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Pgid)
+			if err != nil {
+				return types.SetpgidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetppidArgs(decoder *Decoder) (types.GetppidArgs, error) {
-  return types.GetppidArgs{}, nil
+	return types.GetppidArgs{}, nil
 }
 
 func ParseGetpgrpArgs(decoder *Decoder) (types.GetpgrpArgs, error) {
-  return types.GetpgrpArgs{}, nil
+	return types.GetpgrpArgs{}, nil
 }
 
 func ParseSetsidArgs(decoder *Decoder) (types.SetsidArgs, error) {
-  return types.SetsidArgs{}, nil
+	return types.SetsidArgs{}, nil
 }
 
 func ParseSetreuidArgs(decoder *Decoder) (types.SetreuidArgs, error) {
-  var result types.SetreuidArgs
-  var err error
+	var result types.SetreuidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetreuidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetreuidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetreuidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetreuidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Ruid)
-      if err != nil {
-        return types.SetreuidArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Euid)
-      if err != nil {
-        return types.SetreuidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Ruid)
+			if err != nil {
+				return types.SetreuidArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Euid)
+			if err != nil {
+				return types.SetreuidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetregidArgs(decoder *Decoder) (types.SetregidArgs, error) {
-  var result types.SetregidArgs
-  var err error
+	var result types.SetregidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetregidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetregidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetregidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetregidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Rgid)
-      if err != nil {
-        return types.SetregidArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Egid)
-      if err != nil {
-        return types.SetregidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Rgid)
+			if err != nil {
+				return types.SetregidArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Egid)
+			if err != nil {
+				return types.SetregidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetgroupsArgs(decoder *Decoder) (types.GetgroupsArgs, error) {
-  var result types.GetgroupsArgs
-  var err error
+	var result types.GetgroupsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetgroupsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetgroupsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetgroupsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetgroupsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Size)
-      if err != nil {
-        return types.GetgroupsArgs{}, err
-      }
-    case 1:
-      var dataList uint64
-      err = decoder.DecodeUint64(&dataList)
-      if err != nil {
-        return types.GetgroupsArgs{}, err
-      }
-      result.List = uintptr(dataList)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Size)
+			if err != nil {
+				return types.GetgroupsArgs{}, err
+			}
+		case 1:
+			var dataList uint64
+			err = decoder.DecodeUint64(&dataList)
+			if err != nil {
+				return types.GetgroupsArgs{}, err
+			}
+			result.List = uintptr(dataList)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetgroupsArgs(decoder *Decoder) (types.SetgroupsArgs, error) {
-  var result types.SetgroupsArgs
-  var err error
+	var result types.SetgroupsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetgroupsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetgroupsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetgroupsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetgroupsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Size)
-      if err != nil {
-        return types.SetgroupsArgs{}, err
-      }
-    case 1:
-      var dataList uint64
-      err = decoder.DecodeUint64(&dataList)
-      if err != nil {
-        return types.SetgroupsArgs{}, err
-      }
-      result.List = uintptr(dataList)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Size)
+			if err != nil {
+				return types.SetgroupsArgs{}, err
+			}
+		case 1:
+			var dataList uint64
+			err = decoder.DecodeUint64(&dataList)
+			if err != nil {
+				return types.SetgroupsArgs{}, err
+			}
+			result.List = uintptr(dataList)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetresuidArgs(decoder *Decoder) (types.SetresuidArgs, error) {
-  var result types.SetresuidArgs
-  var err error
+	var result types.SetresuidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetresuidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetresuidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetresuidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetresuidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Ruid)
-      if err != nil {
-        return types.SetresuidArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Euid)
-      if err != nil {
-        return types.SetresuidArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Suid)
-      if err != nil {
-        return types.SetresuidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Ruid)
+			if err != nil {
+				return types.SetresuidArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Euid)
+			if err != nil {
+				return types.SetresuidArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Suid)
+			if err != nil {
+				return types.SetresuidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetresuidArgs(decoder *Decoder) (types.GetresuidArgs, error) {
-  var result types.GetresuidArgs
-  var err error
+	var result types.GetresuidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetresuidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetresuidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetresuidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetresuidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRuid uint64
-      err = decoder.DecodeUint64(&dataRuid)
-      if err != nil {
-        return types.GetresuidArgs{}, err
-      }
-      result.Ruid = uintptr(dataRuid)
-    case 1:
-      var dataEuid uint64
-      err = decoder.DecodeUint64(&dataEuid)
-      if err != nil {
-        return types.GetresuidArgs{}, err
-      }
-      result.Euid = uintptr(dataEuid)
-    case 2:
-      var dataSuid uint64
-      err = decoder.DecodeUint64(&dataSuid)
-      if err != nil {
-        return types.GetresuidArgs{}, err
-      }
-      result.Suid = uintptr(dataSuid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRuid uint64
+			err = decoder.DecodeUint64(&dataRuid)
+			if err != nil {
+				return types.GetresuidArgs{}, err
+			}
+			result.Ruid = uintptr(dataRuid)
+		case 1:
+			var dataEuid uint64
+			err = decoder.DecodeUint64(&dataEuid)
+			if err != nil {
+				return types.GetresuidArgs{}, err
+			}
+			result.Euid = uintptr(dataEuid)
+		case 2:
+			var dataSuid uint64
+			err = decoder.DecodeUint64(&dataSuid)
+			if err != nil {
+				return types.GetresuidArgs{}, err
+			}
+			result.Suid = uintptr(dataSuid)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetresgidArgs(decoder *Decoder) (types.SetresgidArgs, error) {
-  var result types.SetresgidArgs
-  var err error
+	var result types.SetresgidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetresgidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetresgidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetresgidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetresgidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Rgid)
-      if err != nil {
-        return types.SetresgidArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Egid)
-      if err != nil {
-        return types.SetresgidArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Sgid)
-      if err != nil {
-        return types.SetresgidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Rgid)
+			if err != nil {
+				return types.SetresgidArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Egid)
+			if err != nil {
+				return types.SetresgidArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Sgid)
+			if err != nil {
+				return types.SetresgidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetresgidArgs(decoder *Decoder) (types.GetresgidArgs, error) {
-  var result types.GetresgidArgs
-  var err error
+	var result types.GetresgidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetresgidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetresgidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetresgidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetresgidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRgid uint64
-      err = decoder.DecodeUint64(&dataRgid)
-      if err != nil {
-        return types.GetresgidArgs{}, err
-      }
-      result.Rgid = uintptr(dataRgid)
-    case 1:
-      var dataEgid uint64
-      err = decoder.DecodeUint64(&dataEgid)
-      if err != nil {
-        return types.GetresgidArgs{}, err
-      }
-      result.Egid = uintptr(dataEgid)
-    case 2:
-      var dataSgid uint64
-      err = decoder.DecodeUint64(&dataSgid)
-      if err != nil {
-        return types.GetresgidArgs{}, err
-      }
-      result.Sgid = uintptr(dataSgid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRgid uint64
+			err = decoder.DecodeUint64(&dataRgid)
+			if err != nil {
+				return types.GetresgidArgs{}, err
+			}
+			result.Rgid = uintptr(dataRgid)
+		case 1:
+			var dataEgid uint64
+			err = decoder.DecodeUint64(&dataEgid)
+			if err != nil {
+				return types.GetresgidArgs{}, err
+			}
+			result.Egid = uintptr(dataEgid)
+		case 2:
+			var dataSgid uint64
+			err = decoder.DecodeUint64(&dataSgid)
+			if err != nil {
+				return types.GetresgidArgs{}, err
+			}
+			result.Sgid = uintptr(dataSgid)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetpgidArgs(decoder *Decoder) (types.GetpgidArgs, error) {
-  var result types.GetpgidArgs
-  var err error
+	var result types.GetpgidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetpgidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetpgidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetpgidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetpgidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.GetpgidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.GetpgidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetfsuidArgs(decoder *Decoder) (types.SetfsuidArgs, error) {
-  var result types.SetfsuidArgs
-  var err error
+	var result types.SetfsuidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetfsuidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetfsuidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetfsuidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetfsuidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fsuid)
-      if err != nil {
-        return types.SetfsuidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fsuid)
+			if err != nil {
+				return types.SetfsuidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetfsgidArgs(decoder *Decoder) (types.SetfsgidArgs, error) {
-  var result types.SetfsgidArgs
-  var err error
+	var result types.SetfsgidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetfsgidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetfsgidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetfsgidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetfsgidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fsgid)
-      if err != nil {
-        return types.SetfsgidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fsgid)
+			if err != nil {
+				return types.SetfsgidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetsidArgs(decoder *Decoder) (types.GetsidArgs, error) {
-  var result types.GetsidArgs
-  var err error
+	var result types.GetsidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetsidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetsidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetsidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetsidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.GetsidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.GetsidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCapgetArgs(decoder *Decoder) (types.CapgetArgs, error) {
-  var result types.CapgetArgs
-  var err error
+	var result types.CapgetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CapgetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CapgetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CapgetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CapgetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataHdrp uint64
-      err = decoder.DecodeUint64(&dataHdrp)
-      if err != nil {
-        return types.CapgetArgs{}, err
-      }
-      result.Hdrp = uintptr(dataHdrp)
-    case 1:
-      var dataDatap uint64
-      err = decoder.DecodeUint64(&dataDatap)
-      if err != nil {
-        return types.CapgetArgs{}, err
-      }
-      result.Datap = uintptr(dataDatap)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataHdrp uint64
+			err = decoder.DecodeUint64(&dataHdrp)
+			if err != nil {
+				return types.CapgetArgs{}, err
+			}
+			result.Hdrp = uintptr(dataHdrp)
+		case 1:
+			var dataDatap uint64
+			err = decoder.DecodeUint64(&dataDatap)
+			if err != nil {
+				return types.CapgetArgs{}, err
+			}
+			result.Datap = uintptr(dataDatap)
+		}
+	}
+	return result, nil
 }
 
 func ParseCapsetArgs(decoder *Decoder) (types.CapsetArgs, error) {
-  var result types.CapsetArgs
-  var err error
+	var result types.CapsetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CapsetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CapsetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CapsetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CapsetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataHdrp uint64
-      err = decoder.DecodeUint64(&dataHdrp)
-      if err != nil {
-        return types.CapsetArgs{}, err
-      }
-      result.Hdrp = uintptr(dataHdrp)
-    case 1:
-      var dataDatap uint64
-      err = decoder.DecodeUint64(&dataDatap)
-      if err != nil {
-        return types.CapsetArgs{}, err
-      }
-      result.Datap = uintptr(dataDatap)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataHdrp uint64
+			err = decoder.DecodeUint64(&dataHdrp)
+			if err != nil {
+				return types.CapsetArgs{}, err
+			}
+			result.Hdrp = uintptr(dataHdrp)
+		case 1:
+			var dataDatap uint64
+			err = decoder.DecodeUint64(&dataDatap)
+			if err != nil {
+				return types.CapsetArgs{}, err
+			}
+			result.Datap = uintptr(dataDatap)
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigpendingArgs(decoder *Decoder) (types.RtSigpendingArgs, error) {
-  var result types.RtSigpendingArgs
-  var err error
+	var result types.RtSigpendingArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtSigpendingArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtSigpendingArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtSigpendingArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtSigpendingArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataSet uint64
-      err = decoder.DecodeUint64(&dataSet)
-      if err != nil {
-        return types.RtSigpendingArgs{}, err
-      }
-      result.Set = uintptr(dataSet)
-    case 1:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.RtSigpendingArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataSet uint64
+			err = decoder.DecodeUint64(&dataSet)
+			if err != nil {
+				return types.RtSigpendingArgs{}, err
+			}
+			result.Set = uintptr(dataSet)
+		case 1:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.RtSigpendingArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigtimedwaitArgs(decoder *Decoder) (types.RtSigtimedwaitArgs, error) {
-  var result types.RtSigtimedwaitArgs
-  var err error
+	var result types.RtSigtimedwaitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtSigtimedwaitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtSigtimedwaitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtSigtimedwaitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtSigtimedwaitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataSet uint64
-      err = decoder.DecodeUint64(&dataSet)
-      if err != nil {
-        return types.RtSigtimedwaitArgs{}, err
-      }
-      result.Set = uintptr(dataSet)
-    case 1:
-      var dataInfo uint64
-      err = decoder.DecodeUint64(&dataInfo)
-      if err != nil {
-        return types.RtSigtimedwaitArgs{}, err
-      }
-      result.Info = uintptr(dataInfo)
-    case 2:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.RtSigtimedwaitArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.RtSigtimedwaitArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataSet uint64
+			err = decoder.DecodeUint64(&dataSet)
+			if err != nil {
+				return types.RtSigtimedwaitArgs{}, err
+			}
+			result.Set = uintptr(dataSet)
+		case 1:
+			var dataInfo uint64
+			err = decoder.DecodeUint64(&dataInfo)
+			if err != nil {
+				return types.RtSigtimedwaitArgs{}, err
+			}
+			result.Info = uintptr(dataInfo)
+		case 2:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.RtSigtimedwaitArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.RtSigtimedwaitArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigqueueinfoArgs(decoder *Decoder) (types.RtSigqueueinfoArgs, error) {
-  var result types.RtSigqueueinfoArgs
-  var err error
+	var result types.RtSigqueueinfoArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtSigqueueinfoArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtSigqueueinfoArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtSigqueueinfoArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtSigqueueinfoArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Tgid)
-      if err != nil {
-        return types.RtSigqueueinfoArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.RtSigqueueinfoArgs{}, err
-      }
-    case 2:
-      var dataInfo uint64
-      err = decoder.DecodeUint64(&dataInfo)
-      if err != nil {
-        return types.RtSigqueueinfoArgs{}, err
-      }
-      result.Info = uintptr(dataInfo)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Tgid)
+			if err != nil {
+				return types.RtSigqueueinfoArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.RtSigqueueinfoArgs{}, err
+			}
+		case 2:
+			var dataInfo uint64
+			err = decoder.DecodeUint64(&dataInfo)
+			if err != nil {
+				return types.RtSigqueueinfoArgs{}, err
+			}
+			result.Info = uintptr(dataInfo)
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigsuspendArgs(decoder *Decoder) (types.RtSigsuspendArgs, error) {
-  var result types.RtSigsuspendArgs
-  var err error
+	var result types.RtSigsuspendArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtSigsuspendArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtSigsuspendArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtSigsuspendArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtSigsuspendArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataMask uint64
-      err = decoder.DecodeUint64(&dataMask)
-      if err != nil {
-        return types.RtSigsuspendArgs{}, err
-      }
-      result.Mask = uintptr(dataMask)
-    case 1:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.RtSigsuspendArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataMask uint64
+			err = decoder.DecodeUint64(&dataMask)
+			if err != nil {
+				return types.RtSigsuspendArgs{}, err
+			}
+			result.Mask = uintptr(dataMask)
+		case 1:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.RtSigsuspendArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSigaltstackArgs(decoder *Decoder) (types.SigaltstackArgs, error) {
-  var result types.SigaltstackArgs
-  var err error
+	var result types.SigaltstackArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SigaltstackArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SigaltstackArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SigaltstackArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SigaltstackArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataSs uint64
-      err = decoder.DecodeUint64(&dataSs)
-      if err != nil {
-        return types.SigaltstackArgs{}, err
-      }
-      result.Ss = uintptr(dataSs)
-    case 1:
-      var dataOldSs uint64
-      err = decoder.DecodeUint64(&dataOldSs)
-      if err != nil {
-        return types.SigaltstackArgs{}, err
-      }
-      result.OldSs = uintptr(dataOldSs)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataSs uint64
+			err = decoder.DecodeUint64(&dataSs)
+			if err != nil {
+				return types.SigaltstackArgs{}, err
+			}
+			result.Ss = uintptr(dataSs)
+		case 1:
+			var dataOldSs uint64
+			err = decoder.DecodeUint64(&dataOldSs)
+			if err != nil {
+				return types.SigaltstackArgs{}, err
+			}
+			result.OldSs = uintptr(dataOldSs)
+		}
+	}
+	return result, nil
 }
 
 func ParseUtimeArgs(decoder *Decoder) (types.UtimeArgs, error) {
-  var result types.UtimeArgs
-  var err error
+	var result types.UtimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UtimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UtimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UtimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UtimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Filename, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UtimeArgs{}, err
-      }
-    case 1:
-      var dataTimes uint64
-      err = decoder.DecodeUint64(&dataTimes)
-      if err != nil {
-        return types.UtimeArgs{}, err
-      }
-      result.Times = uintptr(dataTimes)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Filename, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UtimeArgs{}, err
+			}
+		case 1:
+			var dataTimes uint64
+			err = decoder.DecodeUint64(&dataTimes)
+			if err != nil {
+				return types.UtimeArgs{}, err
+			}
+			result.Times = uintptr(dataTimes)
+		}
+	}
+	return result, nil
 }
 
 func ParseMknodArgs(decoder *Decoder) (types.MknodArgs, error) {
-  var result types.MknodArgs
-  var err error
+	var result types.MknodArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MknodArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MknodArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MknodArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MknodArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MknodArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.MknodArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.MknodArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MknodArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.MknodArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.MknodArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUselibArgs(decoder *Decoder) (types.UselibArgs, error) {
-  var result types.UselibArgs
-  var err error
+	var result types.UselibArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UselibArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UselibArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UselibArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UselibArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Library, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UselibArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Library, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UselibArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePersonalityArgs(decoder *Decoder) (types.PersonalityArgs, error) {
-  var result types.PersonalityArgs
-  var err error
+	var result types.PersonalityArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PersonalityArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PersonalityArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PersonalityArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PersonalityArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Persona)
-      if err != nil {
-        return types.PersonalityArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Persona)
+			if err != nil {
+				return types.PersonalityArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUstatArgs(decoder *Decoder) (types.UstatArgs, error) {
-  var result types.UstatArgs
-  var err error
+	var result types.UstatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UstatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UstatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UstatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UstatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.UstatArgs{}, err
-      }
-    case 1:
-      var dataUbuf uint64
-      err = decoder.DecodeUint64(&dataUbuf)
-      if err != nil {
-        return types.UstatArgs{}, err
-      }
-      result.Ubuf = uintptr(dataUbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.UstatArgs{}, err
+			}
+		case 1:
+			var dataUbuf uint64
+			err = decoder.DecodeUint64(&dataUbuf)
+			if err != nil {
+				return types.UstatArgs{}, err
+			}
+			result.Ubuf = uintptr(dataUbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseStatfsArgs(decoder *Decoder) (types.StatfsArgs, error) {
-  var result types.StatfsArgs
-  var err error
+	var result types.StatfsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.StatfsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.StatfsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.StatfsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.StatfsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.StatfsArgs{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.StatfsArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.StatfsArgs{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.StatfsArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseFstatfsArgs(decoder *Decoder) (types.FstatfsArgs, error) {
-  var result types.FstatfsArgs
-  var err error
+	var result types.FstatfsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FstatfsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FstatfsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FstatfsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FstatfsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FstatfsArgs{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.FstatfsArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FstatfsArgs{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.FstatfsArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseSysfsArgs(decoder *Decoder) (types.SysfsArgs, error) {
-  var result types.SysfsArgs
-  var err error
+	var result types.SysfsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SysfsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SysfsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SysfsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SysfsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Option)
-      if err != nil {
-        return types.SysfsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Option)
+			if err != nil {
+				return types.SysfsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetpriorityArgs(decoder *Decoder) (types.GetpriorityArgs, error) {
-  var result types.GetpriorityArgs
-  var err error
+	var result types.GetpriorityArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetpriorityArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetpriorityArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetpriorityArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetpriorityArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Which)
-      if err != nil {
-        return types.GetpriorityArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Who)
-      if err != nil {
-        return types.GetpriorityArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Which)
+			if err != nil {
+				return types.GetpriorityArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Who)
+			if err != nil {
+				return types.GetpriorityArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetpriorityArgs(decoder *Decoder) (types.SetpriorityArgs, error) {
-  var result types.SetpriorityArgs
-  var err error
+	var result types.SetpriorityArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetpriorityArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetpriorityArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetpriorityArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetpriorityArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Which)
-      if err != nil {
-        return types.SetpriorityArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Who)
-      if err != nil {
-        return types.SetpriorityArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Prio)
-      if err != nil {
-        return types.SetpriorityArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Which)
+			if err != nil {
+				return types.SetpriorityArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Who)
+			if err != nil {
+				return types.SetpriorityArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Prio)
+			if err != nil {
+				return types.SetpriorityArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedSetparamArgs(decoder *Decoder) (types.SchedSetparamArgs, error) {
-  var result types.SchedSetparamArgs
-  var err error
+	var result types.SchedSetparamArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedSetparamArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedSetparamArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedSetparamArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedSetparamArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedSetparamArgs{}, err
-      }
-    case 1:
-      var dataParam uint64
-      err = decoder.DecodeUint64(&dataParam)
-      if err != nil {
-        return types.SchedSetparamArgs{}, err
-      }
-      result.Param = uintptr(dataParam)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedSetparamArgs{}, err
+			}
+		case 1:
+			var dataParam uint64
+			err = decoder.DecodeUint64(&dataParam)
+			if err != nil {
+				return types.SchedSetparamArgs{}, err
+			}
+			result.Param = uintptr(dataParam)
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedGetparamArgs(decoder *Decoder) (types.SchedGetparamArgs, error) {
-  var result types.SchedGetparamArgs
-  var err error
+	var result types.SchedGetparamArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedGetparamArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedGetparamArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedGetparamArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedGetparamArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedGetparamArgs{}, err
-      }
-    case 1:
-      var dataParam uint64
-      err = decoder.DecodeUint64(&dataParam)
-      if err != nil {
-        return types.SchedGetparamArgs{}, err
-      }
-      result.Param = uintptr(dataParam)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedGetparamArgs{}, err
+			}
+		case 1:
+			var dataParam uint64
+			err = decoder.DecodeUint64(&dataParam)
+			if err != nil {
+				return types.SchedGetparamArgs{}, err
+			}
+			result.Param = uintptr(dataParam)
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedSetschedulerArgs(decoder *Decoder) (types.SchedSetschedulerArgs, error) {
-  var result types.SchedSetschedulerArgs
-  var err error
+	var result types.SchedSetschedulerArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedSetschedulerArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedSetschedulerArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedSetschedulerArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedSetschedulerArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedSetschedulerArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Policy)
-      if err != nil {
-        return types.SchedSetschedulerArgs{}, err
-      }
-    case 2:
-      var dataParam uint64
-      err = decoder.DecodeUint64(&dataParam)
-      if err != nil {
-        return types.SchedSetschedulerArgs{}, err
-      }
-      result.Param = uintptr(dataParam)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedSetschedulerArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Policy)
+			if err != nil {
+				return types.SchedSetschedulerArgs{}, err
+			}
+		case 2:
+			var dataParam uint64
+			err = decoder.DecodeUint64(&dataParam)
+			if err != nil {
+				return types.SchedSetschedulerArgs{}, err
+			}
+			result.Param = uintptr(dataParam)
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedGetschedulerArgs(decoder *Decoder) (types.SchedGetschedulerArgs, error) {
-  var result types.SchedGetschedulerArgs
-  var err error
+	var result types.SchedGetschedulerArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedGetschedulerArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedGetschedulerArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedGetschedulerArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedGetschedulerArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedGetschedulerArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedGetschedulerArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedGetPriorityMaxArgs(decoder *Decoder) (types.SchedGetPriorityMaxArgs, error) {
-  var result types.SchedGetPriorityMaxArgs
-  var err error
+	var result types.SchedGetPriorityMaxArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedGetPriorityMaxArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedGetPriorityMaxArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedGetPriorityMaxArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedGetPriorityMaxArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Policy)
-      if err != nil {
-        return types.SchedGetPriorityMaxArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Policy)
+			if err != nil {
+				return types.SchedGetPriorityMaxArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedGetPriorityMinArgs(decoder *Decoder) (types.SchedGetPriorityMinArgs, error) {
-  var result types.SchedGetPriorityMinArgs
-  var err error
+	var result types.SchedGetPriorityMinArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedGetPriorityMinArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedGetPriorityMinArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedGetPriorityMinArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedGetPriorityMinArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Policy)
-      if err != nil {
-        return types.SchedGetPriorityMinArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Policy)
+			if err != nil {
+				return types.SchedGetPriorityMinArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedRrGetIntervalArgs(decoder *Decoder) (types.SchedRrGetIntervalArgs, error) {
-  var result types.SchedRrGetIntervalArgs
-  var err error
+	var result types.SchedRrGetIntervalArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedRrGetIntervalArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedRrGetIntervalArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedRrGetIntervalArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedRrGetIntervalArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedRrGetIntervalArgs{}, err
-      }
-    case 1:
-      result.Tp, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.SchedRrGetIntervalArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedRrGetIntervalArgs{}, err
+			}
+		case 1:
+			result.Tp, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.SchedRrGetIntervalArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMlockArgs(decoder *Decoder) (types.MlockArgs, error) {
-  var result types.MlockArgs
-  var err error
+	var result types.MlockArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MlockArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MlockArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MlockArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MlockArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MlockArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.MlockArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MlockArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.MlockArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMunlockArgs(decoder *Decoder) (types.MunlockArgs, error) {
-  var result types.MunlockArgs
-  var err error
+	var result types.MunlockArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MunlockArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MunlockArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MunlockArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MunlockArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MunlockArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.MunlockArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MunlockArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.MunlockArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMlockallArgs(decoder *Decoder) (types.MlockallArgs, error) {
-  var result types.MlockallArgs
-  var err error
+	var result types.MlockallArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MlockallArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MlockallArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MlockallArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MlockallArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.MlockallArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.MlockallArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMunlockallArgs(decoder *Decoder) (types.MunlockallArgs, error) {
-  return types.MunlockallArgs{}, nil
+	return types.MunlockallArgs{}, nil
 }
 
 func ParseVhangupArgs(decoder *Decoder) (types.VhangupArgs, error) {
-  return types.VhangupArgs{}, nil
+	return types.VhangupArgs{}, nil
 }
 
 func ParseModifyLdtArgs(decoder *Decoder) (types.ModifyLdtArgs, error) {
-  var result types.ModifyLdtArgs
-  var err error
+	var result types.ModifyLdtArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ModifyLdtArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ModifyLdtArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ModifyLdtArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ModifyLdtArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Func)
-      if err != nil {
-        return types.ModifyLdtArgs{}, err
-      }
-    case 1:
-      var dataPtr uint64
-      err = decoder.DecodeUint64(&dataPtr)
-      if err != nil {
-        return types.ModifyLdtArgs{}, err
-      }
-      result.Ptr = uintptr(dataPtr)
-    case 2:
-      err = decoder.DecodeUint64(&result.Bytecount)
-      if err != nil {
-        return types.ModifyLdtArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Func)
+			if err != nil {
+				return types.ModifyLdtArgs{}, err
+			}
+		case 1:
+			var dataPtr uint64
+			err = decoder.DecodeUint64(&dataPtr)
+			if err != nil {
+				return types.ModifyLdtArgs{}, err
+			}
+			result.Ptr = uintptr(dataPtr)
+		case 2:
+			err = decoder.DecodeUint64(&result.Bytecount)
+			if err != nil {
+				return types.ModifyLdtArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePivotRootArgs(decoder *Decoder) (types.PivotRootArgs, error) {
-  var result types.PivotRootArgs
-  var err error
+	var result types.PivotRootArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PivotRootArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PivotRootArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PivotRootArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PivotRootArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.NewRoot, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.PivotRootArgs{}, err
-      }
-    case 1:
-      result.PutOld, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.PivotRootArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.NewRoot, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.PivotRootArgs{}, err
+			}
+		case 1:
+			result.PutOld, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.PivotRootArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSysctlArgs(decoder *Decoder) (types.SysctlArgs, error) {
-  var result types.SysctlArgs
-  var err error
+	var result types.SysctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SysctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SysctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SysctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SysctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataArgs uint64
-      err = decoder.DecodeUint64(&dataArgs)
-      if err != nil {
-        return types.SysctlArgs{}, err
-      }
-      result.Args = uintptr(dataArgs)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataArgs uint64
+			err = decoder.DecodeUint64(&dataArgs)
+			if err != nil {
+				return types.SysctlArgs{}, err
+			}
+			result.Args = uintptr(dataArgs)
+		}
+	}
+	return result, nil
 }
 
 func ParsePrctlArgs(decoder *Decoder) (types.PrctlArgs, error) {
-  var result types.PrctlArgs
-  var err error
+	var result types.PrctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PrctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PrctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PrctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PrctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Option)
-      if err != nil {
-        return types.PrctlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Arg2)
-      if err != nil {
-        return types.PrctlArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Arg3)
-      if err != nil {
-        return types.PrctlArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Arg4)
-      if err != nil {
-        return types.PrctlArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Arg5)
-      if err != nil {
-        return types.PrctlArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Option)
+			if err != nil {
+				return types.PrctlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Arg2)
+			if err != nil {
+				return types.PrctlArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Arg3)
+			if err != nil {
+				return types.PrctlArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Arg4)
+			if err != nil {
+				return types.PrctlArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Arg5)
+			if err != nil {
+				return types.PrctlArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseArchPrctlArgs(decoder *Decoder) (types.ArchPrctlArgs, error) {
-  var result types.ArchPrctlArgs
-  var err error
+	var result types.ArchPrctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ArchPrctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ArchPrctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ArchPrctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ArchPrctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Option)
-      if err != nil {
-        return types.ArchPrctlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Addr)
-      if err != nil {
-        return types.ArchPrctlArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Option)
+			if err != nil {
+				return types.ArchPrctlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Addr)
+			if err != nil {
+				return types.ArchPrctlArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseAdjtimexArgs(decoder *Decoder) (types.AdjtimexArgs, error) {
-  var result types.AdjtimexArgs
-  var err error
+	var result types.AdjtimexArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.AdjtimexArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.AdjtimexArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.AdjtimexArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.AdjtimexArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.AdjtimexArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.AdjtimexArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetrlimitArgs(decoder *Decoder) (types.SetrlimitArgs, error) {
-  var result types.SetrlimitArgs
-  var err error
+	var result types.SetrlimitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetrlimitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetrlimitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetrlimitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetrlimitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Resource)
-      if err != nil {
-        return types.SetrlimitArgs{}, err
-      }
-    case 1:
-      var dataRlim uint64
-      err = decoder.DecodeUint64(&dataRlim)
-      if err != nil {
-        return types.SetrlimitArgs{}, err
-      }
-      result.Rlim = uintptr(dataRlim)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Resource)
+			if err != nil {
+				return types.SetrlimitArgs{}, err
+			}
+		case 1:
+			var dataRlim uint64
+			err = decoder.DecodeUint64(&dataRlim)
+			if err != nil {
+				return types.SetrlimitArgs{}, err
+			}
+			result.Rlim = uintptr(dataRlim)
+		}
+	}
+	return result, nil
 }
 
 func ParseChrootArgs(decoder *Decoder) (types.ChrootArgs, error) {
-  var result types.ChrootArgs
-  var err error
+	var result types.ChrootArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ChrootArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ChrootArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ChrootArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ChrootArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ChrootArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ChrootArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSyncArgs(decoder *Decoder) (types.SyncArgs, error) {
-  return types.SyncArgs{}, nil
+	return types.SyncArgs{}, nil
 }
 
 func ParseAcctArgs(decoder *Decoder) (types.AcctArgs, error) {
-  var result types.AcctArgs
-  var err error
+	var result types.AcctArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.AcctArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.AcctArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.AcctArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.AcctArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Filename, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.AcctArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Filename, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.AcctArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSettimeofdayArgs(decoder *Decoder) (types.SettimeofdayArgs, error) {
-  var result types.SettimeofdayArgs
-  var err error
+	var result types.SettimeofdayArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SettimeofdayArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SettimeofdayArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SettimeofdayArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SettimeofdayArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataTv uint64
-      err = decoder.DecodeUint64(&dataTv)
-      if err != nil {
-        return types.SettimeofdayArgs{}, err
-      }
-      result.Tv = uintptr(dataTv)
-    case 1:
-      var dataTz uint64
-      err = decoder.DecodeUint64(&dataTz)
-      if err != nil {
-        return types.SettimeofdayArgs{}, err
-      }
-      result.Tz = uintptr(dataTz)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataTv uint64
+			err = decoder.DecodeUint64(&dataTv)
+			if err != nil {
+				return types.SettimeofdayArgs{}, err
+			}
+			result.Tv = uintptr(dataTv)
+		case 1:
+			var dataTz uint64
+			err = decoder.DecodeUint64(&dataTz)
+			if err != nil {
+				return types.SettimeofdayArgs{}, err
+			}
+			result.Tz = uintptr(dataTz)
+		}
+	}
+	return result, nil
 }
 
 func ParseMountArgs(decoder *Decoder) (types.MountArgs, error) {
-  var result types.MountArgs
-  var err error
+	var result types.MountArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MountArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MountArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MountArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MountArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Source, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MountArgs{}, err
-      }
-    case 1:
-      result.Target, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MountArgs{}, err
-      }
-    case 2:
-      result.Filesystemtype, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MountArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Mountflags)
-      if err != nil {
-        return types.MountArgs{}, err
-      }
-    case 4:
-      var dataData uint64
-      err = decoder.DecodeUint64(&dataData)
-      if err != nil {
-        return types.MountArgs{}, err
-      }
-      result.Data = uintptr(dataData)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Source, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MountArgs{}, err
+			}
+		case 1:
+			result.Target, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MountArgs{}, err
+			}
+		case 2:
+			result.Filesystemtype, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MountArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Mountflags)
+			if err != nil {
+				return types.MountArgs{}, err
+			}
+		case 4:
+			var dataData uint64
+			err = decoder.DecodeUint64(&dataData)
+			if err != nil {
+				return types.MountArgs{}, err
+			}
+			result.Data = uintptr(dataData)
+		}
+	}
+	return result, nil
 }
 
 func ParseUmount2Args(decoder *Decoder) (types.Umount2Args, error) {
-  var result types.Umount2Args
-  var err error
+	var result types.Umount2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Umount2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Umount2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Umount2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Umount2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Target, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Umount2Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Umount2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Target, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Umount2Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Umount2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSwaponArgs(decoder *Decoder) (types.SwaponArgs, error) {
-  var result types.SwaponArgs
-  var err error
+	var result types.SwaponArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SwaponArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SwaponArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SwaponArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SwaponArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SwaponArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Swapflags)
-      if err != nil {
-        return types.SwaponArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SwaponArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Swapflags)
+			if err != nil {
+				return types.SwaponArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSwapoffArgs(decoder *Decoder) (types.SwapoffArgs, error) {
-  var result types.SwapoffArgs
-  var err error
+	var result types.SwapoffArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SwapoffArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SwapoffArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SwapoffArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SwapoffArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SwapoffArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SwapoffArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRebootArgs(decoder *Decoder) (types.RebootArgs, error) {
-  var result types.RebootArgs
-  var err error
+	var result types.RebootArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RebootArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RebootArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RebootArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RebootArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Magic)
-      if err != nil {
-        return types.RebootArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Magic2)
-      if err != nil {
-        return types.RebootArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.RebootArgs{}, err
-      }
-    case 3:
-      var dataArg uint64
-      err = decoder.DecodeUint64(&dataArg)
-      if err != nil {
-        return types.RebootArgs{}, err
-      }
-      result.Arg = uintptr(dataArg)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Magic)
+			if err != nil {
+				return types.RebootArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Magic2)
+			if err != nil {
+				return types.RebootArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.RebootArgs{}, err
+			}
+		case 3:
+			var dataArg uint64
+			err = decoder.DecodeUint64(&dataArg)
+			if err != nil {
+				return types.RebootArgs{}, err
+			}
+			result.Arg = uintptr(dataArg)
+		}
+	}
+	return result, nil
 }
 
 func ParseSethostnameArgs(decoder *Decoder) (types.SethostnameArgs, error) {
-  var result types.SethostnameArgs
-  var err error
+	var result types.SethostnameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SethostnameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SethostnameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SethostnameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SethostnameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SethostnameArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.SethostnameArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SethostnameArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.SethostnameArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetdomainnameArgs(decoder *Decoder) (types.SetdomainnameArgs, error) {
-  var result types.SetdomainnameArgs
-  var err error
+	var result types.SetdomainnameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetdomainnameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetdomainnameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetdomainnameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetdomainnameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SetdomainnameArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.SetdomainnameArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SetdomainnameArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.SetdomainnameArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseIoplArgs(decoder *Decoder) (types.IoplArgs, error) {
-  var result types.IoplArgs
-  var err error
+	var result types.IoplArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoplArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoplArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoplArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoplArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Level)
-      if err != nil {
-        return types.IoplArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Level)
+			if err != nil {
+				return types.IoplArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseIopermArgs(decoder *Decoder) (types.IopermArgs, error) {
-  var result types.IopermArgs
-  var err error
+	var result types.IopermArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IopermArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IopermArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IopermArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IopermArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.From)
-      if err != nil {
-        return types.IopermArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Num)
-      if err != nil {
-        return types.IopermArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.TurnOn)
-      if err != nil {
-        return types.IopermArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.From)
+			if err != nil {
+				return types.IopermArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Num)
+			if err != nil {
+				return types.IopermArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.TurnOn)
+			if err != nil {
+				return types.IopermArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCreateModuleArgs(decoder *Decoder) (types.CreateModuleArgs, error) {
-  return types.CreateModuleArgs{}, nil
+	return types.CreateModuleArgs{}, nil
 }
 
 func ParseInitModuleArgs(decoder *Decoder) (types.InitModuleArgs, error) {
-  var result types.InitModuleArgs
-  var err error
+	var result types.InitModuleArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.InitModuleArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.InitModuleArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.InitModuleArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.InitModuleArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataModuleImage uint64
-      err = decoder.DecodeUint64(&dataModuleImage)
-      if err != nil {
-        return types.InitModuleArgs{}, err
-      }
-      result.ModuleImage = uintptr(dataModuleImage)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.InitModuleArgs{}, err
-      }
-    case 2:
-      result.ParamValues, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.InitModuleArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataModuleImage uint64
+			err = decoder.DecodeUint64(&dataModuleImage)
+			if err != nil {
+				return types.InitModuleArgs{}, err
+			}
+			result.ModuleImage = uintptr(dataModuleImage)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.InitModuleArgs{}, err
+			}
+		case 2:
+			result.ParamValues, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.InitModuleArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDeleteModuleArgs(decoder *Decoder) (types.DeleteModuleArgs, error) {
-  var result types.DeleteModuleArgs
-  var err error
+	var result types.DeleteModuleArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DeleteModuleArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DeleteModuleArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DeleteModuleArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DeleteModuleArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DeleteModuleArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.DeleteModuleArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DeleteModuleArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.DeleteModuleArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetKernelSymsArgs(decoder *Decoder) (types.GetKernelSymsArgs, error) {
-  return types.GetKernelSymsArgs{}, nil
+	return types.GetKernelSymsArgs{}, nil
 }
 
 func ParseQueryModuleArgs(decoder *Decoder) (types.QueryModuleArgs, error) {
-  return types.QueryModuleArgs{}, nil
+	return types.QueryModuleArgs{}, nil
 }
 
 func ParseQuotactlArgs(decoder *Decoder) (types.QuotactlArgs, error) {
-  var result types.QuotactlArgs
-  var err error
+	var result types.QuotactlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.QuotactlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.QuotactlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.QuotactlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.QuotactlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.QuotactlArgs{}, err
-      }
-    case 1:
-      result.Special, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.QuotactlArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Id)
-      if err != nil {
-        return types.QuotactlArgs{}, err
-      }
-    case 3:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.QuotactlArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.QuotactlArgs{}, err
+			}
+		case 1:
+			result.Special, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.QuotactlArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Id)
+			if err != nil {
+				return types.QuotactlArgs{}, err
+			}
+		case 3:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.QuotactlArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		}
+	}
+	return result, nil
 }
 
 func ParseNfsservctlArgs(decoder *Decoder) (types.NfsservctlArgs, error) {
-  return types.NfsservctlArgs{}, nil
+	return types.NfsservctlArgs{}, nil
 }
 
 func ParseGetpmsgArgs(decoder *Decoder) (types.GetpmsgArgs, error) {
-  return types.GetpmsgArgs{}, nil
+	return types.GetpmsgArgs{}, nil
 }
 
 func ParsePutpmsgArgs(decoder *Decoder) (types.PutpmsgArgs, error) {
-  return types.PutpmsgArgs{}, nil
+	return types.PutpmsgArgs{}, nil
 }
 
 func ParseAfsArgs(decoder *Decoder) (types.AfsArgs, error) {
-  return types.AfsArgs{}, nil
+	return types.AfsArgs{}, nil
 }
 
 func ParseTuxcallArgs(decoder *Decoder) (types.TuxcallArgs, error) {
-  return types.TuxcallArgs{}, nil
+	return types.TuxcallArgs{}, nil
 }
 
 func ParseSecurityArgs(decoder *Decoder) (types.SecurityArgs, error) {
-  return types.SecurityArgs{}, nil
+	return types.SecurityArgs{}, nil
 }
 
 func ParseGettidArgs(decoder *Decoder) (types.GettidArgs, error) {
-  return types.GettidArgs{}, nil
+	return types.GettidArgs{}, nil
 }
 
 func ParseReadaheadArgs(decoder *Decoder) (types.ReadaheadArgs, error) {
-  var result types.ReadaheadArgs
-  var err error
+	var result types.ReadaheadArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ReadaheadArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ReadaheadArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ReadaheadArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ReadaheadArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.ReadaheadArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.ReadaheadArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.ReadaheadArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.ReadaheadArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.ReadaheadArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.ReadaheadArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetxattrArgs(decoder *Decoder) (types.SetxattrArgs, error) {
-  var result types.SetxattrArgs
-  var err error
+	var result types.SetxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SetxattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SetxattrArgs{}, err
-      }
-    case 2:
-      var dataValue uint64
-      err = decoder.DecodeUint64(&dataValue)
-      if err != nil {
-        return types.SetxattrArgs{}, err
-      }
-      result.Value = uintptr(dataValue)
-    case 3:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.SetxattrArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SetxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SetxattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SetxattrArgs{}, err
+			}
+		case 2:
+			var dataValue uint64
+			err = decoder.DecodeUint64(&dataValue)
+			if err != nil {
+				return types.SetxattrArgs{}, err
+			}
+			result.Value = uintptr(dataValue)
+		case 3:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.SetxattrArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SetxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLsetxattrArgs(decoder *Decoder) (types.LsetxattrArgs, error) {
-  var result types.LsetxattrArgs
-  var err error
+	var result types.LsetxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LsetxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LsetxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LsetxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LsetxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LsetxattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LsetxattrArgs{}, err
-      }
-    case 2:
-      var dataValue uint64
-      err = decoder.DecodeUint64(&dataValue)
-      if err != nil {
-        return types.LsetxattrArgs{}, err
-      }
-      result.Value = uintptr(dataValue)
-    case 3:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.LsetxattrArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.LsetxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LsetxattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LsetxattrArgs{}, err
+			}
+		case 2:
+			var dataValue uint64
+			err = decoder.DecodeUint64(&dataValue)
+			if err != nil {
+				return types.LsetxattrArgs{}, err
+			}
+			result.Value = uintptr(dataValue)
+		case 3:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.LsetxattrArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.LsetxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFsetxattrArgs(decoder *Decoder) (types.FsetxattrArgs, error) {
-  var result types.FsetxattrArgs
-  var err error
+	var result types.FsetxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FsetxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FsetxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FsetxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FsetxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FsetxattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FsetxattrArgs{}, err
-      }
-    case 2:
-      var dataValue uint64
-      err = decoder.DecodeUint64(&dataValue)
-      if err != nil {
-        return types.FsetxattrArgs{}, err
-      }
-      result.Value = uintptr(dataValue)
-    case 3:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.FsetxattrArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.FsetxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FsetxattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FsetxattrArgs{}, err
+			}
+		case 2:
+			var dataValue uint64
+			err = decoder.DecodeUint64(&dataValue)
+			if err != nil {
+				return types.FsetxattrArgs{}, err
+			}
+			result.Value = uintptr(dataValue)
+		case 3:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.FsetxattrArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.FsetxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetxattrArgs(decoder *Decoder) (types.GetxattrArgs, error) {
-  var result types.GetxattrArgs
-  var err error
+	var result types.GetxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.GetxattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.GetxattrArgs{}, err
-      }
-    case 2:
-      var dataValue uint64
-      err = decoder.DecodeUint64(&dataValue)
-      if err != nil {
-        return types.GetxattrArgs{}, err
-      }
-      result.Value = uintptr(dataValue)
-    case 3:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.GetxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.GetxattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.GetxattrArgs{}, err
+			}
+		case 2:
+			var dataValue uint64
+			err = decoder.DecodeUint64(&dataValue)
+			if err != nil {
+				return types.GetxattrArgs{}, err
+			}
+			result.Value = uintptr(dataValue)
+		case 3:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.GetxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLgetxattrArgs(decoder *Decoder) (types.LgetxattrArgs, error) {
-  var result types.LgetxattrArgs
-  var err error
+	var result types.LgetxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LgetxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LgetxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LgetxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LgetxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LgetxattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LgetxattrArgs{}, err
-      }
-    case 2:
-      var dataValue uint64
-      err = decoder.DecodeUint64(&dataValue)
-      if err != nil {
-        return types.LgetxattrArgs{}, err
-      }
-      result.Value = uintptr(dataValue)
-    case 3:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.LgetxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LgetxattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LgetxattrArgs{}, err
+			}
+		case 2:
+			var dataValue uint64
+			err = decoder.DecodeUint64(&dataValue)
+			if err != nil {
+				return types.LgetxattrArgs{}, err
+			}
+			result.Value = uintptr(dataValue)
+		case 3:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.LgetxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFgetxattrArgs(decoder *Decoder) (types.FgetxattrArgs, error) {
-  var result types.FgetxattrArgs
-  var err error
+	var result types.FgetxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FgetxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FgetxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FgetxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FgetxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FgetxattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FgetxattrArgs{}, err
-      }
-    case 2:
-      var dataValue uint64
-      err = decoder.DecodeUint64(&dataValue)
-      if err != nil {
-        return types.FgetxattrArgs{}, err
-      }
-      result.Value = uintptr(dataValue)
-    case 3:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.FgetxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FgetxattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FgetxattrArgs{}, err
+			}
+		case 2:
+			var dataValue uint64
+			err = decoder.DecodeUint64(&dataValue)
+			if err != nil {
+				return types.FgetxattrArgs{}, err
+			}
+			result.Value = uintptr(dataValue)
+		case 3:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.FgetxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseListxattrArgs(decoder *Decoder) (types.ListxattrArgs, error) {
-  var result types.ListxattrArgs
-  var err error
+	var result types.ListxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ListxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ListxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ListxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ListxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ListxattrArgs{}, err
-      }
-    case 1:
-      result.List, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ListxattrArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.ListxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ListxattrArgs{}, err
+			}
+		case 1:
+			result.List, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ListxattrArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.ListxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLlistxattrArgs(decoder *Decoder) (types.LlistxattrArgs, error) {
-  var result types.LlistxattrArgs
-  var err error
+	var result types.LlistxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LlistxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LlistxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LlistxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LlistxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LlistxattrArgs{}, err
-      }
-    case 1:
-      result.List, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LlistxattrArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.LlistxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LlistxattrArgs{}, err
+			}
+		case 1:
+			result.List, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LlistxattrArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.LlistxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFlistxattrArgs(decoder *Decoder) (types.FlistxattrArgs, error) {
-  var result types.FlistxattrArgs
-  var err error
+	var result types.FlistxattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FlistxattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FlistxattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FlistxattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FlistxattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FlistxattrArgs{}, err
-      }
-    case 1:
-      result.List, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FlistxattrArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.FlistxattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FlistxattrArgs{}, err
+			}
+		case 1:
+			result.List, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FlistxattrArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.FlistxattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRemovexattrArgs(decoder *Decoder) (types.RemovexattrArgs, error) {
-  var result types.RemovexattrArgs
-  var err error
+	var result types.RemovexattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RemovexattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RemovexattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RemovexattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RemovexattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RemovexattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RemovexattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RemovexattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RemovexattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLremovexattrArgs(decoder *Decoder) (types.LremovexattrArgs, error) {
-  var result types.LremovexattrArgs
-  var err error
+	var result types.LremovexattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LremovexattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LremovexattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LremovexattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LremovexattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LremovexattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LremovexattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LremovexattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LremovexattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFremovexattrArgs(decoder *Decoder) (types.FremovexattrArgs, error) {
-  var result types.FremovexattrArgs
-  var err error
+	var result types.FremovexattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FremovexattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FremovexattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FremovexattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FremovexattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FremovexattrArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FremovexattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FremovexattrArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FremovexattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTkillArgs(decoder *Decoder) (types.TkillArgs, error) {
-  var result types.TkillArgs
-  var err error
+	var result types.TkillArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TkillArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TkillArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TkillArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TkillArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Tid)
-      if err != nil {
-        return types.TkillArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.TkillArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Tid)
+			if err != nil {
+				return types.TkillArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.TkillArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTimeArgs(decoder *Decoder) (types.TimeArgs, error) {
-  var result types.TimeArgs
-  var err error
+	var result types.TimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataTloc uint64
-      err = decoder.DecodeUint64(&dataTloc)
-      if err != nil {
-        return types.TimeArgs{}, err
-      }
-      result.Tloc = uintptr(dataTloc)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataTloc uint64
+			err = decoder.DecodeUint64(&dataTloc)
+			if err != nil {
+				return types.TimeArgs{}, err
+			}
+			result.Tloc = uintptr(dataTloc)
+		}
+	}
+	return result, nil
 }
 
 func ParseFutexArgs(decoder *Decoder) (types.FutexArgs, error) {
-  var result types.FutexArgs
-  var err error
+	var result types.FutexArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FutexArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FutexArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FutexArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FutexArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataUaddr uint64
-      err = decoder.DecodeUint64(&dataUaddr)
-      if err != nil {
-        return types.FutexArgs{}, err
-      }
-      result.Uaddr = uintptr(dataUaddr)
-    case 1:
-      err = decoder.DecodeInt32(&result.FutexOp)
-      if err != nil {
-        return types.FutexArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Val)
-      if err != nil {
-        return types.FutexArgs{}, err
-      }
-    case 3:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.FutexArgs{}, err
-      }
-    case 4:
-      var dataUaddr2 uint64
-      err = decoder.DecodeUint64(&dataUaddr2)
-      if err != nil {
-        return types.FutexArgs{}, err
-      }
-      result.Uaddr2 = uintptr(dataUaddr2)
-    case 5:
-      err = decoder.DecodeInt32(&result.Val3)
-      if err != nil {
-        return types.FutexArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataUaddr uint64
+			err = decoder.DecodeUint64(&dataUaddr)
+			if err != nil {
+				return types.FutexArgs{}, err
+			}
+			result.Uaddr = uintptr(dataUaddr)
+		case 1:
+			err = decoder.DecodeInt32(&result.FutexOp)
+			if err != nil {
+				return types.FutexArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Val)
+			if err != nil {
+				return types.FutexArgs{}, err
+			}
+		case 3:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.FutexArgs{}, err
+			}
+		case 4:
+			var dataUaddr2 uint64
+			err = decoder.DecodeUint64(&dataUaddr2)
+			if err != nil {
+				return types.FutexArgs{}, err
+			}
+			result.Uaddr2 = uintptr(dataUaddr2)
+		case 5:
+			err = decoder.DecodeInt32(&result.Val3)
+			if err != nil {
+				return types.FutexArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedSetaffinityArgs(decoder *Decoder) (types.SchedSetaffinityArgs, error) {
-  var result types.SchedSetaffinityArgs
-  var err error
+	var result types.SchedSetaffinityArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedSetaffinityArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedSetaffinityArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedSetaffinityArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedSetaffinityArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedSetaffinityArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Cpusetsize)
-      if err != nil {
-        return types.SchedSetaffinityArgs{}, err
-      }
-    case 2:
-      var dataMask uint64
-      err = decoder.DecodeUint64(&dataMask)
-      if err != nil {
-        return types.SchedSetaffinityArgs{}, err
-      }
-      result.Mask = uintptr(dataMask)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedSetaffinityArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Cpusetsize)
+			if err != nil {
+				return types.SchedSetaffinityArgs{}, err
+			}
+		case 2:
+			var dataMask uint64
+			err = decoder.DecodeUint64(&dataMask)
+			if err != nil {
+				return types.SchedSetaffinityArgs{}, err
+			}
+			result.Mask = uintptr(dataMask)
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedGetaffinityArgs(decoder *Decoder) (types.SchedGetaffinityArgs, error) {
-  var result types.SchedGetaffinityArgs
-  var err error
+	var result types.SchedGetaffinityArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedGetaffinityArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedGetaffinityArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedGetaffinityArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedGetaffinityArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedGetaffinityArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Cpusetsize)
-      if err != nil {
-        return types.SchedGetaffinityArgs{}, err
-      }
-    case 2:
-      var dataMask uint64
-      err = decoder.DecodeUint64(&dataMask)
-      if err != nil {
-        return types.SchedGetaffinityArgs{}, err
-      }
-      result.Mask = uintptr(dataMask)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedGetaffinityArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Cpusetsize)
+			if err != nil {
+				return types.SchedGetaffinityArgs{}, err
+			}
+		case 2:
+			var dataMask uint64
+			err = decoder.DecodeUint64(&dataMask)
+			if err != nil {
+				return types.SchedGetaffinityArgs{}, err
+			}
+			result.Mask = uintptr(dataMask)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetThreadAreaArgs(decoder *Decoder) (types.SetThreadAreaArgs, error) {
-  var result types.SetThreadAreaArgs
-  var err error
+	var result types.SetThreadAreaArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetThreadAreaArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetThreadAreaArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetThreadAreaArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetThreadAreaArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataUInfo uint64
-      err = decoder.DecodeUint64(&dataUInfo)
-      if err != nil {
-        return types.SetThreadAreaArgs{}, err
-      }
-      result.UInfo = uintptr(dataUInfo)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataUInfo uint64
+			err = decoder.DecodeUint64(&dataUInfo)
+			if err != nil {
+				return types.SetThreadAreaArgs{}, err
+			}
+			result.UInfo = uintptr(dataUInfo)
+		}
+	}
+	return result, nil
 }
 
 func ParseIoSetupArgs(decoder *Decoder) (types.IoSetupArgs, error) {
-  var result types.IoSetupArgs
-  var err error
+	var result types.IoSetupArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoSetupArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoSetupArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoSetupArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoSetupArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.NrEvents)
-      if err != nil {
-        return types.IoSetupArgs{}, err
-      }
-    case 1:
-      var dataCtxIdp uint64
-      err = decoder.DecodeUint64(&dataCtxIdp)
-      if err != nil {
-        return types.IoSetupArgs{}, err
-      }
-      result.CtxIdp = uintptr(dataCtxIdp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.NrEvents)
+			if err != nil {
+				return types.IoSetupArgs{}, err
+			}
+		case 1:
+			var dataCtxIdp uint64
+			err = decoder.DecodeUint64(&dataCtxIdp)
+			if err != nil {
+				return types.IoSetupArgs{}, err
+			}
+			result.CtxIdp = uintptr(dataCtxIdp)
+		}
+	}
+	return result, nil
 }
 
 func ParseIoDestroyArgs(decoder *Decoder) (types.IoDestroyArgs, error) {
-  var result types.IoDestroyArgs
-  var err error
+	var result types.IoDestroyArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoDestroyArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoDestroyArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoDestroyArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoDestroyArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataCtxId uint64
-      err = decoder.DecodeUint64(&dataCtxId)
-      if err != nil {
-        return types.IoDestroyArgs{}, err
-      }
-      result.CtxId = uintptr(dataCtxId)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataCtxId uint64
+			err = decoder.DecodeUint64(&dataCtxId)
+			if err != nil {
+				return types.IoDestroyArgs{}, err
+			}
+			result.CtxId = uintptr(dataCtxId)
+		}
+	}
+	return result, nil
 }
 
 func ParseIoGeteventsArgs(decoder *Decoder) (types.IoGeteventsArgs, error) {
-  var result types.IoGeteventsArgs
-  var err error
+	var result types.IoGeteventsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoGeteventsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoGeteventsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoGeteventsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoGeteventsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataCtxId uint64
-      err = decoder.DecodeUint64(&dataCtxId)
-      if err != nil {
-        return types.IoGeteventsArgs{}, err
-      }
-      result.CtxId = uintptr(dataCtxId)
-    case 1:
-      err = decoder.DecodeInt64(&result.MinNr)
-      if err != nil {
-        return types.IoGeteventsArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt64(&result.Nr)
-      if err != nil {
-        return types.IoGeteventsArgs{}, err
-      }
-    case 3:
-      var dataEvents uint64
-      err = decoder.DecodeUint64(&dataEvents)
-      if err != nil {
-        return types.IoGeteventsArgs{}, err
-      }
-      result.Events = uintptr(dataEvents)
-    case 4:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.IoGeteventsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataCtxId uint64
+			err = decoder.DecodeUint64(&dataCtxId)
+			if err != nil {
+				return types.IoGeteventsArgs{}, err
+			}
+			result.CtxId = uintptr(dataCtxId)
+		case 1:
+			err = decoder.DecodeInt64(&result.MinNr)
+			if err != nil {
+				return types.IoGeteventsArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt64(&result.Nr)
+			if err != nil {
+				return types.IoGeteventsArgs{}, err
+			}
+		case 3:
+			var dataEvents uint64
+			err = decoder.DecodeUint64(&dataEvents)
+			if err != nil {
+				return types.IoGeteventsArgs{}, err
+			}
+			result.Events = uintptr(dataEvents)
+		case 4:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.IoGeteventsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseIoSubmitArgs(decoder *Decoder) (types.IoSubmitArgs, error) {
-  var result types.IoSubmitArgs
-  var err error
+	var result types.IoSubmitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoSubmitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoSubmitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoSubmitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoSubmitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataCtxId uint64
-      err = decoder.DecodeUint64(&dataCtxId)
-      if err != nil {
-        return types.IoSubmitArgs{}, err
-      }
-      result.CtxId = uintptr(dataCtxId)
-    case 1:
-      err = decoder.DecodeInt64(&result.Nr)
-      if err != nil {
-        return types.IoSubmitArgs{}, err
-      }
-    case 2:
-      var dataIocbpp uint64
-      err = decoder.DecodeUint64(&dataIocbpp)
-      if err != nil {
-        return types.IoSubmitArgs{}, err
-      }
-      result.Iocbpp = uintptr(dataIocbpp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataCtxId uint64
+			err = decoder.DecodeUint64(&dataCtxId)
+			if err != nil {
+				return types.IoSubmitArgs{}, err
+			}
+			result.CtxId = uintptr(dataCtxId)
+		case 1:
+			err = decoder.DecodeInt64(&result.Nr)
+			if err != nil {
+				return types.IoSubmitArgs{}, err
+			}
+		case 2:
+			var dataIocbpp uint64
+			err = decoder.DecodeUint64(&dataIocbpp)
+			if err != nil {
+				return types.IoSubmitArgs{}, err
+			}
+			result.Iocbpp = uintptr(dataIocbpp)
+		}
+	}
+	return result, nil
 }
 
 func ParseIoCancelArgs(decoder *Decoder) (types.IoCancelArgs, error) {
-  var result types.IoCancelArgs
-  var err error
+	var result types.IoCancelArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoCancelArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoCancelArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoCancelArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoCancelArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataCtxId uint64
-      err = decoder.DecodeUint64(&dataCtxId)
-      if err != nil {
-        return types.IoCancelArgs{}, err
-      }
-      result.CtxId = uintptr(dataCtxId)
-    case 1:
-      var dataIocb uint64
-      err = decoder.DecodeUint64(&dataIocb)
-      if err != nil {
-        return types.IoCancelArgs{}, err
-      }
-      result.Iocb = uintptr(dataIocb)
-    case 2:
-      var dataResult uint64
-      err = decoder.DecodeUint64(&dataResult)
-      if err != nil {
-        return types.IoCancelArgs{}, err
-      }
-      result.Result = uintptr(dataResult)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataCtxId uint64
+			err = decoder.DecodeUint64(&dataCtxId)
+			if err != nil {
+				return types.IoCancelArgs{}, err
+			}
+			result.CtxId = uintptr(dataCtxId)
+		case 1:
+			var dataIocb uint64
+			err = decoder.DecodeUint64(&dataIocb)
+			if err != nil {
+				return types.IoCancelArgs{}, err
+			}
+			result.Iocb = uintptr(dataIocb)
+		case 2:
+			var dataResult uint64
+			err = decoder.DecodeUint64(&dataResult)
+			if err != nil {
+				return types.IoCancelArgs{}, err
+			}
+			result.Result = uintptr(dataResult)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetThreadAreaArgs(decoder *Decoder) (types.GetThreadAreaArgs, error) {
-  var result types.GetThreadAreaArgs
-  var err error
+	var result types.GetThreadAreaArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetThreadAreaArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetThreadAreaArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetThreadAreaArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetThreadAreaArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataUInfo uint64
-      err = decoder.DecodeUint64(&dataUInfo)
-      if err != nil {
-        return types.GetThreadAreaArgs{}, err
-      }
-      result.UInfo = uintptr(dataUInfo)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataUInfo uint64
+			err = decoder.DecodeUint64(&dataUInfo)
+			if err != nil {
+				return types.GetThreadAreaArgs{}, err
+			}
+			result.UInfo = uintptr(dataUInfo)
+		}
+	}
+	return result, nil
 }
 
 func ParseLookupDcookieArgs(decoder *Decoder) (types.LookupDcookieArgs, error) {
-  var result types.LookupDcookieArgs
-  var err error
+	var result types.LookupDcookieArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LookupDcookieArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LookupDcookieArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LookupDcookieArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LookupDcookieArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Cookie)
-      if err != nil {
-        return types.LookupDcookieArgs{}, err
-      }
-    case 1:
-      result.Buffer, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LookupDcookieArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.LookupDcookieArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Cookie)
+			if err != nil {
+				return types.LookupDcookieArgs{}, err
+			}
+		case 1:
+			result.Buffer, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LookupDcookieArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.LookupDcookieArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEpollCreateArgs(decoder *Decoder) (types.EpollCreateArgs, error) {
-  var result types.EpollCreateArgs
-  var err error
+	var result types.EpollCreateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.EpollCreateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.EpollCreateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.EpollCreateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.EpollCreateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Size)
-      if err != nil {
-        return types.EpollCreateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Size)
+			if err != nil {
+				return types.EpollCreateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEpollCtlOldArgs(decoder *Decoder) (types.EpollCtlOldArgs, error) {
-  return types.EpollCtlOldArgs{}, nil
+	return types.EpollCtlOldArgs{}, nil
 }
 
 func ParseEpollWaitOldArgs(decoder *Decoder) (types.EpollWaitOldArgs, error) {
-  return types.EpollWaitOldArgs{}, nil
+	return types.EpollWaitOldArgs{}, nil
 }
 
 func ParseRemapFilePagesArgs(decoder *Decoder) (types.RemapFilePagesArgs, error) {
-  var result types.RemapFilePagesArgs
-  var err error
+	var result types.RemapFilePagesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RemapFilePagesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RemapFilePagesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RemapFilePagesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RemapFilePagesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.RemapFilePagesArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.RemapFilePagesArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Prot)
-      if err != nil {
-        return types.RemapFilePagesArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Pgoff)
-      if err != nil {
-        return types.RemapFilePagesArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.RemapFilePagesArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.RemapFilePagesArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.RemapFilePagesArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Prot)
+			if err != nil {
+				return types.RemapFilePagesArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Pgoff)
+			if err != nil {
+				return types.RemapFilePagesArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.RemapFilePagesArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetdents64Args(decoder *Decoder) (types.Getdents64Args, error) {
-  var result types.Getdents64Args
-  var err error
+	var result types.Getdents64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Getdents64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Getdents64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Getdents64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Getdents64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Fd)
-      if err != nil {
-        return types.Getdents64Args{}, err
-      }
-    case 1:
-      var dataDirp uint64
-      err = decoder.DecodeUint64(&dataDirp)
-      if err != nil {
-        return types.Getdents64Args{}, err
-      }
-      result.Dirp = uintptr(dataDirp)
-    case 2:
-      err = decoder.DecodeUint32(&result.Count)
-      if err != nil {
-        return types.Getdents64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Fd)
+			if err != nil {
+				return types.Getdents64Args{}, err
+			}
+		case 1:
+			var dataDirp uint64
+			err = decoder.DecodeUint64(&dataDirp)
+			if err != nil {
+				return types.Getdents64Args{}, err
+			}
+			result.Dirp = uintptr(dataDirp)
+		case 2:
+			err = decoder.DecodeUint32(&result.Count)
+			if err != nil {
+				return types.Getdents64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetTidAddressArgs(decoder *Decoder) (types.SetTidAddressArgs, error) {
-  var result types.SetTidAddressArgs
-  var err error
+	var result types.SetTidAddressArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetTidAddressArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetTidAddressArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetTidAddressArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetTidAddressArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataTidptr uint64
-      err = decoder.DecodeUint64(&dataTidptr)
-      if err != nil {
-        return types.SetTidAddressArgs{}, err
-      }
-      result.Tidptr = uintptr(dataTidptr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataTidptr uint64
+			err = decoder.DecodeUint64(&dataTidptr)
+			if err != nil {
+				return types.SetTidAddressArgs{}, err
+			}
+			result.Tidptr = uintptr(dataTidptr)
+		}
+	}
+	return result, nil
 }
 
 func ParseRestartSyscallArgs(decoder *Decoder) (types.RestartSyscallArgs, error) {
-  return types.RestartSyscallArgs{}, nil
+	return types.RestartSyscallArgs{}, nil
 }
 
 func ParseSemtimedopArgs(decoder *Decoder) (types.SemtimedopArgs, error) {
-  var result types.SemtimedopArgs
-  var err error
+	var result types.SemtimedopArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SemtimedopArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SemtimedopArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SemtimedopArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SemtimedopArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Semid)
-      if err != nil {
-        return types.SemtimedopArgs{}, err
-      }
-    case 1:
-      var dataSops uint64
-      err = decoder.DecodeUint64(&dataSops)
-      if err != nil {
-        return types.SemtimedopArgs{}, err
-      }
-      result.Sops = uintptr(dataSops)
-    case 2:
-      err = decoder.DecodeUint64(&result.Nsops)
-      if err != nil {
-        return types.SemtimedopArgs{}, err
-      }
-    case 3:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.SemtimedopArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Semid)
+			if err != nil {
+				return types.SemtimedopArgs{}, err
+			}
+		case 1:
+			var dataSops uint64
+			err = decoder.DecodeUint64(&dataSops)
+			if err != nil {
+				return types.SemtimedopArgs{}, err
+			}
+			result.Sops = uintptr(dataSops)
+		case 2:
+			err = decoder.DecodeUint64(&result.Nsops)
+			if err != nil {
+				return types.SemtimedopArgs{}, err
+			}
+		case 3:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.SemtimedopArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFadvise64Args(decoder *Decoder) (types.Fadvise64Args, error) {
-  var result types.Fadvise64Args
-  var err error
+	var result types.Fadvise64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Fadvise64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Fadvise64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Fadvise64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Fadvise64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Fadvise64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.Fadvise64Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.Fadvise64Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Advice)
-      if err != nil {
-        return types.Fadvise64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Fadvise64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.Fadvise64Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.Fadvise64Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Advice)
+			if err != nil {
+				return types.Fadvise64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerCreateArgs(decoder *Decoder) (types.TimerCreateArgs, error) {
-  var result types.TimerCreateArgs
-  var err error
+	var result types.TimerCreateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerCreateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerCreateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerCreateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerCreateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Clockid)
-      if err != nil {
-        return types.TimerCreateArgs{}, err
-      }
-    case 1:
-      var dataSevp uint64
-      err = decoder.DecodeUint64(&dataSevp)
-      if err != nil {
-        return types.TimerCreateArgs{}, err
-      }
-      result.Sevp = uintptr(dataSevp)
-    case 2:
-      var dataTimerId uint64
-      err = decoder.DecodeUint64(&dataTimerId)
-      if err != nil {
-        return types.TimerCreateArgs{}, err
-      }
-      result.TimerId = uintptr(dataTimerId)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Clockid)
+			if err != nil {
+				return types.TimerCreateArgs{}, err
+			}
+		case 1:
+			var dataSevp uint64
+			err = decoder.DecodeUint64(&dataSevp)
+			if err != nil {
+				return types.TimerCreateArgs{}, err
+			}
+			result.Sevp = uintptr(dataSevp)
+		case 2:
+			var dataTimerId uint64
+			err = decoder.DecodeUint64(&dataTimerId)
+			if err != nil {
+				return types.TimerCreateArgs{}, err
+			}
+			result.TimerId = uintptr(dataTimerId)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerSettimeArgs(decoder *Decoder) (types.TimerSettimeArgs, error) {
-  var result types.TimerSettimeArgs
-  var err error
+	var result types.TimerSettimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerSettimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerSettimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerSettimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerSettimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.TimerId)
-      if err != nil {
-        return types.TimerSettimeArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.TimerSettimeArgs{}, err
-      }
-    case 2:
-      var dataNewValue uint64
-      err = decoder.DecodeUint64(&dataNewValue)
-      if err != nil {
-        return types.TimerSettimeArgs{}, err
-      }
-      result.NewValue = uintptr(dataNewValue)
-    case 3:
-      var dataOldValue uint64
-      err = decoder.DecodeUint64(&dataOldValue)
-      if err != nil {
-        return types.TimerSettimeArgs{}, err
-      }
-      result.OldValue = uintptr(dataOldValue)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.TimerId)
+			if err != nil {
+				return types.TimerSettimeArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.TimerSettimeArgs{}, err
+			}
+		case 2:
+			var dataNewValue uint64
+			err = decoder.DecodeUint64(&dataNewValue)
+			if err != nil {
+				return types.TimerSettimeArgs{}, err
+			}
+			result.NewValue = uintptr(dataNewValue)
+		case 3:
+			var dataOldValue uint64
+			err = decoder.DecodeUint64(&dataOldValue)
+			if err != nil {
+				return types.TimerSettimeArgs{}, err
+			}
+			result.OldValue = uintptr(dataOldValue)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerGettimeArgs(decoder *Decoder) (types.TimerGettimeArgs, error) {
-  var result types.TimerGettimeArgs
-  var err error
+	var result types.TimerGettimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerGettimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerGettimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerGettimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerGettimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.TimerId)
-      if err != nil {
-        return types.TimerGettimeArgs{}, err
-      }
-    case 1:
-      var dataCurrValue uint64
-      err = decoder.DecodeUint64(&dataCurrValue)
-      if err != nil {
-        return types.TimerGettimeArgs{}, err
-      }
-      result.CurrValue = uintptr(dataCurrValue)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.TimerId)
+			if err != nil {
+				return types.TimerGettimeArgs{}, err
+			}
+		case 1:
+			var dataCurrValue uint64
+			err = decoder.DecodeUint64(&dataCurrValue)
+			if err != nil {
+				return types.TimerGettimeArgs{}, err
+			}
+			result.CurrValue = uintptr(dataCurrValue)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerGetoverrunArgs(decoder *Decoder) (types.TimerGetoverrunArgs, error) {
-  var result types.TimerGetoverrunArgs
-  var err error
+	var result types.TimerGetoverrunArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerGetoverrunArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerGetoverrunArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerGetoverrunArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerGetoverrunArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.TimerId)
-      if err != nil {
-        return types.TimerGetoverrunArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.TimerId)
+			if err != nil {
+				return types.TimerGetoverrunArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerDeleteArgs(decoder *Decoder) (types.TimerDeleteArgs, error) {
-  var result types.TimerDeleteArgs
-  var err error
+	var result types.TimerDeleteArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerDeleteArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerDeleteArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerDeleteArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerDeleteArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.TimerId)
-      if err != nil {
-        return types.TimerDeleteArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.TimerId)
+			if err != nil {
+				return types.TimerDeleteArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseClockSettimeArgs(decoder *Decoder) (types.ClockSettimeArgs, error) {
-  var result types.ClockSettimeArgs
-  var err error
+	var result types.ClockSettimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockSettimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockSettimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockSettimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockSettimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Clockid)
-      if err != nil {
-        return types.ClockSettimeArgs{}, err
-      }
-    case 1:
-      result.Tp, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.ClockSettimeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Clockid)
+			if err != nil {
+				return types.ClockSettimeArgs{}, err
+			}
+		case 1:
+			result.Tp, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.ClockSettimeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseClockGettimeArgs(decoder *Decoder) (types.ClockGettimeArgs, error) {
-  var result types.ClockGettimeArgs
-  var err error
+	var result types.ClockGettimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockGettimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockGettimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockGettimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockGettimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Clockid)
-      if err != nil {
-        return types.ClockGettimeArgs{}, err
-      }
-    case 1:
-      result.Tp, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.ClockGettimeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Clockid)
+			if err != nil {
+				return types.ClockGettimeArgs{}, err
+			}
+		case 1:
+			result.Tp, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.ClockGettimeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseClockGetresArgs(decoder *Decoder) (types.ClockGetresArgs, error) {
-  var result types.ClockGetresArgs
-  var err error
+	var result types.ClockGetresArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockGetresArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockGetresArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockGetresArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockGetresArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Clockid)
-      if err != nil {
-        return types.ClockGetresArgs{}, err
-      }
-    case 1:
-      result.Res, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.ClockGetresArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Clockid)
+			if err != nil {
+				return types.ClockGetresArgs{}, err
+			}
+		case 1:
+			result.Res, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.ClockGetresArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseClockNanosleepArgs(decoder *Decoder) (types.ClockNanosleepArgs, error) {
-  var result types.ClockNanosleepArgs
-  var err error
+	var result types.ClockNanosleepArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockNanosleepArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockNanosleepArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockNanosleepArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockNanosleepArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Clockid)
-      if err != nil {
-        return types.ClockNanosleepArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.ClockNanosleepArgs{}, err
-      }
-    case 2:
-      result.Request, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.ClockNanosleepArgs{}, err
-      }
-    case 3:
-      result.Remain, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.ClockNanosleepArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Clockid)
+			if err != nil {
+				return types.ClockNanosleepArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.ClockNanosleepArgs{}, err
+			}
+		case 2:
+			result.Request, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.ClockNanosleepArgs{}, err
+			}
+		case 3:
+			result.Remain, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.ClockNanosleepArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseExitGroupArgs(decoder *Decoder) (types.ExitGroupArgs, error) {
-  var result types.ExitGroupArgs
-  var err error
+	var result types.ExitGroupArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ExitGroupArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ExitGroupArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ExitGroupArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ExitGroupArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Status)
-      if err != nil {
-        return types.ExitGroupArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Status)
+			if err != nil {
+				return types.ExitGroupArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEpollWaitArgs(decoder *Decoder) (types.EpollWaitArgs, error) {
-  var result types.EpollWaitArgs
-  var err error
+	var result types.EpollWaitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.EpollWaitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.EpollWaitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.EpollWaitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.EpollWaitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Epfd)
-      if err != nil {
-        return types.EpollWaitArgs{}, err
-      }
-    case 1:
-      var dataEvents uint64
-      err = decoder.DecodeUint64(&dataEvents)
-      if err != nil {
-        return types.EpollWaitArgs{}, err
-      }
-      result.Events = uintptr(dataEvents)
-    case 2:
-      err = decoder.DecodeInt32(&result.Maxevents)
-      if err != nil {
-        return types.EpollWaitArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Timeout)
-      if err != nil {
-        return types.EpollWaitArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Epfd)
+			if err != nil {
+				return types.EpollWaitArgs{}, err
+			}
+		case 1:
+			var dataEvents uint64
+			err = decoder.DecodeUint64(&dataEvents)
+			if err != nil {
+				return types.EpollWaitArgs{}, err
+			}
+			result.Events = uintptr(dataEvents)
+		case 2:
+			err = decoder.DecodeInt32(&result.Maxevents)
+			if err != nil {
+				return types.EpollWaitArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Timeout)
+			if err != nil {
+				return types.EpollWaitArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEpollCtlArgs(decoder *Decoder) (types.EpollCtlArgs, error) {
-  var result types.EpollCtlArgs
-  var err error
+	var result types.EpollCtlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.EpollCtlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.EpollCtlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.EpollCtlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.EpollCtlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Epfd)
-      if err != nil {
-        return types.EpollCtlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Op)
-      if err != nil {
-        return types.EpollCtlArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.EpollCtlArgs{}, err
-      }
-    case 3:
-      var dataEvent uint64
-      err = decoder.DecodeUint64(&dataEvent)
-      if err != nil {
-        return types.EpollCtlArgs{}, err
-      }
-      result.Event = uintptr(dataEvent)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Epfd)
+			if err != nil {
+				return types.EpollCtlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Op)
+			if err != nil {
+				return types.EpollCtlArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.EpollCtlArgs{}, err
+			}
+		case 3:
+			var dataEvent uint64
+			err = decoder.DecodeUint64(&dataEvent)
+			if err != nil {
+				return types.EpollCtlArgs{}, err
+			}
+			result.Event = uintptr(dataEvent)
+		}
+	}
+	return result, nil
 }
 
 func ParseTgkillArgs(decoder *Decoder) (types.TgkillArgs, error) {
-  var result types.TgkillArgs
-  var err error
+	var result types.TgkillArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TgkillArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TgkillArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TgkillArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TgkillArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Tgid)
-      if err != nil {
-        return types.TgkillArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Tid)
-      if err != nil {
-        return types.TgkillArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.TgkillArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Tgid)
+			if err != nil {
+				return types.TgkillArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Tid)
+			if err != nil {
+				return types.TgkillArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.TgkillArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUtimesArgs(decoder *Decoder) (types.UtimesArgs, error) {
-  var result types.UtimesArgs
-  var err error
+	var result types.UtimesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UtimesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UtimesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UtimesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UtimesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Filename, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UtimesArgs{}, err
-      }
-    case 1:
-      var dataTimes uint64
-      err = decoder.DecodeUint64(&dataTimes)
-      if err != nil {
-        return types.UtimesArgs{}, err
-      }
-      result.Times = uintptr(dataTimes)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Filename, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UtimesArgs{}, err
+			}
+		case 1:
+			var dataTimes uint64
+			err = decoder.DecodeUint64(&dataTimes)
+			if err != nil {
+				return types.UtimesArgs{}, err
+			}
+			result.Times = uintptr(dataTimes)
+		}
+	}
+	return result, nil
 }
 
 func ParseVserverArgs(decoder *Decoder) (types.VserverArgs, error) {
-  return types.VserverArgs{}, nil
+	return types.VserverArgs{}, nil
 }
 
 func ParseMbindArgs(decoder *Decoder) (types.MbindArgs, error) {
-  var result types.MbindArgs
-  var err error
+	var result types.MbindArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MbindArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MbindArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MbindArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MbindArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MbindArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.MbindArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Mode)
-      if err != nil {
-        return types.MbindArgs{}, err
-      }
-    case 3:
-      var dataNodemask uint64
-      err = decoder.DecodeUint64(&dataNodemask)
-      if err != nil {
-        return types.MbindArgs{}, err
-      }
-      result.Nodemask = uintptr(dataNodemask)
-    case 4:
-      err = decoder.DecodeUint64(&result.Maxnode)
-      if err != nil {
-        return types.MbindArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.MbindArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MbindArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.MbindArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Mode)
+			if err != nil {
+				return types.MbindArgs{}, err
+			}
+		case 3:
+			var dataNodemask uint64
+			err = decoder.DecodeUint64(&dataNodemask)
+			if err != nil {
+				return types.MbindArgs{}, err
+			}
+			result.Nodemask = uintptr(dataNodemask)
+		case 4:
+			err = decoder.DecodeUint64(&result.Maxnode)
+			if err != nil {
+				return types.MbindArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.MbindArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetMempolicyArgs(decoder *Decoder) (types.SetMempolicyArgs, error) {
-  var result types.SetMempolicyArgs
-  var err error
+	var result types.SetMempolicyArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetMempolicyArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetMempolicyArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetMempolicyArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetMempolicyArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Mode)
-      if err != nil {
-        return types.SetMempolicyArgs{}, err
-      }
-    case 1:
-      var dataNodemask uint64
-      err = decoder.DecodeUint64(&dataNodemask)
-      if err != nil {
-        return types.SetMempolicyArgs{}, err
-      }
-      result.Nodemask = uintptr(dataNodemask)
-    case 2:
-      err = decoder.DecodeUint64(&result.Maxnode)
-      if err != nil {
-        return types.SetMempolicyArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Mode)
+			if err != nil {
+				return types.SetMempolicyArgs{}, err
+			}
+		case 1:
+			var dataNodemask uint64
+			err = decoder.DecodeUint64(&dataNodemask)
+			if err != nil {
+				return types.SetMempolicyArgs{}, err
+			}
+			result.Nodemask = uintptr(dataNodemask)
+		case 2:
+			err = decoder.DecodeUint64(&result.Maxnode)
+			if err != nil {
+				return types.SetMempolicyArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetMempolicyArgs(decoder *Decoder) (types.GetMempolicyArgs, error) {
-  var result types.GetMempolicyArgs
-  var err error
+	var result types.GetMempolicyArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetMempolicyArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetMempolicyArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetMempolicyArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetMempolicyArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataMode uint64
-      err = decoder.DecodeUint64(&dataMode)
-      if err != nil {
-        return types.GetMempolicyArgs{}, err
-      }
-      result.Mode = uintptr(dataMode)
-    case 1:
-      var dataNodemask uint64
-      err = decoder.DecodeUint64(&dataNodemask)
-      if err != nil {
-        return types.GetMempolicyArgs{}, err
-      }
-      result.Nodemask = uintptr(dataNodemask)
-    case 2:
-      err = decoder.DecodeUint64(&result.Maxnode)
-      if err != nil {
-        return types.GetMempolicyArgs{}, err
-      }
-    case 3:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.GetMempolicyArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 4:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.GetMempolicyArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataMode uint64
+			err = decoder.DecodeUint64(&dataMode)
+			if err != nil {
+				return types.GetMempolicyArgs{}, err
+			}
+			result.Mode = uintptr(dataMode)
+		case 1:
+			var dataNodemask uint64
+			err = decoder.DecodeUint64(&dataNodemask)
+			if err != nil {
+				return types.GetMempolicyArgs{}, err
+			}
+			result.Nodemask = uintptr(dataNodemask)
+		case 2:
+			err = decoder.DecodeUint64(&result.Maxnode)
+			if err != nil {
+				return types.GetMempolicyArgs{}, err
+			}
+		case 3:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.GetMempolicyArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 4:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.GetMempolicyArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMqOpenArgs(decoder *Decoder) (types.MqOpenArgs, error) {
-  var result types.MqOpenArgs
-  var err error
+	var result types.MqOpenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqOpenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqOpenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqOpenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqOpenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MqOpenArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Oflag)
-      if err != nil {
-        return types.MqOpenArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.MqOpenArgs{}, err
-      }
-    case 3:
-      var dataAttr uint64
-      err = decoder.DecodeUint64(&dataAttr)
-      if err != nil {
-        return types.MqOpenArgs{}, err
-      }
-      result.Attr = uintptr(dataAttr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MqOpenArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Oflag)
+			if err != nil {
+				return types.MqOpenArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.MqOpenArgs{}, err
+			}
+		case 3:
+			var dataAttr uint64
+			err = decoder.DecodeUint64(&dataAttr)
+			if err != nil {
+				return types.MqOpenArgs{}, err
+			}
+			result.Attr = uintptr(dataAttr)
+		}
+	}
+	return result, nil
 }
 
 func ParseMqUnlinkArgs(decoder *Decoder) (types.MqUnlinkArgs, error) {
-  var result types.MqUnlinkArgs
-  var err error
+	var result types.MqUnlinkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqUnlinkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqUnlinkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqUnlinkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqUnlinkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MqUnlinkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MqUnlinkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMqTimedsendArgs(decoder *Decoder) (types.MqTimedsendArgs, error) {
-  var result types.MqTimedsendArgs
-  var err error
+	var result types.MqTimedsendArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqTimedsendArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqTimedsendArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqTimedsendArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqTimedsendArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Mqdes)
-      if err != nil {
-        return types.MqTimedsendArgs{}, err
-      }
-    case 1:
-      result.MsgPtr, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MqTimedsendArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.MsgLen)
-      if err != nil {
-        return types.MqTimedsendArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.MsgPrio)
-      if err != nil {
-        return types.MqTimedsendArgs{}, err
-      }
-    case 4:
-      result.AbsTimeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.MqTimedsendArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Mqdes)
+			if err != nil {
+				return types.MqTimedsendArgs{}, err
+			}
+		case 1:
+			result.MsgPtr, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MqTimedsendArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.MsgLen)
+			if err != nil {
+				return types.MqTimedsendArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.MsgPrio)
+			if err != nil {
+				return types.MqTimedsendArgs{}, err
+			}
+		case 4:
+			result.AbsTimeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.MqTimedsendArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMqTimedreceiveArgs(decoder *Decoder) (types.MqTimedreceiveArgs, error) {
-  var result types.MqTimedreceiveArgs
-  var err error
+	var result types.MqTimedreceiveArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqTimedreceiveArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqTimedreceiveArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqTimedreceiveArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqTimedreceiveArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Mqdes)
-      if err != nil {
-        return types.MqTimedreceiveArgs{}, err
-      }
-    case 1:
-      result.MsgPtr, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MqTimedreceiveArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.MsgLen)
-      if err != nil {
-        return types.MqTimedreceiveArgs{}, err
-      }
-    case 3:
-      var dataMsgPrio uint64
-      err = decoder.DecodeUint64(&dataMsgPrio)
-      if err != nil {
-        return types.MqTimedreceiveArgs{}, err
-      }
-      result.MsgPrio = uintptr(dataMsgPrio)
-    case 4:
-      result.AbsTimeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.MqTimedreceiveArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Mqdes)
+			if err != nil {
+				return types.MqTimedreceiveArgs{}, err
+			}
+		case 1:
+			result.MsgPtr, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MqTimedreceiveArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.MsgLen)
+			if err != nil {
+				return types.MqTimedreceiveArgs{}, err
+			}
+		case 3:
+			var dataMsgPrio uint64
+			err = decoder.DecodeUint64(&dataMsgPrio)
+			if err != nil {
+				return types.MqTimedreceiveArgs{}, err
+			}
+			result.MsgPrio = uintptr(dataMsgPrio)
+		case 4:
+			result.AbsTimeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.MqTimedreceiveArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMqNotifyArgs(decoder *Decoder) (types.MqNotifyArgs, error) {
-  var result types.MqNotifyArgs
-  var err error
+	var result types.MqNotifyArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqNotifyArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqNotifyArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqNotifyArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqNotifyArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Mqdes)
-      if err != nil {
-        return types.MqNotifyArgs{}, err
-      }
-    case 1:
-      var dataSevp uint64
-      err = decoder.DecodeUint64(&dataSevp)
-      if err != nil {
-        return types.MqNotifyArgs{}, err
-      }
-      result.Sevp = uintptr(dataSevp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Mqdes)
+			if err != nil {
+				return types.MqNotifyArgs{}, err
+			}
+		case 1:
+			var dataSevp uint64
+			err = decoder.DecodeUint64(&dataSevp)
+			if err != nil {
+				return types.MqNotifyArgs{}, err
+			}
+			result.Sevp = uintptr(dataSevp)
+		}
+	}
+	return result, nil
 }
 
 func ParseMqGetsetattrArgs(decoder *Decoder) (types.MqGetsetattrArgs, error) {
-  var result types.MqGetsetattrArgs
-  var err error
+	var result types.MqGetsetattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqGetsetattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqGetsetattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqGetsetattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqGetsetattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Mqdes)
-      if err != nil {
-        return types.MqGetsetattrArgs{}, err
-      }
-    case 1:
-      var dataNewattr uint64
-      err = decoder.DecodeUint64(&dataNewattr)
-      if err != nil {
-        return types.MqGetsetattrArgs{}, err
-      }
-      result.Newattr = uintptr(dataNewattr)
-    case 2:
-      var dataOldattr uint64
-      err = decoder.DecodeUint64(&dataOldattr)
-      if err != nil {
-        return types.MqGetsetattrArgs{}, err
-      }
-      result.Oldattr = uintptr(dataOldattr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Mqdes)
+			if err != nil {
+				return types.MqGetsetattrArgs{}, err
+			}
+		case 1:
+			var dataNewattr uint64
+			err = decoder.DecodeUint64(&dataNewattr)
+			if err != nil {
+				return types.MqGetsetattrArgs{}, err
+			}
+			result.Newattr = uintptr(dataNewattr)
+		case 2:
+			var dataOldattr uint64
+			err = decoder.DecodeUint64(&dataOldattr)
+			if err != nil {
+				return types.MqGetsetattrArgs{}, err
+			}
+			result.Oldattr = uintptr(dataOldattr)
+		}
+	}
+	return result, nil
 }
 
 func ParseKexecLoadArgs(decoder *Decoder) (types.KexecLoadArgs, error) {
-  var result types.KexecLoadArgs
-  var err error
+	var result types.KexecLoadArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KexecLoadArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KexecLoadArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KexecLoadArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KexecLoadArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Entry)
-      if err != nil {
-        return types.KexecLoadArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.NrSegments)
-      if err != nil {
-        return types.KexecLoadArgs{}, err
-      }
-    case 2:
-      var dataSegments uint64
-      err = decoder.DecodeUint64(&dataSegments)
-      if err != nil {
-        return types.KexecLoadArgs{}, err
-      }
-      result.Segments = uintptr(dataSegments)
-    case 3:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.KexecLoadArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Entry)
+			if err != nil {
+				return types.KexecLoadArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.NrSegments)
+			if err != nil {
+				return types.KexecLoadArgs{}, err
+			}
+		case 2:
+			var dataSegments uint64
+			err = decoder.DecodeUint64(&dataSegments)
+			if err != nil {
+				return types.KexecLoadArgs{}, err
+			}
+			result.Segments = uintptr(dataSegments)
+		case 3:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.KexecLoadArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseWaitidArgs(decoder *Decoder) (types.WaitidArgs, error) {
-  var result types.WaitidArgs
-  var err error
+	var result types.WaitidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.WaitidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.WaitidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.WaitidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.WaitidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Idtype)
-      if err != nil {
-        return types.WaitidArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Id)
-      if err != nil {
-        return types.WaitidArgs{}, err
-      }
-    case 2:
-      var dataInfop uint64
-      err = decoder.DecodeUint64(&dataInfop)
-      if err != nil {
-        return types.WaitidArgs{}, err
-      }
-      result.Infop = uintptr(dataInfop)
-    case 3:
-      err = decoder.DecodeInt32(&result.Options)
-      if err != nil {
-        return types.WaitidArgs{}, err
-      }
-    case 4:
-      var dataRusage uint64
-      err = decoder.DecodeUint64(&dataRusage)
-      if err != nil {
-        return types.WaitidArgs{}, err
-      }
-      result.Rusage = uintptr(dataRusage)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Idtype)
+			if err != nil {
+				return types.WaitidArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Id)
+			if err != nil {
+				return types.WaitidArgs{}, err
+			}
+		case 2:
+			var dataInfop uint64
+			err = decoder.DecodeUint64(&dataInfop)
+			if err != nil {
+				return types.WaitidArgs{}, err
+			}
+			result.Infop = uintptr(dataInfop)
+		case 3:
+			err = decoder.DecodeInt32(&result.Options)
+			if err != nil {
+				return types.WaitidArgs{}, err
+			}
+		case 4:
+			var dataRusage uint64
+			err = decoder.DecodeUint64(&dataRusage)
+			if err != nil {
+				return types.WaitidArgs{}, err
+			}
+			result.Rusage = uintptr(dataRusage)
+		}
+	}
+	return result, nil
 }
 
 func ParseAddKeyArgs(decoder *Decoder) (types.AddKeyArgs, error) {
-  var result types.AddKeyArgs
-  var err error
+	var result types.AddKeyArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.AddKeyArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.AddKeyArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.AddKeyArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.AddKeyArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Type, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.AddKeyArgs{}, err
-      }
-    case 1:
-      result.Description, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.AddKeyArgs{}, err
-      }
-    case 2:
-      var dataPayload uint64
-      err = decoder.DecodeUint64(&dataPayload)
-      if err != nil {
-        return types.AddKeyArgs{}, err
-      }
-      result.Payload = uintptr(dataPayload)
-    case 3:
-      err = decoder.DecodeUint64(&result.Plen)
-      if err != nil {
-        return types.AddKeyArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Keyring)
-      if err != nil {
-        return types.AddKeyArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Type, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.AddKeyArgs{}, err
+			}
+		case 1:
+			result.Description, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.AddKeyArgs{}, err
+			}
+		case 2:
+			var dataPayload uint64
+			err = decoder.DecodeUint64(&dataPayload)
+			if err != nil {
+				return types.AddKeyArgs{}, err
+			}
+			result.Payload = uintptr(dataPayload)
+		case 3:
+			err = decoder.DecodeUint64(&result.Plen)
+			if err != nil {
+				return types.AddKeyArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Keyring)
+			if err != nil {
+				return types.AddKeyArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRequestKeyArgs(decoder *Decoder) (types.RequestKeyArgs, error) {
-  var result types.RequestKeyArgs
-  var err error
+	var result types.RequestKeyArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RequestKeyArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RequestKeyArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RequestKeyArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RequestKeyArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Type, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RequestKeyArgs{}, err
-      }
-    case 1:
-      result.Description, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RequestKeyArgs{}, err
-      }
-    case 2:
-      result.CalloutInfo, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RequestKeyArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.DestKeyring)
-      if err != nil {
-        return types.RequestKeyArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Type, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RequestKeyArgs{}, err
+			}
+		case 1:
+			result.Description, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RequestKeyArgs{}, err
+			}
+		case 2:
+			result.CalloutInfo, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RequestKeyArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.DestKeyring)
+			if err != nil {
+				return types.RequestKeyArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseKeyctlArgs(decoder *Decoder) (types.KeyctlArgs, error) {
-  var result types.KeyctlArgs
-  var err error
+	var result types.KeyctlArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KeyctlArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KeyctlArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KeyctlArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KeyctlArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Operation)
-      if err != nil {
-        return types.KeyctlArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Arg2)
-      if err != nil {
-        return types.KeyctlArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Arg3)
-      if err != nil {
-        return types.KeyctlArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Arg4)
-      if err != nil {
-        return types.KeyctlArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Arg5)
-      if err != nil {
-        return types.KeyctlArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Operation)
+			if err != nil {
+				return types.KeyctlArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Arg2)
+			if err != nil {
+				return types.KeyctlArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Arg3)
+			if err != nil {
+				return types.KeyctlArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Arg4)
+			if err != nil {
+				return types.KeyctlArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Arg5)
+			if err != nil {
+				return types.KeyctlArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseIoprioSetArgs(decoder *Decoder) (types.IoprioSetArgs, error) {
-  var result types.IoprioSetArgs
-  var err error
+	var result types.IoprioSetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoprioSetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoprioSetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoprioSetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoprioSetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Which)
-      if err != nil {
-        return types.IoprioSetArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Who)
-      if err != nil {
-        return types.IoprioSetArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Ioprio)
-      if err != nil {
-        return types.IoprioSetArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Which)
+			if err != nil {
+				return types.IoprioSetArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Who)
+			if err != nil {
+				return types.IoprioSetArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Ioprio)
+			if err != nil {
+				return types.IoprioSetArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseIoprioGetArgs(decoder *Decoder) (types.IoprioGetArgs, error) {
-  var result types.IoprioGetArgs
-  var err error
+	var result types.IoprioGetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoprioGetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoprioGetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoprioGetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoprioGetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Which)
-      if err != nil {
-        return types.IoprioGetArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Who)
-      if err != nil {
-        return types.IoprioGetArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Which)
+			if err != nil {
+				return types.IoprioGetArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Who)
+			if err != nil {
+				return types.IoprioGetArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseInotifyInitArgs(decoder *Decoder) (types.InotifyInitArgs, error) {
-  return types.InotifyInitArgs{}, nil
+	return types.InotifyInitArgs{}, nil
 }
 
 func ParseInotifyAddWatchArgs(decoder *Decoder) (types.InotifyAddWatchArgs, error) {
-  var result types.InotifyAddWatchArgs
-  var err error
+	var result types.InotifyAddWatchArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.InotifyAddWatchArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.InotifyAddWatchArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.InotifyAddWatchArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.InotifyAddWatchArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.InotifyAddWatchArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.InotifyAddWatchArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mask)
-      if err != nil {
-        return types.InotifyAddWatchArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.InotifyAddWatchArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.InotifyAddWatchArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mask)
+			if err != nil {
+				return types.InotifyAddWatchArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseInotifyRmWatchArgs(decoder *Decoder) (types.InotifyRmWatchArgs, error) {
-  var result types.InotifyRmWatchArgs
-  var err error
+	var result types.InotifyRmWatchArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.InotifyRmWatchArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.InotifyRmWatchArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.InotifyRmWatchArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.InotifyRmWatchArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.InotifyRmWatchArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Wd)
-      if err != nil {
-        return types.InotifyRmWatchArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.InotifyRmWatchArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Wd)
+			if err != nil {
+				return types.InotifyRmWatchArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMigratePagesArgs(decoder *Decoder) (types.MigratePagesArgs, error) {
-  var result types.MigratePagesArgs
-  var err error
+	var result types.MigratePagesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MigratePagesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MigratePagesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MigratePagesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MigratePagesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.MigratePagesArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Maxnode)
-      if err != nil {
-        return types.MigratePagesArgs{}, err
-      }
-    case 2:
-      var dataOldNodes uint64
-      err = decoder.DecodeUint64(&dataOldNodes)
-      if err != nil {
-        return types.MigratePagesArgs{}, err
-      }
-      result.OldNodes = uintptr(dataOldNodes)
-    case 3:
-      var dataNewNodes uint64
-      err = decoder.DecodeUint64(&dataNewNodes)
-      if err != nil {
-        return types.MigratePagesArgs{}, err
-      }
-      result.NewNodes = uintptr(dataNewNodes)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.MigratePagesArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Maxnode)
+			if err != nil {
+				return types.MigratePagesArgs{}, err
+			}
+		case 2:
+			var dataOldNodes uint64
+			err = decoder.DecodeUint64(&dataOldNodes)
+			if err != nil {
+				return types.MigratePagesArgs{}, err
+			}
+			result.OldNodes = uintptr(dataOldNodes)
+		case 3:
+			var dataNewNodes uint64
+			err = decoder.DecodeUint64(&dataNewNodes)
+			if err != nil {
+				return types.MigratePagesArgs{}, err
+			}
+			result.NewNodes = uintptr(dataNewNodes)
+		}
+	}
+	return result, nil
 }
 
 func ParseOpenatArgs(decoder *Decoder) (types.OpenatArgs, error) {
-  var result types.OpenatArgs
-  var err error
+	var result types.OpenatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OpenatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OpenatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OpenatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OpenatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.OpenatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.OpenatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.OpenatArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.OpenatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.OpenatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.OpenatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.OpenatArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.OpenatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMkdiratArgs(decoder *Decoder) (types.MkdiratArgs, error) {
-  var result types.MkdiratArgs
-  var err error
+	var result types.MkdiratArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MkdiratArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MkdiratArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MkdiratArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MkdiratArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.MkdiratArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MkdiratArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.MkdiratArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.MkdiratArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MkdiratArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.MkdiratArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMknodatArgs(decoder *Decoder) (types.MknodatArgs, error) {
-  var result types.MknodatArgs
-  var err error
+	var result types.MknodatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MknodatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MknodatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MknodatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MknodatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.MknodatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MknodatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.MknodatArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.MknodatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.MknodatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MknodatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.MknodatArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.MknodatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFchownatArgs(decoder *Decoder) (types.FchownatArgs, error) {
-  var result types.FchownatArgs
-  var err error
+	var result types.FchownatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FchownatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FchownatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FchownatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FchownatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.FchownatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FchownatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Owner)
-      if err != nil {
-        return types.FchownatArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Group)
-      if err != nil {
-        return types.FchownatArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.FchownatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.FchownatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FchownatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Owner)
+			if err != nil {
+				return types.FchownatArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Group)
+			if err != nil {
+				return types.FchownatArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.FchownatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFutimesatArgs(decoder *Decoder) (types.FutimesatArgs, error) {
-  var result types.FutimesatArgs
-  var err error
+	var result types.FutimesatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FutimesatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FutimesatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FutimesatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FutimesatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.FutimesatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FutimesatArgs{}, err
-      }
-    case 2:
-      var dataTimes uint64
-      err = decoder.DecodeUint64(&dataTimes)
-      if err != nil {
-        return types.FutimesatArgs{}, err
-      }
-      result.Times = uintptr(dataTimes)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.FutimesatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FutimesatArgs{}, err
+			}
+		case 2:
+			var dataTimes uint64
+			err = decoder.DecodeUint64(&dataTimes)
+			if err != nil {
+				return types.FutimesatArgs{}, err
+			}
+			result.Times = uintptr(dataTimes)
+		}
+	}
+	return result, nil
 }
 
 func ParseNewfstatatArgs(decoder *Decoder) (types.NewfstatatArgs, error) {
-  var result types.NewfstatatArgs
-  var err error
+	var result types.NewfstatatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NewfstatatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NewfstatatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NewfstatatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NewfstatatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.NewfstatatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NewfstatatArgs{}, err
-      }
-    case 2:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.NewfstatatArgs{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.NewfstatatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.NewfstatatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NewfstatatArgs{}, err
+			}
+		case 2:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.NewfstatatArgs{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.NewfstatatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUnlinkatArgs(decoder *Decoder) (types.UnlinkatArgs, error) {
-  var result types.UnlinkatArgs
-  var err error
+	var result types.UnlinkatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UnlinkatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UnlinkatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UnlinkatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UnlinkatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.UnlinkatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UnlinkatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.UnlinkatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.UnlinkatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UnlinkatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.UnlinkatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRenameatArgs(decoder *Decoder) (types.RenameatArgs, error) {
-  var result types.RenameatArgs
-  var err error
+	var result types.RenameatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RenameatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RenameatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RenameatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RenameatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Olddirfd)
-      if err != nil {
-        return types.RenameatArgs{}, err
-      }
-    case 1:
-      result.Oldpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RenameatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Newdirfd)
-      if err != nil {
-        return types.RenameatArgs{}, err
-      }
-    case 3:
-      result.Newpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RenameatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Olddirfd)
+			if err != nil {
+				return types.RenameatArgs{}, err
+			}
+		case 1:
+			result.Oldpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RenameatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Newdirfd)
+			if err != nil {
+				return types.RenameatArgs{}, err
+			}
+		case 3:
+			result.Newpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RenameatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLinkatArgs(decoder *Decoder) (types.LinkatArgs, error) {
-  var result types.LinkatArgs
-  var err error
+	var result types.LinkatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LinkatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LinkatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LinkatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LinkatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Olddirfd)
-      if err != nil {
-        return types.LinkatArgs{}, err
-      }
-    case 1:
-      result.Oldpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LinkatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Newdirfd)
-      if err != nil {
-        return types.LinkatArgs{}, err
-      }
-    case 3:
-      result.Newpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LinkatArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.LinkatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Olddirfd)
+			if err != nil {
+				return types.LinkatArgs{}, err
+			}
+		case 1:
+			result.Oldpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LinkatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Newdirfd)
+			if err != nil {
+				return types.LinkatArgs{}, err
+			}
+		case 3:
+			result.Newpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LinkatArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.LinkatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSymlinkatArgs(decoder *Decoder) (types.SymlinkatArgs, error) {
-  var result types.SymlinkatArgs
-  var err error
+	var result types.SymlinkatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SymlinkatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SymlinkatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SymlinkatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SymlinkatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Target, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SymlinkatArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Newdirfd)
-      if err != nil {
-        return types.SymlinkatArgs{}, err
-      }
-    case 2:
-      result.Linkpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SymlinkatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Target, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SymlinkatArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Newdirfd)
+			if err != nil {
+				return types.SymlinkatArgs{}, err
+			}
+		case 2:
+			result.Linkpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SymlinkatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseReadlinkatArgs(decoder *Decoder) (types.ReadlinkatArgs, error) {
-  var result types.ReadlinkatArgs
-  var err error
+	var result types.ReadlinkatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ReadlinkatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ReadlinkatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ReadlinkatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ReadlinkatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.ReadlinkatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ReadlinkatArgs{}, err
-      }
-    case 2:
-      result.Buf, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ReadlinkatArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Bufsiz)
-      if err != nil {
-        return types.ReadlinkatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.ReadlinkatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ReadlinkatArgs{}, err
+			}
+		case 2:
+			result.Buf, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ReadlinkatArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Bufsiz)
+			if err != nil {
+				return types.ReadlinkatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFchmodatArgs(decoder *Decoder) (types.FchmodatArgs, error) {
-  var result types.FchmodatArgs
-  var err error
+	var result types.FchmodatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FchmodatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FchmodatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FchmodatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FchmodatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.FchmodatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FchmodatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.FchmodatArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.FchmodatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.FchmodatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FchmodatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.FchmodatArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.FchmodatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFaccessatArgs(decoder *Decoder) (types.FaccessatArgs, error) {
-  var result types.FaccessatArgs
-  var err error
+	var result types.FaccessatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FaccessatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FaccessatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FaccessatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FaccessatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.FaccessatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FaccessatArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Mode)
-      if err != nil {
-        return types.FaccessatArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.FaccessatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.FaccessatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FaccessatArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Mode)
+			if err != nil {
+				return types.FaccessatArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.FaccessatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePselect6Args(decoder *Decoder) (types.Pselect6Args, error) {
-  var result types.Pselect6Args
-  var err error
+	var result types.Pselect6Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Pselect6Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Pselect6Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Pselect6Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Pselect6Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Nfds)
-      if err != nil {
-        return types.Pselect6Args{}, err
-      }
-    case 1:
-      var dataReadfds uint64
-      err = decoder.DecodeUint64(&dataReadfds)
-      if err != nil {
-        return types.Pselect6Args{}, err
-      }
-      result.Readfds = uintptr(dataReadfds)
-    case 2:
-      var dataWritefds uint64
-      err = decoder.DecodeUint64(&dataWritefds)
-      if err != nil {
-        return types.Pselect6Args{}, err
-      }
-      result.Writefds = uintptr(dataWritefds)
-    case 3:
-      var dataExceptfds uint64
-      err = decoder.DecodeUint64(&dataExceptfds)
-      if err != nil {
-        return types.Pselect6Args{}, err
-      }
-      result.Exceptfds = uintptr(dataExceptfds)
-    case 4:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.Pselect6Args{}, err
-      }
-    case 5:
-      var dataSigmask uint64
-      err = decoder.DecodeUint64(&dataSigmask)
-      if err != nil {
-        return types.Pselect6Args{}, err
-      }
-      result.Sigmask = uintptr(dataSigmask)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Nfds)
+			if err != nil {
+				return types.Pselect6Args{}, err
+			}
+		case 1:
+			var dataReadfds uint64
+			err = decoder.DecodeUint64(&dataReadfds)
+			if err != nil {
+				return types.Pselect6Args{}, err
+			}
+			result.Readfds = uintptr(dataReadfds)
+		case 2:
+			var dataWritefds uint64
+			err = decoder.DecodeUint64(&dataWritefds)
+			if err != nil {
+				return types.Pselect6Args{}, err
+			}
+			result.Writefds = uintptr(dataWritefds)
+		case 3:
+			var dataExceptfds uint64
+			err = decoder.DecodeUint64(&dataExceptfds)
+			if err != nil {
+				return types.Pselect6Args{}, err
+			}
+			result.Exceptfds = uintptr(dataExceptfds)
+		case 4:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.Pselect6Args{}, err
+			}
+		case 5:
+			var dataSigmask uint64
+			err = decoder.DecodeUint64(&dataSigmask)
+			if err != nil {
+				return types.Pselect6Args{}, err
+			}
+			result.Sigmask = uintptr(dataSigmask)
+		}
+	}
+	return result, nil
 }
 
 func ParsePpollArgs(decoder *Decoder) (types.PpollArgs, error) {
-  var result types.PpollArgs
-  var err error
+	var result types.PpollArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PpollArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PpollArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PpollArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PpollArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataFds uint64
-      err = decoder.DecodeUint64(&dataFds)
-      if err != nil {
-        return types.PpollArgs{}, err
-      }
-      result.Fds = uintptr(dataFds)
-    case 1:
-      err = decoder.DecodeUint32(&result.Nfds)
-      if err != nil {
-        return types.PpollArgs{}, err
-      }
-    case 2:
-      result.TmoP, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.PpollArgs{}, err
-      }
-    case 3:
-      var dataSigmask uint64
-      err = decoder.DecodeUint64(&dataSigmask)
-      if err != nil {
-        return types.PpollArgs{}, err
-      }
-      result.Sigmask = uintptr(dataSigmask)
-    case 4:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.PpollArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataFds uint64
+			err = decoder.DecodeUint64(&dataFds)
+			if err != nil {
+				return types.PpollArgs{}, err
+			}
+			result.Fds = uintptr(dataFds)
+		case 1:
+			err = decoder.DecodeUint32(&result.Nfds)
+			if err != nil {
+				return types.PpollArgs{}, err
+			}
+		case 2:
+			result.TmoP, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.PpollArgs{}, err
+			}
+		case 3:
+			var dataSigmask uint64
+			err = decoder.DecodeUint64(&dataSigmask)
+			if err != nil {
+				return types.PpollArgs{}, err
+			}
+			result.Sigmask = uintptr(dataSigmask)
+		case 4:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.PpollArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUnshareArgs(decoder *Decoder) (types.UnshareArgs, error) {
-  var result types.UnshareArgs
-  var err error
+	var result types.UnshareArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UnshareArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UnshareArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UnshareArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UnshareArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.UnshareArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.UnshareArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetRobustListArgs(decoder *Decoder) (types.SetRobustListArgs, error) {
-  var result types.SetRobustListArgs
-  var err error
+	var result types.SetRobustListArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetRobustListArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetRobustListArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetRobustListArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetRobustListArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataHead uint64
-      err = decoder.DecodeUint64(&dataHead)
-      if err != nil {
-        return types.SetRobustListArgs{}, err
-      }
-      result.Head = uintptr(dataHead)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.SetRobustListArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataHead uint64
+			err = decoder.DecodeUint64(&dataHead)
+			if err != nil {
+				return types.SetRobustListArgs{}, err
+			}
+			result.Head = uintptr(dataHead)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.SetRobustListArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetRobustListArgs(decoder *Decoder) (types.GetRobustListArgs, error) {
-  var result types.GetRobustListArgs
-  var err error
+	var result types.GetRobustListArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetRobustListArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetRobustListArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetRobustListArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetRobustListArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.GetRobustListArgs{}, err
-      }
-    case 1:
-      var dataHeadPtr uint64
-      err = decoder.DecodeUint64(&dataHeadPtr)
-      if err != nil {
-        return types.GetRobustListArgs{}, err
-      }
-      result.HeadPtr = uintptr(dataHeadPtr)
-    case 2:
-      var dataLenPtr uint64
-      err = decoder.DecodeUint64(&dataLenPtr)
-      if err != nil {
-        return types.GetRobustListArgs{}, err
-      }
-      result.LenPtr = uintptr(dataLenPtr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.GetRobustListArgs{}, err
+			}
+		case 1:
+			var dataHeadPtr uint64
+			err = decoder.DecodeUint64(&dataHeadPtr)
+			if err != nil {
+				return types.GetRobustListArgs{}, err
+			}
+			result.HeadPtr = uintptr(dataHeadPtr)
+		case 2:
+			var dataLenPtr uint64
+			err = decoder.DecodeUint64(&dataLenPtr)
+			if err != nil {
+				return types.GetRobustListArgs{}, err
+			}
+			result.LenPtr = uintptr(dataLenPtr)
+		}
+	}
+	return result, nil
 }
 
 func ParseSpliceArgs(decoder *Decoder) (types.SpliceArgs, error) {
-  var result types.SpliceArgs
-  var err error
+	var result types.SpliceArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SpliceArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SpliceArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SpliceArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SpliceArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.FdIn)
-      if err != nil {
-        return types.SpliceArgs{}, err
-      }
-    case 1:
-      var dataOffIn uint64
-      err = decoder.DecodeUint64(&dataOffIn)
-      if err != nil {
-        return types.SpliceArgs{}, err
-      }
-      result.OffIn = uintptr(dataOffIn)
-    case 2:
-      err = decoder.DecodeInt32(&result.FdOut)
-      if err != nil {
-        return types.SpliceArgs{}, err
-      }
-    case 3:
-      var dataOffOut uint64
-      err = decoder.DecodeUint64(&dataOffOut)
-      if err != nil {
-        return types.SpliceArgs{}, err
-      }
-      result.OffOut = uintptr(dataOffOut)
-    case 4:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.SpliceArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.SpliceArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.FdIn)
+			if err != nil {
+				return types.SpliceArgs{}, err
+			}
+		case 1:
+			var dataOffIn uint64
+			err = decoder.DecodeUint64(&dataOffIn)
+			if err != nil {
+				return types.SpliceArgs{}, err
+			}
+			result.OffIn = uintptr(dataOffIn)
+		case 2:
+			err = decoder.DecodeInt32(&result.FdOut)
+			if err != nil {
+				return types.SpliceArgs{}, err
+			}
+		case 3:
+			var dataOffOut uint64
+			err = decoder.DecodeUint64(&dataOffOut)
+			if err != nil {
+				return types.SpliceArgs{}, err
+			}
+			result.OffOut = uintptr(dataOffOut)
+		case 4:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.SpliceArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.SpliceArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTeeArgs(decoder *Decoder) (types.TeeArgs, error) {
-  var result types.TeeArgs
-  var err error
+	var result types.TeeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TeeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TeeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TeeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TeeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.FdIn)
-      if err != nil {
-        return types.TeeArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.FdOut)
-      if err != nil {
-        return types.TeeArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.TeeArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.TeeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.FdIn)
+			if err != nil {
+				return types.TeeArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.FdOut)
+			if err != nil {
+				return types.TeeArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.TeeArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.TeeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSyncFileRangeArgs(decoder *Decoder) (types.SyncFileRangeArgs, error) {
-  var result types.SyncFileRangeArgs
-  var err error
+	var result types.SyncFileRangeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SyncFileRangeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SyncFileRangeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SyncFileRangeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SyncFileRangeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.SyncFileRangeArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.SyncFileRangeArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Nbytes)
-      if err != nil {
-        return types.SyncFileRangeArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.SyncFileRangeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.SyncFileRangeArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.SyncFileRangeArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Nbytes)
+			if err != nil {
+				return types.SyncFileRangeArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.SyncFileRangeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseVmspliceArgs(decoder *Decoder) (types.VmspliceArgs, error) {
-  var result types.VmspliceArgs
-  var err error
+	var result types.VmspliceArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.VmspliceArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.VmspliceArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.VmspliceArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.VmspliceArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.VmspliceArgs{}, err
-      }
-    case 1:
-      var dataIov uint64
-      err = decoder.DecodeUint64(&dataIov)
-      if err != nil {
-        return types.VmspliceArgs{}, err
-      }
-      result.Iov = uintptr(dataIov)
-    case 2:
-      err = decoder.DecodeUint64(&result.NrSegs)
-      if err != nil {
-        return types.VmspliceArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.VmspliceArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.VmspliceArgs{}, err
+			}
+		case 1:
+			var dataIov uint64
+			err = decoder.DecodeUint64(&dataIov)
+			if err != nil {
+				return types.VmspliceArgs{}, err
+			}
+			result.Iov = uintptr(dataIov)
+		case 2:
+			err = decoder.DecodeUint64(&result.NrSegs)
+			if err != nil {
+				return types.VmspliceArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.VmspliceArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMovePagesArgs(decoder *Decoder) (types.MovePagesArgs, error) {
-  var result types.MovePagesArgs
-  var err error
+	var result types.MovePagesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MovePagesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MovePagesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MovePagesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MovePagesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.MovePagesArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.MovePagesArgs{}, err
-      }
-    case 2:
-      var dataPages uint64
-      err = decoder.DecodeUint64(&dataPages)
-      if err != nil {
-        return types.MovePagesArgs{}, err
-      }
-      result.Pages = uintptr(dataPages)
-    case 3:
-      var dataNodes uint64
-      err = decoder.DecodeUint64(&dataNodes)
-      if err != nil {
-        return types.MovePagesArgs{}, err
-      }
-      result.Nodes = uintptr(dataNodes)
-    case 4:
-      var dataStatus uint64
-      err = decoder.DecodeUint64(&dataStatus)
-      if err != nil {
-        return types.MovePagesArgs{}, err
-      }
-      result.Status = uintptr(dataStatus)
-    case 5:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.MovePagesArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.MovePagesArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.MovePagesArgs{}, err
+			}
+		case 2:
+			var dataPages uint64
+			err = decoder.DecodeUint64(&dataPages)
+			if err != nil {
+				return types.MovePagesArgs{}, err
+			}
+			result.Pages = uintptr(dataPages)
+		case 3:
+			var dataNodes uint64
+			err = decoder.DecodeUint64(&dataNodes)
+			if err != nil {
+				return types.MovePagesArgs{}, err
+			}
+			result.Nodes = uintptr(dataNodes)
+		case 4:
+			var dataStatus uint64
+			err = decoder.DecodeUint64(&dataStatus)
+			if err != nil {
+				return types.MovePagesArgs{}, err
+			}
+			result.Status = uintptr(dataStatus)
+		case 5:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.MovePagesArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUtimensatArgs(decoder *Decoder) (types.UtimensatArgs, error) {
-  var result types.UtimensatArgs
-  var err error
+	var result types.UtimensatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UtimensatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UtimensatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UtimensatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UtimensatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.UtimensatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UtimensatArgs{}, err
-      }
-    case 2:
-      result.Times, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.UtimensatArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.UtimensatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.UtimensatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UtimensatArgs{}, err
+			}
+		case 2:
+			result.Times, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.UtimensatArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.UtimensatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEpollPwaitArgs(decoder *Decoder) (types.EpollPwaitArgs, error) {
-  var result types.EpollPwaitArgs
-  var err error
+	var result types.EpollPwaitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.EpollPwaitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.EpollPwaitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.EpollPwaitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.EpollPwaitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Epfd)
-      if err != nil {
-        return types.EpollPwaitArgs{}, err
-      }
-    case 1:
-      var dataEvents uint64
-      err = decoder.DecodeUint64(&dataEvents)
-      if err != nil {
-        return types.EpollPwaitArgs{}, err
-      }
-      result.Events = uintptr(dataEvents)
-    case 2:
-      err = decoder.DecodeInt32(&result.Maxevents)
-      if err != nil {
-        return types.EpollPwaitArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Timeout)
-      if err != nil {
-        return types.EpollPwaitArgs{}, err
-      }
-    case 4:
-      var dataSigmask uint64
-      err = decoder.DecodeUint64(&dataSigmask)
-      if err != nil {
-        return types.EpollPwaitArgs{}, err
-      }
-      result.Sigmask = uintptr(dataSigmask)
-    case 5:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.EpollPwaitArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Epfd)
+			if err != nil {
+				return types.EpollPwaitArgs{}, err
+			}
+		case 1:
+			var dataEvents uint64
+			err = decoder.DecodeUint64(&dataEvents)
+			if err != nil {
+				return types.EpollPwaitArgs{}, err
+			}
+			result.Events = uintptr(dataEvents)
+		case 2:
+			err = decoder.DecodeInt32(&result.Maxevents)
+			if err != nil {
+				return types.EpollPwaitArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Timeout)
+			if err != nil {
+				return types.EpollPwaitArgs{}, err
+			}
+		case 4:
+			var dataSigmask uint64
+			err = decoder.DecodeUint64(&dataSigmask)
+			if err != nil {
+				return types.EpollPwaitArgs{}, err
+			}
+			result.Sigmask = uintptr(dataSigmask)
+		case 5:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.EpollPwaitArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSignalfdArgs(decoder *Decoder) (types.SignalfdArgs, error) {
-  var result types.SignalfdArgs
-  var err error
+	var result types.SignalfdArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SignalfdArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SignalfdArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SignalfdArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SignalfdArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.SignalfdArgs{}, err
-      }
-    case 1:
-      var dataMask uint64
-      err = decoder.DecodeUint64(&dataMask)
-      if err != nil {
-        return types.SignalfdArgs{}, err
-      }
-      result.Mask = uintptr(dataMask)
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SignalfdArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.SignalfdArgs{}, err
+			}
+		case 1:
+			var dataMask uint64
+			err = decoder.DecodeUint64(&dataMask)
+			if err != nil {
+				return types.SignalfdArgs{}, err
+			}
+			result.Mask = uintptr(dataMask)
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SignalfdArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerfdCreateArgs(decoder *Decoder) (types.TimerfdCreateArgs, error) {
-  var result types.TimerfdCreateArgs
-  var err error
+	var result types.TimerfdCreateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerfdCreateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerfdCreateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerfdCreateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerfdCreateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Clockid)
-      if err != nil {
-        return types.TimerfdCreateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.TimerfdCreateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Clockid)
+			if err != nil {
+				return types.TimerfdCreateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.TimerfdCreateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEventfdArgs(decoder *Decoder) (types.EventfdArgs, error) {
-  var result types.EventfdArgs
-  var err error
+	var result types.EventfdArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.EventfdArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.EventfdArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.EventfdArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.EventfdArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Initval)
-      if err != nil {
-        return types.EventfdArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.EventfdArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Initval)
+			if err != nil {
+				return types.EventfdArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.EventfdArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFallocateArgs(decoder *Decoder) (types.FallocateArgs, error) {
-  var result types.FallocateArgs
-  var err error
+	var result types.FallocateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FallocateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FallocateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FallocateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FallocateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FallocateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Mode)
-      if err != nil {
-        return types.FallocateArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.FallocateArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.FallocateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FallocateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Mode)
+			if err != nil {
+				return types.FallocateArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.FallocateArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.FallocateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerfdSettimeArgs(decoder *Decoder) (types.TimerfdSettimeArgs, error) {
-  var result types.TimerfdSettimeArgs
-  var err error
+	var result types.TimerfdSettimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerfdSettimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerfdSettimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerfdSettimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerfdSettimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.TimerfdSettimeArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.TimerfdSettimeArgs{}, err
-      }
-    case 2:
-      var dataNewValue uint64
-      err = decoder.DecodeUint64(&dataNewValue)
-      if err != nil {
-        return types.TimerfdSettimeArgs{}, err
-      }
-      result.NewValue = uintptr(dataNewValue)
-    case 3:
-      var dataOldValue uint64
-      err = decoder.DecodeUint64(&dataOldValue)
-      if err != nil {
-        return types.TimerfdSettimeArgs{}, err
-      }
-      result.OldValue = uintptr(dataOldValue)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.TimerfdSettimeArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.TimerfdSettimeArgs{}, err
+			}
+		case 2:
+			var dataNewValue uint64
+			err = decoder.DecodeUint64(&dataNewValue)
+			if err != nil {
+				return types.TimerfdSettimeArgs{}, err
+			}
+			result.NewValue = uintptr(dataNewValue)
+		case 3:
+			var dataOldValue uint64
+			err = decoder.DecodeUint64(&dataOldValue)
+			if err != nil {
+				return types.TimerfdSettimeArgs{}, err
+			}
+			result.OldValue = uintptr(dataOldValue)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerfdGettimeArgs(decoder *Decoder) (types.TimerfdGettimeArgs, error) {
-  var result types.TimerfdGettimeArgs
-  var err error
+	var result types.TimerfdGettimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerfdGettimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerfdGettimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerfdGettimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerfdGettimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.TimerfdGettimeArgs{}, err
-      }
-    case 1:
-      var dataCurrValue uint64
-      err = decoder.DecodeUint64(&dataCurrValue)
-      if err != nil {
-        return types.TimerfdGettimeArgs{}, err
-      }
-      result.CurrValue = uintptr(dataCurrValue)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.TimerfdGettimeArgs{}, err
+			}
+		case 1:
+			var dataCurrValue uint64
+			err = decoder.DecodeUint64(&dataCurrValue)
+			if err != nil {
+				return types.TimerfdGettimeArgs{}, err
+			}
+			result.CurrValue = uintptr(dataCurrValue)
+		}
+	}
+	return result, nil
 }
 
 func ParseAccept4Args(decoder *Decoder) (types.Accept4Args, error) {
-  var result types.Accept4Args
-  var err error
+	var result types.Accept4Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Accept4Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Accept4Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Accept4Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Accept4Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.Accept4Args{}, err
-      }
-    case 1:
-      result.Addr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.Accept4Args{}, err
-      }
-    case 2:
-      var dataAddrlen uint64
-      err = decoder.DecodeUint64(&dataAddrlen)
-      if err != nil {
-        return types.Accept4Args{}, err
-      }
-      result.Addrlen = uintptr(dataAddrlen)
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Accept4Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.Accept4Args{}, err
+			}
+		case 1:
+			result.Addr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.Accept4Args{}, err
+			}
+		case 2:
+			var dataAddrlen uint64
+			err = decoder.DecodeUint64(&dataAddrlen)
+			if err != nil {
+				return types.Accept4Args{}, err
+			}
+			result.Addrlen = uintptr(dataAddrlen)
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Accept4Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSignalfd4Args(decoder *Decoder) (types.Signalfd4Args, error) {
-  var result types.Signalfd4Args
-  var err error
+	var result types.Signalfd4Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Signalfd4Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Signalfd4Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Signalfd4Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Signalfd4Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Signalfd4Args{}, err
-      }
-    case 1:
-      var dataMask uint64
-      err = decoder.DecodeUint64(&dataMask)
-      if err != nil {
-        return types.Signalfd4Args{}, err
-      }
-      result.Mask = uintptr(dataMask)
-    case 2:
-      err = decoder.DecodeUint64(&result.Sizemask)
-      if err != nil {
-        return types.Signalfd4Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Signalfd4Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Signalfd4Args{}, err
+			}
+		case 1:
+			var dataMask uint64
+			err = decoder.DecodeUint64(&dataMask)
+			if err != nil {
+				return types.Signalfd4Args{}, err
+			}
+			result.Mask = uintptr(dataMask)
+		case 2:
+			err = decoder.DecodeUint64(&result.Sizemask)
+			if err != nil {
+				return types.Signalfd4Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Signalfd4Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEventfd2Args(decoder *Decoder) (types.Eventfd2Args, error) {
-  var result types.Eventfd2Args
-  var err error
+	var result types.Eventfd2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Eventfd2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Eventfd2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Eventfd2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Eventfd2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Initval)
-      if err != nil {
-        return types.Eventfd2Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Eventfd2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Initval)
+			if err != nil {
+				return types.Eventfd2Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Eventfd2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEpollCreate1Args(decoder *Decoder) (types.EpollCreate1Args, error) {
-  var result types.EpollCreate1Args
-  var err error
+	var result types.EpollCreate1Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.EpollCreate1Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.EpollCreate1Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.EpollCreate1Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.EpollCreate1Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.EpollCreate1Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.EpollCreate1Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDup3Args(decoder *Decoder) (types.Dup3Args, error) {
-  var result types.Dup3Args
-  var err error
+	var result types.Dup3Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Dup3Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Dup3Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Dup3Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Dup3Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Oldfd)
-      if err != nil {
-        return types.Dup3Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Newfd)
-      if err != nil {
-        return types.Dup3Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Dup3Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Oldfd)
+			if err != nil {
+				return types.Dup3Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Newfd)
+			if err != nil {
+				return types.Dup3Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Dup3Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePipe2Args(decoder *Decoder) (types.Pipe2Args, error) {
-  var result types.Pipe2Args
-  var err error
+	var result types.Pipe2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Pipe2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Pipe2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Pipe2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Pipe2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeIntArray(result.Pipefd[:], 2)
-      if err != nil {
-        return types.Pipe2Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Pipe2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeIntArray(result.Pipefd[:], 2)
+			if err != nil {
+				return types.Pipe2Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Pipe2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseInotifyInit1Args(decoder *Decoder) (types.InotifyInit1Args, error) {
-  var result types.InotifyInit1Args
-  var err error
+	var result types.InotifyInit1Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.InotifyInit1Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.InotifyInit1Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.InotifyInit1Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.InotifyInit1Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.InotifyInit1Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.InotifyInit1Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePreadvArgs(decoder *Decoder) (types.PreadvArgs, error) {
-  var result types.PreadvArgs
-  var err error
+	var result types.PreadvArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PreadvArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PreadvArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PreadvArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PreadvArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.PreadvArgs{}, err
-      }
-    case 1:
-      var dataIov uint64
-      err = decoder.DecodeUint64(&dataIov)
-      if err != nil {
-        return types.PreadvArgs{}, err
-      }
-      result.Iov = uintptr(dataIov)
-    case 2:
-      err = decoder.DecodeUint64(&result.Iovcnt)
-      if err != nil {
-        return types.PreadvArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.PosL)
-      if err != nil {
-        return types.PreadvArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.PosH)
-      if err != nil {
-        return types.PreadvArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.PreadvArgs{}, err
+			}
+		case 1:
+			var dataIov uint64
+			err = decoder.DecodeUint64(&dataIov)
+			if err != nil {
+				return types.PreadvArgs{}, err
+			}
+			result.Iov = uintptr(dataIov)
+		case 2:
+			err = decoder.DecodeUint64(&result.Iovcnt)
+			if err != nil {
+				return types.PreadvArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.PosL)
+			if err != nil {
+				return types.PreadvArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.PosH)
+			if err != nil {
+				return types.PreadvArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePwritevArgs(decoder *Decoder) (types.PwritevArgs, error) {
-  var result types.PwritevArgs
-  var err error
+	var result types.PwritevArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PwritevArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PwritevArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PwritevArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PwritevArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.PwritevArgs{}, err
-      }
-    case 1:
-      var dataIov uint64
-      err = decoder.DecodeUint64(&dataIov)
-      if err != nil {
-        return types.PwritevArgs{}, err
-      }
-      result.Iov = uintptr(dataIov)
-    case 2:
-      err = decoder.DecodeUint64(&result.Iovcnt)
-      if err != nil {
-        return types.PwritevArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.PosL)
-      if err != nil {
-        return types.PwritevArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.PosH)
-      if err != nil {
-        return types.PwritevArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.PwritevArgs{}, err
+			}
+		case 1:
+			var dataIov uint64
+			err = decoder.DecodeUint64(&dataIov)
+			if err != nil {
+				return types.PwritevArgs{}, err
+			}
+			result.Iov = uintptr(dataIov)
+		case 2:
+			err = decoder.DecodeUint64(&result.Iovcnt)
+			if err != nil {
+				return types.PwritevArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.PosL)
+			if err != nil {
+				return types.PwritevArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.PosH)
+			if err != nil {
+				return types.PwritevArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRtTgsigqueueinfoArgs(decoder *Decoder) (types.RtTgsigqueueinfoArgs, error) {
-  var result types.RtTgsigqueueinfoArgs
-  var err error
+	var result types.RtTgsigqueueinfoArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtTgsigqueueinfoArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtTgsigqueueinfoArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtTgsigqueueinfoArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtTgsigqueueinfoArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Tgid)
-      if err != nil {
-        return types.RtTgsigqueueinfoArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Tid)
-      if err != nil {
-        return types.RtTgsigqueueinfoArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.RtTgsigqueueinfoArgs{}, err
-      }
-    case 3:
-      var dataInfo uint64
-      err = decoder.DecodeUint64(&dataInfo)
-      if err != nil {
-        return types.RtTgsigqueueinfoArgs{}, err
-      }
-      result.Info = uintptr(dataInfo)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Tgid)
+			if err != nil {
+				return types.RtTgsigqueueinfoArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Tid)
+			if err != nil {
+				return types.RtTgsigqueueinfoArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.RtTgsigqueueinfoArgs{}, err
+			}
+		case 3:
+			var dataInfo uint64
+			err = decoder.DecodeUint64(&dataInfo)
+			if err != nil {
+				return types.RtTgsigqueueinfoArgs{}, err
+			}
+			result.Info = uintptr(dataInfo)
+		}
+	}
+	return result, nil
 }
 
 func ParsePerfEventOpenArgs(decoder *Decoder) (types.PerfEventOpenArgs, error) {
-  var result types.PerfEventOpenArgs
-  var err error
+	var result types.PerfEventOpenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PerfEventOpenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PerfEventOpenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PerfEventOpenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PerfEventOpenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAttr uint64
-      err = decoder.DecodeUint64(&dataAttr)
-      if err != nil {
-        return types.PerfEventOpenArgs{}, err
-      }
-      result.Attr = uintptr(dataAttr)
-    case 1:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.PerfEventOpenArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Cpu)
-      if err != nil {
-        return types.PerfEventOpenArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.GroupFd)
-      if err != nil {
-        return types.PerfEventOpenArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.PerfEventOpenArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAttr uint64
+			err = decoder.DecodeUint64(&dataAttr)
+			if err != nil {
+				return types.PerfEventOpenArgs{}, err
+			}
+			result.Attr = uintptr(dataAttr)
+		case 1:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.PerfEventOpenArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Cpu)
+			if err != nil {
+				return types.PerfEventOpenArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.GroupFd)
+			if err != nil {
+				return types.PerfEventOpenArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.PerfEventOpenArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRecvmmsgArgs(decoder *Decoder) (types.RecvmmsgArgs, error) {
-  var result types.RecvmmsgArgs
-  var err error
+	var result types.RecvmmsgArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RecvmmsgArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RecvmmsgArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RecvmmsgArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RecvmmsgArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.RecvmmsgArgs{}, err
-      }
-    case 1:
-      var dataMsgvec uint64
-      err = decoder.DecodeUint64(&dataMsgvec)
-      if err != nil {
-        return types.RecvmmsgArgs{}, err
-      }
-      result.Msgvec = uintptr(dataMsgvec)
-    case 2:
-      err = decoder.DecodeUint32(&result.Vlen)
-      if err != nil {
-        return types.RecvmmsgArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.RecvmmsgArgs{}, err
-      }
-    case 4:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.RecvmmsgArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.RecvmmsgArgs{}, err
+			}
+		case 1:
+			var dataMsgvec uint64
+			err = decoder.DecodeUint64(&dataMsgvec)
+			if err != nil {
+				return types.RecvmmsgArgs{}, err
+			}
+			result.Msgvec = uintptr(dataMsgvec)
+		case 2:
+			err = decoder.DecodeUint32(&result.Vlen)
+			if err != nil {
+				return types.RecvmmsgArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.RecvmmsgArgs{}, err
+			}
+		case 4:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.RecvmmsgArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFanotifyInitArgs(decoder *Decoder) (types.FanotifyInitArgs, error) {
-  var result types.FanotifyInitArgs
-  var err error
+	var result types.FanotifyInitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FanotifyInitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FanotifyInitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FanotifyInitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FanotifyInitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.FanotifyInitArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.EventFFlags)
-      if err != nil {
-        return types.FanotifyInitArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.FanotifyInitArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.EventFFlags)
+			if err != nil {
+				return types.FanotifyInitArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFanotifyMarkArgs(decoder *Decoder) (types.FanotifyMarkArgs, error) {
-  var result types.FanotifyMarkArgs
-  var err error
+	var result types.FanotifyMarkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FanotifyMarkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FanotifyMarkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FanotifyMarkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FanotifyMarkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.FanotifyFd)
-      if err != nil {
-        return types.FanotifyMarkArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.FanotifyMarkArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Mask)
-      if err != nil {
-        return types.FanotifyMarkArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.FanotifyMarkArgs{}, err
-      }
-    case 4:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FanotifyMarkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.FanotifyFd)
+			if err != nil {
+				return types.FanotifyMarkArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.FanotifyMarkArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Mask)
+			if err != nil {
+				return types.FanotifyMarkArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.FanotifyMarkArgs{}, err
+			}
+		case 4:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FanotifyMarkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePrlimit64Args(decoder *Decoder) (types.Prlimit64Args, error) {
-  var result types.Prlimit64Args
-  var err error
+	var result types.Prlimit64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Prlimit64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Prlimit64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Prlimit64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Prlimit64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.Prlimit64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Resource)
-      if err != nil {
-        return types.Prlimit64Args{}, err
-      }
-    case 2:
-      var dataNewLimit uint64
-      err = decoder.DecodeUint64(&dataNewLimit)
-      if err != nil {
-        return types.Prlimit64Args{}, err
-      }
-      result.NewLimit = uintptr(dataNewLimit)
-    case 3:
-      var dataOldLimit uint64
-      err = decoder.DecodeUint64(&dataOldLimit)
-      if err != nil {
-        return types.Prlimit64Args{}, err
-      }
-      result.OldLimit = uintptr(dataOldLimit)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.Prlimit64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Resource)
+			if err != nil {
+				return types.Prlimit64Args{}, err
+			}
+		case 2:
+			var dataNewLimit uint64
+			err = decoder.DecodeUint64(&dataNewLimit)
+			if err != nil {
+				return types.Prlimit64Args{}, err
+			}
+			result.NewLimit = uintptr(dataNewLimit)
+		case 3:
+			var dataOldLimit uint64
+			err = decoder.DecodeUint64(&dataOldLimit)
+			if err != nil {
+				return types.Prlimit64Args{}, err
+			}
+			result.OldLimit = uintptr(dataOldLimit)
+		}
+	}
+	return result, nil
 }
 
 func ParseNameToHandleAtArgs(decoder *Decoder) (types.NameToHandleAtArgs, error) {
-  var result types.NameToHandleAtArgs
-  var err error
+	var result types.NameToHandleAtArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NameToHandleAtArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NameToHandleAtArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NameToHandleAtArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NameToHandleAtArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.NameToHandleAtArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NameToHandleAtArgs{}, err
-      }
-    case 2:
-      var dataHandle uint64
-      err = decoder.DecodeUint64(&dataHandle)
-      if err != nil {
-        return types.NameToHandleAtArgs{}, err
-      }
-      result.Handle = uintptr(dataHandle)
-    case 3:
-      var dataMountId uint64
-      err = decoder.DecodeUint64(&dataMountId)
-      if err != nil {
-        return types.NameToHandleAtArgs{}, err
-      }
-      result.MountId = uintptr(dataMountId)
-    case 4:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.NameToHandleAtArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.NameToHandleAtArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NameToHandleAtArgs{}, err
+			}
+		case 2:
+			var dataHandle uint64
+			err = decoder.DecodeUint64(&dataHandle)
+			if err != nil {
+				return types.NameToHandleAtArgs{}, err
+			}
+			result.Handle = uintptr(dataHandle)
+		case 3:
+			var dataMountId uint64
+			err = decoder.DecodeUint64(&dataMountId)
+			if err != nil {
+				return types.NameToHandleAtArgs{}, err
+			}
+			result.MountId = uintptr(dataMountId)
+		case 4:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.NameToHandleAtArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseOpenByHandleAtArgs(decoder *Decoder) (types.OpenByHandleAtArgs, error) {
-  var result types.OpenByHandleAtArgs
-  var err error
+	var result types.OpenByHandleAtArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OpenByHandleAtArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OpenByHandleAtArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OpenByHandleAtArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OpenByHandleAtArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.MountFd)
-      if err != nil {
-        return types.OpenByHandleAtArgs{}, err
-      }
-    case 1:
-      var dataHandle uint64
-      err = decoder.DecodeUint64(&dataHandle)
-      if err != nil {
-        return types.OpenByHandleAtArgs{}, err
-      }
-      result.Handle = uintptr(dataHandle)
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.OpenByHandleAtArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.MountFd)
+			if err != nil {
+				return types.OpenByHandleAtArgs{}, err
+			}
+		case 1:
+			var dataHandle uint64
+			err = decoder.DecodeUint64(&dataHandle)
+			if err != nil {
+				return types.OpenByHandleAtArgs{}, err
+			}
+			result.Handle = uintptr(dataHandle)
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.OpenByHandleAtArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseClockAdjtimeArgs(decoder *Decoder) (types.ClockAdjtimeArgs, error) {
-  var result types.ClockAdjtimeArgs
-  var err error
+	var result types.ClockAdjtimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockAdjtimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockAdjtimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockAdjtimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockAdjtimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.ClkId)
-      if err != nil {
-        return types.ClockAdjtimeArgs{}, err
-      }
-    case 1:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.ClockAdjtimeArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.ClkId)
+			if err != nil {
+				return types.ClockAdjtimeArgs{}, err
+			}
+		case 1:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.ClockAdjtimeArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseSyncfsArgs(decoder *Decoder) (types.SyncfsArgs, error) {
-  var result types.SyncfsArgs
-  var err error
+	var result types.SyncfsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SyncfsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SyncfsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SyncfsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SyncfsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.SyncfsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.SyncfsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSendmmsgArgs(decoder *Decoder) (types.SendmmsgArgs, error) {
-  var result types.SendmmsgArgs
-  var err error
+	var result types.SendmmsgArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SendmmsgArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SendmmsgArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SendmmsgArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SendmmsgArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SendmmsgArgs{}, err
-      }
-    case 1:
-      var dataMsgvec uint64
-      err = decoder.DecodeUint64(&dataMsgvec)
-      if err != nil {
-        return types.SendmmsgArgs{}, err
-      }
-      result.Msgvec = uintptr(dataMsgvec)
-    case 2:
-      err = decoder.DecodeUint32(&result.Vlen)
-      if err != nil {
-        return types.SendmmsgArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SendmmsgArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SendmmsgArgs{}, err
+			}
+		case 1:
+			var dataMsgvec uint64
+			err = decoder.DecodeUint64(&dataMsgvec)
+			if err != nil {
+				return types.SendmmsgArgs{}, err
+			}
+			result.Msgvec = uintptr(dataMsgvec)
+		case 2:
+			err = decoder.DecodeUint32(&result.Vlen)
+			if err != nil {
+				return types.SendmmsgArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SendmmsgArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSetnsArgs(decoder *Decoder) (types.SetnsArgs, error) {
-  var result types.SetnsArgs
-  var err error
+	var result types.SetnsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SetnsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SetnsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SetnsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SetnsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.SetnsArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Nstype)
-      if err != nil {
-        return types.SetnsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.SetnsArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Nstype)
+			if err != nil {
+				return types.SetnsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseGetcpuArgs(decoder *Decoder) (types.GetcpuArgs, error) {
-  var result types.GetcpuArgs
-  var err error
+	var result types.GetcpuArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetcpuArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetcpuArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetcpuArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetcpuArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataCpu uint64
-      err = decoder.DecodeUint64(&dataCpu)
-      if err != nil {
-        return types.GetcpuArgs{}, err
-      }
-      result.Cpu = uintptr(dataCpu)
-    case 1:
-      var dataNode uint64
-      err = decoder.DecodeUint64(&dataNode)
-      if err != nil {
-        return types.GetcpuArgs{}, err
-      }
-      result.Node = uintptr(dataNode)
-    case 2:
-      var dataTcache uint64
-      err = decoder.DecodeUint64(&dataTcache)
-      if err != nil {
-        return types.GetcpuArgs{}, err
-      }
-      result.Tcache = uintptr(dataTcache)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataCpu uint64
+			err = decoder.DecodeUint64(&dataCpu)
+			if err != nil {
+				return types.GetcpuArgs{}, err
+			}
+			result.Cpu = uintptr(dataCpu)
+		case 1:
+			var dataNode uint64
+			err = decoder.DecodeUint64(&dataNode)
+			if err != nil {
+				return types.GetcpuArgs{}, err
+			}
+			result.Node = uintptr(dataNode)
+		case 2:
+			var dataTcache uint64
+			err = decoder.DecodeUint64(&dataTcache)
+			if err != nil {
+				return types.GetcpuArgs{}, err
+			}
+			result.Tcache = uintptr(dataTcache)
+		}
+	}
+	return result, nil
 }
 
 func ParseProcessVmReadvArgs(decoder *Decoder) (types.ProcessVmReadvArgs, error) {
-  var result types.ProcessVmReadvArgs
-  var err error
+	var result types.ProcessVmReadvArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ProcessVmReadvArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ProcessVmReadvArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ProcessVmReadvArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ProcessVmReadvArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.ProcessVmReadvArgs{}, err
-      }
-    case 1:
-      var dataLocalIov uint64
-      err = decoder.DecodeUint64(&dataLocalIov)
-      if err != nil {
-        return types.ProcessVmReadvArgs{}, err
-      }
-      result.LocalIov = uintptr(dataLocalIov)
-    case 2:
-      err = decoder.DecodeUint64(&result.Liovcnt)
-      if err != nil {
-        return types.ProcessVmReadvArgs{}, err
-      }
-    case 3:
-      var dataRemoteIov uint64
-      err = decoder.DecodeUint64(&dataRemoteIov)
-      if err != nil {
-        return types.ProcessVmReadvArgs{}, err
-      }
-      result.RemoteIov = uintptr(dataRemoteIov)
-    case 4:
-      err = decoder.DecodeUint64(&result.Riovcnt)
-      if err != nil {
-        return types.ProcessVmReadvArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.ProcessVmReadvArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.ProcessVmReadvArgs{}, err
+			}
+		case 1:
+			var dataLocalIov uint64
+			err = decoder.DecodeUint64(&dataLocalIov)
+			if err != nil {
+				return types.ProcessVmReadvArgs{}, err
+			}
+			result.LocalIov = uintptr(dataLocalIov)
+		case 2:
+			err = decoder.DecodeUint64(&result.Liovcnt)
+			if err != nil {
+				return types.ProcessVmReadvArgs{}, err
+			}
+		case 3:
+			var dataRemoteIov uint64
+			err = decoder.DecodeUint64(&dataRemoteIov)
+			if err != nil {
+				return types.ProcessVmReadvArgs{}, err
+			}
+			result.RemoteIov = uintptr(dataRemoteIov)
+		case 4:
+			err = decoder.DecodeUint64(&result.Riovcnt)
+			if err != nil {
+				return types.ProcessVmReadvArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.ProcessVmReadvArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseProcessVmWritevArgs(decoder *Decoder) (types.ProcessVmWritevArgs, error) {
-  var result types.ProcessVmWritevArgs
-  var err error
+	var result types.ProcessVmWritevArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ProcessVmWritevArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ProcessVmWritevArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ProcessVmWritevArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ProcessVmWritevArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.ProcessVmWritevArgs{}, err
-      }
-    case 1:
-      var dataLocalIov uint64
-      err = decoder.DecodeUint64(&dataLocalIov)
-      if err != nil {
-        return types.ProcessVmWritevArgs{}, err
-      }
-      result.LocalIov = uintptr(dataLocalIov)
-    case 2:
-      err = decoder.DecodeUint64(&result.Liovcnt)
-      if err != nil {
-        return types.ProcessVmWritevArgs{}, err
-      }
-    case 3:
-      var dataRemoteIov uint64
-      err = decoder.DecodeUint64(&dataRemoteIov)
-      if err != nil {
-        return types.ProcessVmWritevArgs{}, err
-      }
-      result.RemoteIov = uintptr(dataRemoteIov)
-    case 4:
-      err = decoder.DecodeUint64(&result.Riovcnt)
-      if err != nil {
-        return types.ProcessVmWritevArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.ProcessVmWritevArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.ProcessVmWritevArgs{}, err
+			}
+		case 1:
+			var dataLocalIov uint64
+			err = decoder.DecodeUint64(&dataLocalIov)
+			if err != nil {
+				return types.ProcessVmWritevArgs{}, err
+			}
+			result.LocalIov = uintptr(dataLocalIov)
+		case 2:
+			err = decoder.DecodeUint64(&result.Liovcnt)
+			if err != nil {
+				return types.ProcessVmWritevArgs{}, err
+			}
+		case 3:
+			var dataRemoteIov uint64
+			err = decoder.DecodeUint64(&dataRemoteIov)
+			if err != nil {
+				return types.ProcessVmWritevArgs{}, err
+			}
+			result.RemoteIov = uintptr(dataRemoteIov)
+		case 4:
+			err = decoder.DecodeUint64(&result.Riovcnt)
+			if err != nil {
+				return types.ProcessVmWritevArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.ProcessVmWritevArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseKcmpArgs(decoder *Decoder) (types.KcmpArgs, error) {
-  var result types.KcmpArgs
-  var err error
+	var result types.KcmpArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KcmpArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KcmpArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KcmpArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KcmpArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid1)
-      if err != nil {
-        return types.KcmpArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Pid2)
-      if err != nil {
-        return types.KcmpArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.KcmpArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Idx1)
-      if err != nil {
-        return types.KcmpArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Idx2)
-      if err != nil {
-        return types.KcmpArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid1)
+			if err != nil {
+				return types.KcmpArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Pid2)
+			if err != nil {
+				return types.KcmpArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.KcmpArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Idx1)
+			if err != nil {
+				return types.KcmpArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Idx2)
+			if err != nil {
+				return types.KcmpArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFinitModuleArgs(decoder *Decoder) (types.FinitModuleArgs, error) {
-  var result types.FinitModuleArgs
-  var err error
+	var result types.FinitModuleArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FinitModuleArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FinitModuleArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FinitModuleArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FinitModuleArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.FinitModuleArgs{}, err
-      }
-    case 1:
-      result.ParamValues, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FinitModuleArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.FinitModuleArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.FinitModuleArgs{}, err
+			}
+		case 1:
+			result.ParamValues, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FinitModuleArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.FinitModuleArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedSetattrArgs(decoder *Decoder) (types.SchedSetattrArgs, error) {
-  var result types.SchedSetattrArgs
-  var err error
+	var result types.SchedSetattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedSetattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedSetattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedSetattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedSetattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedSetattrArgs{}, err
-      }
-    case 1:
-      var dataAttr uint64
-      err = decoder.DecodeUint64(&dataAttr)
-      if err != nil {
-        return types.SchedSetattrArgs{}, err
-      }
-      result.Attr = uintptr(dataAttr)
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.SchedSetattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedSetattrArgs{}, err
+			}
+		case 1:
+			var dataAttr uint64
+			err = decoder.DecodeUint64(&dataAttr)
+			if err != nil {
+				return types.SchedSetattrArgs{}, err
+			}
+			result.Attr = uintptr(dataAttr)
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.SchedSetattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedGetattrArgs(decoder *Decoder) (types.SchedGetattrArgs, error) {
-  var result types.SchedGetattrArgs
-  var err error
+	var result types.SchedGetattrArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedGetattrArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedGetattrArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedGetattrArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedGetattrArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedGetattrArgs{}, err
-      }
-    case 1:
-      var dataAttr uint64
-      err = decoder.DecodeUint64(&dataAttr)
-      if err != nil {
-        return types.SchedGetattrArgs{}, err
-      }
-      result.Attr = uintptr(dataAttr)
-    case 2:
-      err = decoder.DecodeUint32(&result.Size)
-      if err != nil {
-        return types.SchedGetattrArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.SchedGetattrArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedGetattrArgs{}, err
+			}
+		case 1:
+			var dataAttr uint64
+			err = decoder.DecodeUint64(&dataAttr)
+			if err != nil {
+				return types.SchedGetattrArgs{}, err
+			}
+			result.Attr = uintptr(dataAttr)
+		case 2:
+			err = decoder.DecodeUint32(&result.Size)
+			if err != nil {
+				return types.SchedGetattrArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.SchedGetattrArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRenameat2Args(decoder *Decoder) (types.Renameat2Args, error) {
-  var result types.Renameat2Args
-  var err error
+	var result types.Renameat2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Renameat2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Renameat2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Renameat2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Renameat2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Olddirfd)
-      if err != nil {
-        return types.Renameat2Args{}, err
-      }
-    case 1:
-      result.Oldpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Renameat2Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Newdirfd)
-      if err != nil {
-        return types.Renameat2Args{}, err
-      }
-    case 3:
-      result.Newpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Renameat2Args{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.Renameat2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Olddirfd)
+			if err != nil {
+				return types.Renameat2Args{}, err
+			}
+		case 1:
+			result.Oldpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Renameat2Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Newdirfd)
+			if err != nil {
+				return types.Renameat2Args{}, err
+			}
+		case 3:
+			result.Newpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Renameat2Args{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.Renameat2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSeccompArgs(decoder *Decoder) (types.SeccompArgs, error) {
-  var result types.SeccompArgs
-  var err error
+	var result types.SeccompArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SeccompArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SeccompArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SeccompArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SeccompArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Operation)
-      if err != nil {
-        return types.SeccompArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.SeccompArgs{}, err
-      }
-    case 2:
-      var dataArgs uint64
-      err = decoder.DecodeUint64(&dataArgs)
-      if err != nil {
-        return types.SeccompArgs{}, err
-      }
-      result.Args = uintptr(dataArgs)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Operation)
+			if err != nil {
+				return types.SeccompArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.SeccompArgs{}, err
+			}
+		case 2:
+			var dataArgs uint64
+			err = decoder.DecodeUint64(&dataArgs)
+			if err != nil {
+				return types.SeccompArgs{}, err
+			}
+			result.Args = uintptr(dataArgs)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetrandomArgs(decoder *Decoder) (types.GetrandomArgs, error) {
-  var result types.GetrandomArgs
-  var err error
+	var result types.GetrandomArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.GetrandomArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.GetrandomArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.GetrandomArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.GetrandomArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.GetrandomArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    case 1:
-      err = decoder.DecodeUint64(&result.Buflen)
-      if err != nil {
-        return types.GetrandomArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.GetrandomArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.GetrandomArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		case 1:
+			err = decoder.DecodeUint64(&result.Buflen)
+			if err != nil {
+				return types.GetrandomArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.GetrandomArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMemfdCreateArgs(decoder *Decoder) (types.MemfdCreateArgs, error) {
-  var result types.MemfdCreateArgs
-  var err error
+	var result types.MemfdCreateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MemfdCreateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MemfdCreateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MemfdCreateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MemfdCreateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MemfdCreateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.MemfdCreateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MemfdCreateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.MemfdCreateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseKexecFileLoadArgs(decoder *Decoder) (types.KexecFileLoadArgs, error) {
-  var result types.KexecFileLoadArgs
-  var err error
+	var result types.KexecFileLoadArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KexecFileLoadArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KexecFileLoadArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KexecFileLoadArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KexecFileLoadArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.KernelFd)
-      if err != nil {
-        return types.KexecFileLoadArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.InitrdFd)
-      if err != nil {
-        return types.KexecFileLoadArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.CmdlineLen)
-      if err != nil {
-        return types.KexecFileLoadArgs{}, err
-      }
-    case 3:
-      result.Cmdline, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.KexecFileLoadArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.KexecFileLoadArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.KernelFd)
+			if err != nil {
+				return types.KexecFileLoadArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.InitrdFd)
+			if err != nil {
+				return types.KexecFileLoadArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.CmdlineLen)
+			if err != nil {
+				return types.KexecFileLoadArgs{}, err
+			}
+		case 3:
+			result.Cmdline, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.KexecFileLoadArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.KexecFileLoadArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseBpfArgs(decoder *Decoder) (types.BpfArgs, error) {
-  var result types.BpfArgs
-  var err error
+	var result types.BpfArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.BpfArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.BpfArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.BpfArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.BpfArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.BpfArgs{}, err
-      }
-    case 1:
-      var dataAttr uint64
-      err = decoder.DecodeUint64(&dataAttr)
-      if err != nil {
-        return types.BpfArgs{}, err
-      }
-      result.Attr = uintptr(dataAttr)
-    case 2:
-      err = decoder.DecodeUint32(&result.Size)
-      if err != nil {
-        return types.BpfArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.BpfArgs{}, err
+			}
+		case 1:
+			var dataAttr uint64
+			err = decoder.DecodeUint64(&dataAttr)
+			if err != nil {
+				return types.BpfArgs{}, err
+			}
+			result.Attr = uintptr(dataAttr)
+		case 2:
+			err = decoder.DecodeUint32(&result.Size)
+			if err != nil {
+				return types.BpfArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseExecveatArgs(decoder *Decoder) (types.ExecveatArgs, error) {
-  var result types.ExecveatArgs
-  var err error
+	var result types.ExecveatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ExecveatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ExecveatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ExecveatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ExecveatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.ExecveatArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExecveatArgs{}, err
-      }
-    case 2:
-      result.Argv, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.ExecveatArgs{}, err
-      }
-    case 3:
-      result.Envp, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.ExecveatArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.ExecveatArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.ExecveatArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExecveatArgs{}, err
+			}
+		case 2:
+			result.Argv, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.ExecveatArgs{}, err
+			}
+		case 3:
+			result.Envp, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.ExecveatArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.ExecveatArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseUserfaultfdArgs(decoder *Decoder) (types.UserfaultfdArgs, error) {
-  var result types.UserfaultfdArgs
-  var err error
+	var result types.UserfaultfdArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UserfaultfdArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UserfaultfdArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UserfaultfdArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UserfaultfdArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.UserfaultfdArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.UserfaultfdArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMembarrierArgs(decoder *Decoder) (types.MembarrierArgs, error) {
-  var result types.MembarrierArgs
-  var err error
+	var result types.MembarrierArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MembarrierArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MembarrierArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MembarrierArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MembarrierArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.MembarrierArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.MembarrierArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.MembarrierArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.MembarrierArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMlock2Args(decoder *Decoder) (types.Mlock2Args, error) {
-  var result types.Mlock2Args
-  var err error
+	var result types.Mlock2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Mlock2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Mlock2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Mlock2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Mlock2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.Mlock2Args{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.Mlock2Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Mlock2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.Mlock2Args{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.Mlock2Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Mlock2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCopyFileRangeArgs(decoder *Decoder) (types.CopyFileRangeArgs, error) {
-  var result types.CopyFileRangeArgs
-  var err error
+	var result types.CopyFileRangeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CopyFileRangeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CopyFileRangeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CopyFileRangeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CopyFileRangeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.FdIn)
-      if err != nil {
-        return types.CopyFileRangeArgs{}, err
-      }
-    case 1:
-      var dataOffIn uint64
-      err = decoder.DecodeUint64(&dataOffIn)
-      if err != nil {
-        return types.CopyFileRangeArgs{}, err
-      }
-      result.OffIn = uintptr(dataOffIn)
-    case 2:
-      err = decoder.DecodeInt32(&result.FdOut)
-      if err != nil {
-        return types.CopyFileRangeArgs{}, err
-      }
-    case 3:
-      var dataOffOut uint64
-      err = decoder.DecodeUint64(&dataOffOut)
-      if err != nil {
-        return types.CopyFileRangeArgs{}, err
-      }
-      result.OffOut = uintptr(dataOffOut)
-    case 4:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.CopyFileRangeArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.CopyFileRangeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.FdIn)
+			if err != nil {
+				return types.CopyFileRangeArgs{}, err
+			}
+		case 1:
+			var dataOffIn uint64
+			err = decoder.DecodeUint64(&dataOffIn)
+			if err != nil {
+				return types.CopyFileRangeArgs{}, err
+			}
+			result.OffIn = uintptr(dataOffIn)
+		case 2:
+			err = decoder.DecodeInt32(&result.FdOut)
+			if err != nil {
+				return types.CopyFileRangeArgs{}, err
+			}
+		case 3:
+			var dataOffOut uint64
+			err = decoder.DecodeUint64(&dataOffOut)
+			if err != nil {
+				return types.CopyFileRangeArgs{}, err
+			}
+			result.OffOut = uintptr(dataOffOut)
+		case 4:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.CopyFileRangeArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.CopyFileRangeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePreadv2Args(decoder *Decoder) (types.Preadv2Args, error) {
-  var result types.Preadv2Args
-  var err error
+	var result types.Preadv2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Preadv2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Preadv2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Preadv2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Preadv2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Preadv2Args{}, err
-      }
-    case 1:
-      var dataIov uint64
-      err = decoder.DecodeUint64(&dataIov)
-      if err != nil {
-        return types.Preadv2Args{}, err
-      }
-      result.Iov = uintptr(dataIov)
-    case 2:
-      err = decoder.DecodeUint64(&result.Iovcnt)
-      if err != nil {
-        return types.Preadv2Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.PosL)
-      if err != nil {
-        return types.Preadv2Args{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.PosH)
-      if err != nil {
-        return types.Preadv2Args{}, err
-      }
-    case 5:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Preadv2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Preadv2Args{}, err
+			}
+		case 1:
+			var dataIov uint64
+			err = decoder.DecodeUint64(&dataIov)
+			if err != nil {
+				return types.Preadv2Args{}, err
+			}
+			result.Iov = uintptr(dataIov)
+		case 2:
+			err = decoder.DecodeUint64(&result.Iovcnt)
+			if err != nil {
+				return types.Preadv2Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.PosL)
+			if err != nil {
+				return types.Preadv2Args{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.PosH)
+			if err != nil {
+				return types.Preadv2Args{}, err
+			}
+		case 5:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Preadv2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePwritev2Args(decoder *Decoder) (types.Pwritev2Args, error) {
-  var result types.Pwritev2Args
-  var err error
+	var result types.Pwritev2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Pwritev2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Pwritev2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Pwritev2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Pwritev2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Pwritev2Args{}, err
-      }
-    case 1:
-      var dataIov uint64
-      err = decoder.DecodeUint64(&dataIov)
-      if err != nil {
-        return types.Pwritev2Args{}, err
-      }
-      result.Iov = uintptr(dataIov)
-    case 2:
-      err = decoder.DecodeUint64(&result.Iovcnt)
-      if err != nil {
-        return types.Pwritev2Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.PosL)
-      if err != nil {
-        return types.Pwritev2Args{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.PosH)
-      if err != nil {
-        return types.Pwritev2Args{}, err
-      }
-    case 5:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.Pwritev2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Pwritev2Args{}, err
+			}
+		case 1:
+			var dataIov uint64
+			err = decoder.DecodeUint64(&dataIov)
+			if err != nil {
+				return types.Pwritev2Args{}, err
+			}
+			result.Iov = uintptr(dataIov)
+		case 2:
+			err = decoder.DecodeUint64(&result.Iovcnt)
+			if err != nil {
+				return types.Pwritev2Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.PosL)
+			if err != nil {
+				return types.Pwritev2Args{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.PosH)
+			if err != nil {
+				return types.Pwritev2Args{}, err
+			}
+		case 5:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.Pwritev2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePkeyMprotectArgs(decoder *Decoder) (types.PkeyMprotectArgs, error) {
-  var result types.PkeyMprotectArgs
-  var err error
+	var result types.PkeyMprotectArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PkeyMprotectArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PkeyMprotectArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PkeyMprotectArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PkeyMprotectArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.PkeyMprotectArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.PkeyMprotectArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Prot)
-      if err != nil {
-        return types.PkeyMprotectArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Pkey)
-      if err != nil {
-        return types.PkeyMprotectArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.PkeyMprotectArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.PkeyMprotectArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Prot)
+			if err != nil {
+				return types.PkeyMprotectArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Pkey)
+			if err != nil {
+				return types.PkeyMprotectArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePkeyAllocArgs(decoder *Decoder) (types.PkeyAllocArgs, error) {
-  var result types.PkeyAllocArgs
-  var err error
+	var result types.PkeyAllocArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PkeyAllocArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PkeyAllocArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PkeyAllocArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PkeyAllocArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.PkeyAllocArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.AccessRights)
-      if err != nil {
-        return types.PkeyAllocArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.PkeyAllocArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.AccessRights)
+			if err != nil {
+				return types.PkeyAllocArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePkeyFreeArgs(decoder *Decoder) (types.PkeyFreeArgs, error) {
-  var result types.PkeyFreeArgs
-  var err error
+	var result types.PkeyFreeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PkeyFreeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PkeyFreeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PkeyFreeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PkeyFreeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pkey)
-      if err != nil {
-        return types.PkeyFreeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pkey)
+			if err != nil {
+				return types.PkeyFreeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseStatxArgs(decoder *Decoder) (types.StatxArgs, error) {
-  var result types.StatxArgs
-  var err error
+	var result types.StatxArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.StatxArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.StatxArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.StatxArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.StatxArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.StatxArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.StatxArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.StatxArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Mask)
-      if err != nil {
-        return types.StatxArgs{}, err
-      }
-    case 4:
-      var dataStatxbuf uint64
-      err = decoder.DecodeUint64(&dataStatxbuf)
-      if err != nil {
-        return types.StatxArgs{}, err
-      }
-      result.Statxbuf = uintptr(dataStatxbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.StatxArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.StatxArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.StatxArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Mask)
+			if err != nil {
+				return types.StatxArgs{}, err
+			}
+		case 4:
+			var dataStatxbuf uint64
+			err = decoder.DecodeUint64(&dataStatxbuf)
+			if err != nil {
+				return types.StatxArgs{}, err
+			}
+			result.Statxbuf = uintptr(dataStatxbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseIoPgeteventsArgs(decoder *Decoder) (types.IoPgeteventsArgs, error) {
-  var result types.IoPgeteventsArgs
-  var err error
+	var result types.IoPgeteventsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoPgeteventsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoPgeteventsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoPgeteventsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoPgeteventsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataCtxId uint64
-      err = decoder.DecodeUint64(&dataCtxId)
-      if err != nil {
-        return types.IoPgeteventsArgs{}, err
-      }
-      result.CtxId = uintptr(dataCtxId)
-    case 1:
-      err = decoder.DecodeInt64(&result.MinNr)
-      if err != nil {
-        return types.IoPgeteventsArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt64(&result.Nr)
-      if err != nil {
-        return types.IoPgeteventsArgs{}, err
-      }
-    case 3:
-      var dataEvents uint64
-      err = decoder.DecodeUint64(&dataEvents)
-      if err != nil {
-        return types.IoPgeteventsArgs{}, err
-      }
-      result.Events = uintptr(dataEvents)
-    case 4:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.IoPgeteventsArgs{}, err
-      }
-    case 5:
-      var dataUsig uint64
-      err = decoder.DecodeUint64(&dataUsig)
-      if err != nil {
-        return types.IoPgeteventsArgs{}, err
-      }
-      result.Usig = uintptr(dataUsig)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataCtxId uint64
+			err = decoder.DecodeUint64(&dataCtxId)
+			if err != nil {
+				return types.IoPgeteventsArgs{}, err
+			}
+			result.CtxId = uintptr(dataCtxId)
+		case 1:
+			err = decoder.DecodeInt64(&result.MinNr)
+			if err != nil {
+				return types.IoPgeteventsArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt64(&result.Nr)
+			if err != nil {
+				return types.IoPgeteventsArgs{}, err
+			}
+		case 3:
+			var dataEvents uint64
+			err = decoder.DecodeUint64(&dataEvents)
+			if err != nil {
+				return types.IoPgeteventsArgs{}, err
+			}
+			result.Events = uintptr(dataEvents)
+		case 4:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.IoPgeteventsArgs{}, err
+			}
+		case 5:
+			var dataUsig uint64
+			err = decoder.DecodeUint64(&dataUsig)
+			if err != nil {
+				return types.IoPgeteventsArgs{}, err
+			}
+			result.Usig = uintptr(dataUsig)
+		}
+	}
+	return result, nil
 }
 
 func ParseRseqArgs(decoder *Decoder) (types.RseqArgs, error) {
-  var result types.RseqArgs
-  var err error
+	var result types.RseqArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RseqArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RseqArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RseqArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RseqArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRseq uint64
-      err = decoder.DecodeUint64(&dataRseq)
-      if err != nil {
-        return types.RseqArgs{}, err
-      }
-      result.Rseq = uintptr(dataRseq)
-    case 1:
-      err = decoder.DecodeUint32(&result.RseqLen)
-      if err != nil {
-        return types.RseqArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.RseqArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Sig)
-      if err != nil {
-        return types.RseqArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRseq uint64
+			err = decoder.DecodeUint64(&dataRseq)
+			if err != nil {
+				return types.RseqArgs{}, err
+			}
+			result.Rseq = uintptr(dataRseq)
+		case 1:
+			err = decoder.DecodeUint32(&result.RseqLen)
+			if err != nil {
+				return types.RseqArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.RseqArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Sig)
+			if err != nil {
+				return types.RseqArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePidfdSendSignalArgs(decoder *Decoder) (types.PidfdSendSignalArgs, error) {
-  var result types.PidfdSendSignalArgs
-  var err error
+	var result types.PidfdSendSignalArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PidfdSendSignalArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PidfdSendSignalArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PidfdSendSignalArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PidfdSendSignalArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pidfd)
-      if err != nil {
-        return types.PidfdSendSignalArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.PidfdSendSignalArgs{}, err
-      }
-    case 2:
-      var dataInfo uint64
-      err = decoder.DecodeUint64(&dataInfo)
-      if err != nil {
-        return types.PidfdSendSignalArgs{}, err
-      }
-      result.Info = uintptr(dataInfo)
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.PidfdSendSignalArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pidfd)
+			if err != nil {
+				return types.PidfdSendSignalArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.PidfdSendSignalArgs{}, err
+			}
+		case 2:
+			var dataInfo uint64
+			err = decoder.DecodeUint64(&dataInfo)
+			if err != nil {
+				return types.PidfdSendSignalArgs{}, err
+			}
+			result.Info = uintptr(dataInfo)
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.PidfdSendSignalArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseIoUringSetupArgs(decoder *Decoder) (types.IoUringSetupArgs, error) {
-  var result types.IoUringSetupArgs
-  var err error
+	var result types.IoUringSetupArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoUringSetupArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoUringSetupArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoUringSetupArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoUringSetupArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Entries)
-      if err != nil {
-        return types.IoUringSetupArgs{}, err
-      }
-    case 1:
-      var dataP uint64
-      err = decoder.DecodeUint64(&dataP)
-      if err != nil {
-        return types.IoUringSetupArgs{}, err
-      }
-      result.P = uintptr(dataP)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Entries)
+			if err != nil {
+				return types.IoUringSetupArgs{}, err
+			}
+		case 1:
+			var dataP uint64
+			err = decoder.DecodeUint64(&dataP)
+			if err != nil {
+				return types.IoUringSetupArgs{}, err
+			}
+			result.P = uintptr(dataP)
+		}
+	}
+	return result, nil
 }
 
 func ParseIoUringEnterArgs(decoder *Decoder) (types.IoUringEnterArgs, error) {
-  var result types.IoUringEnterArgs
-  var err error
+	var result types.IoUringEnterArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoUringEnterArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoUringEnterArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoUringEnterArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoUringEnterArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Fd)
-      if err != nil {
-        return types.IoUringEnterArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.ToSubmit)
-      if err != nil {
-        return types.IoUringEnterArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.MinComplete)
-      if err != nil {
-        return types.IoUringEnterArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.IoUringEnterArgs{}, err
-      }
-    case 4:
-      var dataSig uint64
-      err = decoder.DecodeUint64(&dataSig)
-      if err != nil {
-        return types.IoUringEnterArgs{}, err
-      }
-      result.Sig = uintptr(dataSig)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Fd)
+			if err != nil {
+				return types.IoUringEnterArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.ToSubmit)
+			if err != nil {
+				return types.IoUringEnterArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.MinComplete)
+			if err != nil {
+				return types.IoUringEnterArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.IoUringEnterArgs{}, err
+			}
+		case 4:
+			var dataSig uint64
+			err = decoder.DecodeUint64(&dataSig)
+			if err != nil {
+				return types.IoUringEnterArgs{}, err
+			}
+			result.Sig = uintptr(dataSig)
+		}
+	}
+	return result, nil
 }
 
 func ParseIoUringRegisterArgs(decoder *Decoder) (types.IoUringRegisterArgs, error) {
-  var result types.IoUringRegisterArgs
-  var err error
+	var result types.IoUringRegisterArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IoUringRegisterArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IoUringRegisterArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IoUringRegisterArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IoUringRegisterArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Fd)
-      if err != nil {
-        return types.IoUringRegisterArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Opcode)
-      if err != nil {
-        return types.IoUringRegisterArgs{}, err
-      }
-    case 2:
-      var dataArg uint64
-      err = decoder.DecodeUint64(&dataArg)
-      if err != nil {
-        return types.IoUringRegisterArgs{}, err
-      }
-      result.Arg = uintptr(dataArg)
-    case 3:
-      err = decoder.DecodeUint32(&result.NrArgs)
-      if err != nil {
-        return types.IoUringRegisterArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Fd)
+			if err != nil {
+				return types.IoUringRegisterArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Opcode)
+			if err != nil {
+				return types.IoUringRegisterArgs{}, err
+			}
+		case 2:
+			var dataArg uint64
+			err = decoder.DecodeUint64(&dataArg)
+			if err != nil {
+				return types.IoUringRegisterArgs{}, err
+			}
+			result.Arg = uintptr(dataArg)
+		case 3:
+			err = decoder.DecodeUint32(&result.NrArgs)
+			if err != nil {
+				return types.IoUringRegisterArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseOpenTreeArgs(decoder *Decoder) (types.OpenTreeArgs, error) {
-  var result types.OpenTreeArgs
-  var err error
+	var result types.OpenTreeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OpenTreeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OpenTreeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OpenTreeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OpenTreeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dfd)
-      if err != nil {
-        return types.OpenTreeArgs{}, err
-      }
-    case 1:
-      result.Filename, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.OpenTreeArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.OpenTreeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dfd)
+			if err != nil {
+				return types.OpenTreeArgs{}, err
+			}
+		case 1:
+			result.Filename, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.OpenTreeArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.OpenTreeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMoveMountArgs(decoder *Decoder) (types.MoveMountArgs, error) {
-  var result types.MoveMountArgs
-  var err error
+	var result types.MoveMountArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MoveMountArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MoveMountArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MoveMountArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MoveMountArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.FromDfd)
-      if err != nil {
-        return types.MoveMountArgs{}, err
-      }
-    case 1:
-      result.FromPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MoveMountArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.ToDfd)
-      if err != nil {
-        return types.MoveMountArgs{}, err
-      }
-    case 3:
-      result.ToPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MoveMountArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.MoveMountArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.FromDfd)
+			if err != nil {
+				return types.MoveMountArgs{}, err
+			}
+		case 1:
+			result.FromPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MoveMountArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.ToDfd)
+			if err != nil {
+				return types.MoveMountArgs{}, err
+			}
+		case 3:
+			result.ToPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MoveMountArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.MoveMountArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFsopenArgs(decoder *Decoder) (types.FsopenArgs, error) {
-  var result types.FsopenArgs
-  var err error
+	var result types.FsopenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FsopenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FsopenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FsopenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FsopenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Fsname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FsopenArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.FsopenArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Fsname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FsopenArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.FsopenArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFsconfigArgs(decoder *Decoder) (types.FsconfigArgs, error) {
-  var result types.FsconfigArgs
-  var err error
+	var result types.FsconfigArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FsconfigArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FsconfigArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FsconfigArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FsconfigArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataFsFd uint64
-      err = decoder.DecodeUint64(&dataFsFd)
-      if err != nil {
-        return types.FsconfigArgs{}, err
-      }
-      result.FsFd = uintptr(dataFsFd)
-    case 1:
-      err = decoder.DecodeUint32(&result.Cmd)
-      if err != nil {
-        return types.FsconfigArgs{}, err
-      }
-    case 2:
-      result.Key, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FsconfigArgs{}, err
-      }
-    case 3:
-      var dataValue uint64
-      err = decoder.DecodeUint64(&dataValue)
-      if err != nil {
-        return types.FsconfigArgs{}, err
-      }
-      result.Value = uintptr(dataValue)
-    case 4:
-      err = decoder.DecodeInt32(&result.Aux)
-      if err != nil {
-        return types.FsconfigArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataFsFd uint64
+			err = decoder.DecodeUint64(&dataFsFd)
+			if err != nil {
+				return types.FsconfigArgs{}, err
+			}
+			result.FsFd = uintptr(dataFsFd)
+		case 1:
+			err = decoder.DecodeUint32(&result.Cmd)
+			if err != nil {
+				return types.FsconfigArgs{}, err
+			}
+		case 2:
+			result.Key, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FsconfigArgs{}, err
+			}
+		case 3:
+			var dataValue uint64
+			err = decoder.DecodeUint64(&dataValue)
+			if err != nil {
+				return types.FsconfigArgs{}, err
+			}
+			result.Value = uintptr(dataValue)
+		case 4:
+			err = decoder.DecodeInt32(&result.Aux)
+			if err != nil {
+				return types.FsconfigArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFsmountArgs(decoder *Decoder) (types.FsmountArgs, error) {
-  var result types.FsmountArgs
-  var err error
+	var result types.FsmountArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FsmountArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FsmountArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FsmountArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FsmountArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fsfd)
-      if err != nil {
-        return types.FsmountArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.FsmountArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.MsFlags)
-      if err != nil {
-        return types.FsmountArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fsfd)
+			if err != nil {
+				return types.FsmountArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.FsmountArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.MsFlags)
+			if err != nil {
+				return types.FsmountArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFspickArgs(decoder *Decoder) (types.FspickArgs, error) {
-  var result types.FspickArgs
-  var err error
+	var result types.FspickArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FspickArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FspickArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FspickArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FspickArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.FspickArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FspickArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.FspickArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.FspickArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FspickArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.FspickArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePidfdOpenArgs(decoder *Decoder) (types.PidfdOpenArgs, error) {
-  var result types.PidfdOpenArgs
-  var err error
+	var result types.PidfdOpenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PidfdOpenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PidfdOpenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PidfdOpenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PidfdOpenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.PidfdOpenArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.PidfdOpenArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.PidfdOpenArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.PidfdOpenArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseClone3Args(decoder *Decoder) (types.Clone3Args, error) {
-  var result types.Clone3Args
-  var err error
+	var result types.Clone3Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Clone3Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Clone3Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Clone3Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Clone3Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataClArgs uint64
-      err = decoder.DecodeUint64(&dataClArgs)
-      if err != nil {
-        return types.Clone3Args{}, err
-      }
-      result.ClArgs = uintptr(dataClArgs)
-    case 1:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.Clone3Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataClArgs uint64
+			err = decoder.DecodeUint64(&dataClArgs)
+			if err != nil {
+				return types.Clone3Args{}, err
+			}
+			result.ClArgs = uintptr(dataClArgs)
+		case 1:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.Clone3Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCloseRangeArgs(decoder *Decoder) (types.CloseRangeArgs, error) {
-  var result types.CloseRangeArgs
-  var err error
+	var result types.CloseRangeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CloseRangeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CloseRangeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CloseRangeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CloseRangeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.First)
-      if err != nil {
-        return types.CloseRangeArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Last)
-      if err != nil {
-        return types.CloseRangeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.First)
+			if err != nil {
+				return types.CloseRangeArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Last)
+			if err != nil {
+				return types.CloseRangeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseOpenat2Args(decoder *Decoder) (types.Openat2Args, error) {
-  var result types.Openat2Args
-  var err error
+	var result types.Openat2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Openat2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Openat2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Openat2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Openat2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dirfd)
-      if err != nil {
-        return types.Openat2Args{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Openat2Args{}, err
-      }
-    case 2:
-      var dataHow uint64
-      err = decoder.DecodeUint64(&dataHow)
-      if err != nil {
-        return types.Openat2Args{}, err
-      }
-      result.How = uintptr(dataHow)
-    case 3:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.Openat2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dirfd)
+			if err != nil {
+				return types.Openat2Args{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Openat2Args{}, err
+			}
+		case 2:
+			var dataHow uint64
+			err = decoder.DecodeUint64(&dataHow)
+			if err != nil {
+				return types.Openat2Args{}, err
+			}
+			result.How = uintptr(dataHow)
+		case 3:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.Openat2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePidfdGetfdArgs(decoder *Decoder) (types.PidfdGetfdArgs, error) {
-  var result types.PidfdGetfdArgs
-  var err error
+	var result types.PidfdGetfdArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PidfdGetfdArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PidfdGetfdArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PidfdGetfdArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PidfdGetfdArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pidfd)
-      if err != nil {
-        return types.PidfdGetfdArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Targetfd)
-      if err != nil {
-        return types.PidfdGetfdArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.PidfdGetfdArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pidfd)
+			if err != nil {
+				return types.PidfdGetfdArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Targetfd)
+			if err != nil {
+				return types.PidfdGetfdArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.PidfdGetfdArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFaccessat2Args(decoder *Decoder) (types.Faccessat2Args, error) {
-  var result types.Faccessat2Args
-  var err error
+	var result types.Faccessat2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Faccessat2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Faccessat2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Faccessat2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Faccessat2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Faccessat2Args{}, err
-      }
-    case 1:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Faccessat2Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Mode)
-      if err != nil {
-        return types.Faccessat2Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Flag)
-      if err != nil {
-        return types.Faccessat2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Faccessat2Args{}, err
+			}
+		case 1:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Faccessat2Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Mode)
+			if err != nil {
+				return types.Faccessat2Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Flag)
+			if err != nil {
+				return types.Faccessat2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseProcessMadviseArgs(decoder *Decoder) (types.ProcessMadviseArgs, error) {
-  var result types.ProcessMadviseArgs
-  var err error
+	var result types.ProcessMadviseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ProcessMadviseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ProcessMadviseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ProcessMadviseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ProcessMadviseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pidfd)
-      if err != nil {
-        return types.ProcessMadviseArgs{}, err
-      }
-    case 1:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.ProcessMadviseArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 2:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.ProcessMadviseArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Advice)
-      if err != nil {
-        return types.ProcessMadviseArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.ProcessMadviseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pidfd)
+			if err != nil {
+				return types.ProcessMadviseArgs{}, err
+			}
+		case 1:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.ProcessMadviseArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 2:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.ProcessMadviseArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Advice)
+			if err != nil {
+				return types.ProcessMadviseArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.ProcessMadviseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseEpollPwait2Args(decoder *Decoder) (types.EpollPwait2Args, error) {
-  var result types.EpollPwait2Args
-  var err error
+	var result types.EpollPwait2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.EpollPwait2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.EpollPwait2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.EpollPwait2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.EpollPwait2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.EpollPwait2Args{}, err
-      }
-    case 1:
-      var dataEvents uint64
-      err = decoder.DecodeUint64(&dataEvents)
-      if err != nil {
-        return types.EpollPwait2Args{}, err
-      }
-      result.Events = uintptr(dataEvents)
-    case 2:
-      err = decoder.DecodeInt32(&result.Maxevents)
-      if err != nil {
-        return types.EpollPwait2Args{}, err
-      }
-    case 3:
-      result.Timeout, err = decoder.ReadTimespec()
-      if err != nil {
-        return types.EpollPwait2Args{}, err
-      }
-    case 4:
-      var dataSigset uint64
-      err = decoder.DecodeUint64(&dataSigset)
-      if err != nil {
-        return types.EpollPwait2Args{}, err
-      }
-      result.Sigset = uintptr(dataSigset)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.EpollPwait2Args{}, err
+			}
+		case 1:
+			var dataEvents uint64
+			err = decoder.DecodeUint64(&dataEvents)
+			if err != nil {
+				return types.EpollPwait2Args{}, err
+			}
+			result.Events = uintptr(dataEvents)
+		case 2:
+			err = decoder.DecodeInt32(&result.Maxevents)
+			if err != nil {
+				return types.EpollPwait2Args{}, err
+			}
+		case 3:
+			result.Timeout, err = decoder.ReadTimespec()
+			if err != nil {
+				return types.EpollPwait2Args{}, err
+			}
+		case 4:
+			var dataSigset uint64
+			err = decoder.DecodeUint64(&dataSigset)
+			if err != nil {
+				return types.EpollPwait2Args{}, err
+			}
+			result.Sigset = uintptr(dataSigset)
+		}
+	}
+	return result, nil
 }
 
 func ParseMountSetattArgs(decoder *Decoder) (types.MountSetattArgs, error) {
-  var result types.MountSetattArgs
-  var err error
+	var result types.MountSetattArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MountSetattArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MountSetattArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MountSetattArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MountSetattArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Dfd)
-      if err != nil {
-        return types.MountSetattArgs{}, err
-      }
-    case 1:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MountSetattArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.MountSetattArgs{}, err
-      }
-    case 3:
-      var dataUattr uint64
-      err = decoder.DecodeUint64(&dataUattr)
-      if err != nil {
-        return types.MountSetattArgs{}, err
-      }
-      result.Uattr = uintptr(dataUattr)
-    case 4:
-      err = decoder.DecodeUint64(&result.Usize)
-      if err != nil {
-        return types.MountSetattArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Dfd)
+			if err != nil {
+				return types.MountSetattArgs{}, err
+			}
+		case 1:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MountSetattArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.MountSetattArgs{}, err
+			}
+		case 3:
+			var dataUattr uint64
+			err = decoder.DecodeUint64(&dataUattr)
+			if err != nil {
+				return types.MountSetattArgs{}, err
+			}
+			result.Uattr = uintptr(dataUattr)
+		case 4:
+			err = decoder.DecodeUint64(&result.Usize)
+			if err != nil {
+				return types.MountSetattArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseQuotactlFdArgs(decoder *Decoder) (types.QuotactlFdArgs, error) {
-  var result types.QuotactlFdArgs
-  var err error
+	var result types.QuotactlFdArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.QuotactlFdArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.QuotactlFdArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.QuotactlFdArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.QuotactlFdArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Fd)
-      if err != nil {
-        return types.QuotactlFdArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Cmd)
-      if err != nil {
-        return types.QuotactlFdArgs{}, err
-      }
-    case 2:
-      var dataId uint64
-      err = decoder.DecodeUint64(&dataId)
-      if err != nil {
-        return types.QuotactlFdArgs{}, err
-      }
-      result.Id = uintptr(dataId)
-    case 3:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.QuotactlFdArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Fd)
+			if err != nil {
+				return types.QuotactlFdArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Cmd)
+			if err != nil {
+				return types.QuotactlFdArgs{}, err
+			}
+		case 2:
+			var dataId uint64
+			err = decoder.DecodeUint64(&dataId)
+			if err != nil {
+				return types.QuotactlFdArgs{}, err
+			}
+			result.Id = uintptr(dataId)
+		case 3:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.QuotactlFdArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		}
+	}
+	return result, nil
 }
 
 func ParseLandlockCreateRulesetArgs(decoder *Decoder) (types.LandlockCreateRulesetArgs, error) {
-  var result types.LandlockCreateRulesetArgs
-  var err error
+	var result types.LandlockCreateRulesetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LandlockCreateRulesetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LandlockCreateRulesetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LandlockCreateRulesetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LandlockCreateRulesetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAttr uint64
-      err = decoder.DecodeUint64(&dataAttr)
-      if err != nil {
-        return types.LandlockCreateRulesetArgs{}, err
-      }
-      result.Attr = uintptr(dataAttr)
-    case 1:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.LandlockCreateRulesetArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.LandlockCreateRulesetArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAttr uint64
+			err = decoder.DecodeUint64(&dataAttr)
+			if err != nil {
+				return types.LandlockCreateRulesetArgs{}, err
+			}
+			result.Attr = uintptr(dataAttr)
+		case 1:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.LandlockCreateRulesetArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.LandlockCreateRulesetArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLandlockAddRuleArgs(decoder *Decoder) (types.LandlockAddRuleArgs, error) {
-  var result types.LandlockAddRuleArgs
-  var err error
+	var result types.LandlockAddRuleArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LandlockAddRuleArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LandlockAddRuleArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LandlockAddRuleArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LandlockAddRuleArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.RulesetFd)
-      if err != nil {
-        return types.LandlockAddRuleArgs{}, err
-      }
-    case 1:
-      var dataRuleType uint64
-      err = decoder.DecodeUint64(&dataRuleType)
-      if err != nil {
-        return types.LandlockAddRuleArgs{}, err
-      }
-      result.RuleType = uintptr(dataRuleType)
-    case 2:
-      var dataRuleAttr uint64
-      err = decoder.DecodeUint64(&dataRuleAttr)
-      if err != nil {
-        return types.LandlockAddRuleArgs{}, err
-      }
-      result.RuleAttr = uintptr(dataRuleAttr)
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.LandlockAddRuleArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.RulesetFd)
+			if err != nil {
+				return types.LandlockAddRuleArgs{}, err
+			}
+		case 1:
+			var dataRuleType uint64
+			err = decoder.DecodeUint64(&dataRuleType)
+			if err != nil {
+				return types.LandlockAddRuleArgs{}, err
+			}
+			result.RuleType = uintptr(dataRuleType)
+		case 2:
+			var dataRuleAttr uint64
+			err = decoder.DecodeUint64(&dataRuleAttr)
+			if err != nil {
+				return types.LandlockAddRuleArgs{}, err
+			}
+			result.RuleAttr = uintptr(dataRuleAttr)
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.LandlockAddRuleArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLandloclRestrictSetArgs(decoder *Decoder) (types.LandloclRestrictSetArgs, error) {
-  var result types.LandloclRestrictSetArgs
-  var err error
+	var result types.LandloclRestrictSetArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LandloclRestrictSetArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LandloclRestrictSetArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LandloclRestrictSetArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LandloclRestrictSetArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.RulesetFd)
-      if err != nil {
-        return types.LandloclRestrictSetArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.LandloclRestrictSetArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.RulesetFd)
+			if err != nil {
+				return types.LandloclRestrictSetArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.LandloclRestrictSetArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMemfdSecretArgs(decoder *Decoder) (types.MemfdSecretArgs, error) {
-  var result types.MemfdSecretArgs
-  var err error
+	var result types.MemfdSecretArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MemfdSecretArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MemfdSecretArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MemfdSecretArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MemfdSecretArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.MemfdSecretArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.MemfdSecretArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseProcessMreleaseArgs(decoder *Decoder) (types.ProcessMreleaseArgs, error) {
-  var result types.ProcessMreleaseArgs
-  var err error
+	var result types.ProcessMreleaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ProcessMreleaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ProcessMreleaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ProcessMreleaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ProcessMreleaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pidfd)
-      if err != nil {
-        return types.ProcessMreleaseArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.ProcessMreleaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pidfd)
+			if err != nil {
+				return types.ProcessMreleaseArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.ProcessMreleaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseWaitpidArgs(decoder *Decoder) (types.WaitpidArgs, error) {
-  var result types.WaitpidArgs
-  var err error
+	var result types.WaitpidArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.WaitpidArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.WaitpidArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.WaitpidArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.WaitpidArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.WaitpidArgs{}, err
-      }
-    case 1:
-      var dataStatus uint64
-      err = decoder.DecodeUint64(&dataStatus)
-      if err != nil {
-        return types.WaitpidArgs{}, err
-      }
-      result.Status = uintptr(dataStatus)
-    case 2:
-      err = decoder.DecodeInt32(&result.Options)
-      if err != nil {
-        return types.WaitpidArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.WaitpidArgs{}, err
+			}
+		case 1:
+			var dataStatus uint64
+			err = decoder.DecodeUint64(&dataStatus)
+			if err != nil {
+				return types.WaitpidArgs{}, err
+			}
+			result.Status = uintptr(dataStatus)
+		case 2:
+			err = decoder.DecodeInt32(&result.Options)
+			if err != nil {
+				return types.WaitpidArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseOldfstatArgs(decoder *Decoder) (types.OldfstatArgs, error) {
-  return types.OldfstatArgs{}, nil
+	return types.OldfstatArgs{}, nil
 }
 
 func ParseBreakArgs(decoder *Decoder) (types.BreakArgs, error) {
-  return types.BreakArgs{}, nil
+	return types.BreakArgs{}, nil
 }
 
 func ParseOldstatArgs(decoder *Decoder) (types.OldstatArgs, error) {
-  var result types.OldstatArgs
-  var err error
+	var result types.OldstatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OldstatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OldstatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OldstatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OldstatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Filename, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.OldstatArgs{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.OldstatArgs{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Filename, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.OldstatArgs{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.OldstatArgs{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseUmountArgs(decoder *Decoder) (types.UmountArgs, error) {
-  var result types.UmountArgs
-  var err error
+	var result types.UmountArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UmountArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UmountArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UmountArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UmountArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Target, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UmountArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Target, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UmountArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseStimeArgs(decoder *Decoder) (types.StimeArgs, error) {
-  var result types.StimeArgs
-  var err error
+	var result types.StimeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.StimeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.StimeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.StimeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.StimeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataT uint64
-      err = decoder.DecodeUint64(&dataT)
-      if err != nil {
-        return types.StimeArgs{}, err
-      }
-      result.T = uintptr(dataT)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataT uint64
+			err = decoder.DecodeUint64(&dataT)
+			if err != nil {
+				return types.StimeArgs{}, err
+			}
+			result.T = uintptr(dataT)
+		}
+	}
+	return result, nil
 }
 
 func ParseSttyArgs(decoder *Decoder) (types.SttyArgs, error) {
-  return types.SttyArgs{}, nil
+	return types.SttyArgs{}, nil
 }
 
 func ParseGttyArgs(decoder *Decoder) (types.GttyArgs, error) {
-  return types.GttyArgs{}, nil
+	return types.GttyArgs{}, nil
 }
 
 func ParseNiceArgs(decoder *Decoder) (types.NiceArgs, error) {
-  var result types.NiceArgs
-  var err error
+	var result types.NiceArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NiceArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NiceArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NiceArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NiceArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Inc)
-      if err != nil {
-        return types.NiceArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Inc)
+			if err != nil {
+				return types.NiceArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFtimeArgs(decoder *Decoder) (types.FtimeArgs, error) {
-  return types.FtimeArgs{}, nil
+	return types.FtimeArgs{}, nil
 }
 
 func ParseProfArgs(decoder *Decoder) (types.ProfArgs, error) {
-  return types.ProfArgs{}, nil
+	return types.ProfArgs{}, nil
 }
 
 func ParseSignalArgs(decoder *Decoder) (types.SignalArgs, error) {
-  var result types.SignalArgs
-  var err error
+	var result types.SignalArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SignalArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SignalArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SignalArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SignalArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Signum)
-      if err != nil {
-        return types.SignalArgs{}, err
-      }
-    case 1:
-      var dataHandler uint64
-      err = decoder.DecodeUint64(&dataHandler)
-      if err != nil {
-        return types.SignalArgs{}, err
-      }
-      result.Handler = uintptr(dataHandler)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Signum)
+			if err != nil {
+				return types.SignalArgs{}, err
+			}
+		case 1:
+			var dataHandler uint64
+			err = decoder.DecodeUint64(&dataHandler)
+			if err != nil {
+				return types.SignalArgs{}, err
+			}
+			result.Handler = uintptr(dataHandler)
+		}
+	}
+	return result, nil
 }
 
 func ParseLockArgs(decoder *Decoder) (types.LockArgs, error) {
-  return types.LockArgs{}, nil
+	return types.LockArgs{}, nil
 }
 
 func ParseMpxArgs(decoder *Decoder) (types.MpxArgs, error) {
-  return types.MpxArgs{}, nil
+	return types.MpxArgs{}, nil
 }
 
 func ParseUlimitArgs(decoder *Decoder) (types.UlimitArgs, error) {
-  return types.UlimitArgs{}, nil
+	return types.UlimitArgs{}, nil
 }
 
 func ParseOldoldunameArgs(decoder *Decoder) (types.OldoldunameArgs, error) {
-  var result types.OldoldunameArgs
-  var err error
+	var result types.OldoldunameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OldoldunameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OldoldunameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OldoldunameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OldoldunameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataName uint64
-      err = decoder.DecodeUint64(&dataName)
-      if err != nil {
-        return types.OldoldunameArgs{}, err
-      }
-      result.Name = uintptr(dataName)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataName uint64
+			err = decoder.DecodeUint64(&dataName)
+			if err != nil {
+				return types.OldoldunameArgs{}, err
+			}
+			result.Name = uintptr(dataName)
+		}
+	}
+	return result, nil
 }
 
 func ParseSigactionArgs(decoder *Decoder) (types.SigactionArgs, error) {
-  var result types.SigactionArgs
-  var err error
+	var result types.SigactionArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SigactionArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SigactionArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SigactionArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SigactionArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.SigactionArgs{}, err
-      }
-    case 1:
-      var dataAct uint64
-      err = decoder.DecodeUint64(&dataAct)
-      if err != nil {
-        return types.SigactionArgs{}, err
-      }
-      result.Act = uintptr(dataAct)
-    case 2:
-      var dataOact uint64
-      err = decoder.DecodeUint64(&dataOact)
-      if err != nil {
-        return types.SigactionArgs{}, err
-      }
-      result.Oact = uintptr(dataOact)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.SigactionArgs{}, err
+			}
+		case 1:
+			var dataAct uint64
+			err = decoder.DecodeUint64(&dataAct)
+			if err != nil {
+				return types.SigactionArgs{}, err
+			}
+			result.Act = uintptr(dataAct)
+		case 2:
+			var dataOact uint64
+			err = decoder.DecodeUint64(&dataOact)
+			if err != nil {
+				return types.SigactionArgs{}, err
+			}
+			result.Oact = uintptr(dataOact)
+		}
+	}
+	return result, nil
 }
 
 func ParseSgetmaskArgs(decoder *Decoder) (types.SgetmaskArgs, error) {
-  return types.SgetmaskArgs{}, nil
+	return types.SgetmaskArgs{}, nil
 }
 
 func ParseSsetmaskArgs(decoder *Decoder) (types.SsetmaskArgs, error) {
-  var result types.SsetmaskArgs
-  var err error
+	var result types.SsetmaskArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SsetmaskArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SsetmaskArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SsetmaskArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SsetmaskArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt64(&result.Newmask)
-      if err != nil {
-        return types.SsetmaskArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt64(&result.Newmask)
+			if err != nil {
+				return types.SsetmaskArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSigsuspendArgs(decoder *Decoder) (types.SigsuspendArgs, error) {
-  var result types.SigsuspendArgs
-  var err error
+	var result types.SigsuspendArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SigsuspendArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SigsuspendArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SigsuspendArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SigsuspendArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataMask uint64
-      err = decoder.DecodeUint64(&dataMask)
-      if err != nil {
-        return types.SigsuspendArgs{}, err
-      }
-      result.Mask = uintptr(dataMask)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataMask uint64
+			err = decoder.DecodeUint64(&dataMask)
+			if err != nil {
+				return types.SigsuspendArgs{}, err
+			}
+			result.Mask = uintptr(dataMask)
+		}
+	}
+	return result, nil
 }
 
 func ParseSigpendingArgs(decoder *Decoder) (types.SigpendingArgs, error) {
-  var result types.SigpendingArgs
-  var err error
+	var result types.SigpendingArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SigpendingArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SigpendingArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SigpendingArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SigpendingArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataSet uint64
-      err = decoder.DecodeUint64(&dataSet)
-      if err != nil {
-        return types.SigpendingArgs{}, err
-      }
-      result.Set = uintptr(dataSet)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataSet uint64
+			err = decoder.DecodeUint64(&dataSet)
+			if err != nil {
+				return types.SigpendingArgs{}, err
+			}
+			result.Set = uintptr(dataSet)
+		}
+	}
+	return result, nil
 }
 
 func ParseOldlstatArgs(decoder *Decoder) (types.OldlstatArgs, error) {
-  var result types.OldlstatArgs
-  var err error
+	var result types.OldlstatArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OldlstatArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OldlstatArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OldlstatArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OldlstatArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.OldlstatArgs{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.OldlstatArgs{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.OldlstatArgs{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.OldlstatArgs{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseReaddirArgs(decoder *Decoder) (types.ReaddirArgs, error) {
-  var result types.ReaddirArgs
-  var err error
+	var result types.ReaddirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ReaddirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ReaddirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ReaddirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ReaddirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Fd)
-      if err != nil {
-        return types.ReaddirArgs{}, err
-      }
-    case 1:
-      var dataDirp uint64
-      err = decoder.DecodeUint64(&dataDirp)
-      if err != nil {
-        return types.ReaddirArgs{}, err
-      }
-      result.Dirp = uintptr(dataDirp)
-    case 2:
-      err = decoder.DecodeUint32(&result.Count)
-      if err != nil {
-        return types.ReaddirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Fd)
+			if err != nil {
+				return types.ReaddirArgs{}, err
+			}
+		case 1:
+			var dataDirp uint64
+			err = decoder.DecodeUint64(&dataDirp)
+			if err != nil {
+				return types.ReaddirArgs{}, err
+			}
+			result.Dirp = uintptr(dataDirp)
+		case 2:
+			err = decoder.DecodeUint32(&result.Count)
+			if err != nil {
+				return types.ReaddirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseProfilArgs(decoder *Decoder) (types.ProfilArgs, error) {
-  return types.ProfilArgs{}, nil
+	return types.ProfilArgs{}, nil
 }
 
 func ParseSocketcallArgs(decoder *Decoder) (types.SocketcallArgs, error) {
-  var result types.SocketcallArgs
-  var err error
+	var result types.SocketcallArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SocketcallArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SocketcallArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SocketcallArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SocketcallArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Call)
-      if err != nil {
-        return types.SocketcallArgs{}, err
-      }
-    case 1:
-      var dataArgs uint64
-      err = decoder.DecodeUint64(&dataArgs)
-      if err != nil {
-        return types.SocketcallArgs{}, err
-      }
-      result.Args = uintptr(dataArgs)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Call)
+			if err != nil {
+				return types.SocketcallArgs{}, err
+			}
+		case 1:
+			var dataArgs uint64
+			err = decoder.DecodeUint64(&dataArgs)
+			if err != nil {
+				return types.SocketcallArgs{}, err
+			}
+			result.Args = uintptr(dataArgs)
+		}
+	}
+	return result, nil
 }
 
 func ParseOldunameArgs(decoder *Decoder) (types.OldunameArgs, error) {
-  var result types.OldunameArgs
-  var err error
+	var result types.OldunameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OldunameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OldunameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OldunameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OldunameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.OldunameArgs{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.OldunameArgs{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseIdleArgs(decoder *Decoder) (types.IdleArgs, error) {
-  return types.IdleArgs{}, nil
+	return types.IdleArgs{}, nil
 }
 
 func ParseVm86oldArgs(decoder *Decoder) (types.Vm86oldArgs, error) {
-  var result types.Vm86oldArgs
-  var err error
+	var result types.Vm86oldArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Vm86oldArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Vm86oldArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Vm86oldArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Vm86oldArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataInfo uint64
-      err = decoder.DecodeUint64(&dataInfo)
-      if err != nil {
-        return types.Vm86oldArgs{}, err
-      }
-      result.Info = uintptr(dataInfo)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataInfo uint64
+			err = decoder.DecodeUint64(&dataInfo)
+			if err != nil {
+				return types.Vm86oldArgs{}, err
+			}
+			result.Info = uintptr(dataInfo)
+		}
+	}
+	return result, nil
 }
 
 func ParseIpcArgs(decoder *Decoder) (types.IpcArgs, error) {
-  var result types.IpcArgs
-  var err error
+	var result types.IpcArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.IpcArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.IpcArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.IpcArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.IpcArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Call)
-      if err != nil {
-        return types.IpcArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.First)
-      if err != nil {
-        return types.IpcArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Second)
-      if err != nil {
-        return types.IpcArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Third)
-      if err != nil {
-        return types.IpcArgs{}, err
-      }
-    case 4:
-      var dataPtr uint64
-      err = decoder.DecodeUint64(&dataPtr)
-      if err != nil {
-        return types.IpcArgs{}, err
-      }
-      result.Ptr = uintptr(dataPtr)
-    case 5:
-      err = decoder.DecodeInt64(&result.Fifth)
-      if err != nil {
-        return types.IpcArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Call)
+			if err != nil {
+				return types.IpcArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.First)
+			if err != nil {
+				return types.IpcArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Second)
+			if err != nil {
+				return types.IpcArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Third)
+			if err != nil {
+				return types.IpcArgs{}, err
+			}
+		case 4:
+			var dataPtr uint64
+			err = decoder.DecodeUint64(&dataPtr)
+			if err != nil {
+				return types.IpcArgs{}, err
+			}
+			result.Ptr = uintptr(dataPtr)
+		case 5:
+			err = decoder.DecodeInt64(&result.Fifth)
+			if err != nil {
+				return types.IpcArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSigreturnArgs(decoder *Decoder) (types.SigreturnArgs, error) {
-  return types.SigreturnArgs{}, nil
+	return types.SigreturnArgs{}, nil
 }
 
 func ParseSigprocmaskArgs(decoder *Decoder) (types.SigprocmaskArgs, error) {
-  var result types.SigprocmaskArgs
-  var err error
+	var result types.SigprocmaskArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SigprocmaskArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SigprocmaskArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SigprocmaskArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SigprocmaskArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.How)
-      if err != nil {
-        return types.SigprocmaskArgs{}, err
-      }
-    case 1:
-      var dataSet uint64
-      err = decoder.DecodeUint64(&dataSet)
-      if err != nil {
-        return types.SigprocmaskArgs{}, err
-      }
-      result.Set = uintptr(dataSet)
-    case 2:
-      var dataOldset uint64
-      err = decoder.DecodeUint64(&dataOldset)
-      if err != nil {
-        return types.SigprocmaskArgs{}, err
-      }
-      result.Oldset = uintptr(dataOldset)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.How)
+			if err != nil {
+				return types.SigprocmaskArgs{}, err
+			}
+		case 1:
+			var dataSet uint64
+			err = decoder.DecodeUint64(&dataSet)
+			if err != nil {
+				return types.SigprocmaskArgs{}, err
+			}
+			result.Set = uintptr(dataSet)
+		case 2:
+			var dataOldset uint64
+			err = decoder.DecodeUint64(&dataOldset)
+			if err != nil {
+				return types.SigprocmaskArgs{}, err
+			}
+			result.Oldset = uintptr(dataOldset)
+		}
+	}
+	return result, nil
 }
 
 func ParseBdflushArgs(decoder *Decoder) (types.BdflushArgs, error) {
-  return types.BdflushArgs{}, nil
+	return types.BdflushArgs{}, nil
 }
 
 func ParseAfs_syscallArgs(decoder *Decoder) (types.Afs_syscallArgs, error) {
-  return types.Afs_syscallArgs{}, nil
+	return types.Afs_syscallArgs{}, nil
 }
 
 func ParseLlseekArgs(decoder *Decoder) (types.LlseekArgs, error) {
-  var result types.LlseekArgs
-  var err error
+	var result types.LlseekArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LlseekArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LlseekArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LlseekArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LlseekArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Fd)
-      if err != nil {
-        return types.LlseekArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.OffsetHigh)
-      if err != nil {
-        return types.LlseekArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.OffsetLow)
-      if err != nil {
-        return types.LlseekArgs{}, err
-      }
-    case 3:
-      var dataResult uint64
-      err = decoder.DecodeUint64(&dataResult)
-      if err != nil {
-        return types.LlseekArgs{}, err
-      }
-      result.Result = uintptr(dataResult)
-    case 4:
-      err = decoder.DecodeUint32(&result.Whence)
-      if err != nil {
-        return types.LlseekArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Fd)
+			if err != nil {
+				return types.LlseekArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.OffsetHigh)
+			if err != nil {
+				return types.LlseekArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.OffsetLow)
+			if err != nil {
+				return types.LlseekArgs{}, err
+			}
+		case 3:
+			var dataResult uint64
+			err = decoder.DecodeUint64(&dataResult)
+			if err != nil {
+				return types.LlseekArgs{}, err
+			}
+			result.Result = uintptr(dataResult)
+		case 4:
+			err = decoder.DecodeUint32(&result.Whence)
+			if err != nil {
+				return types.LlseekArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseOldSelectArgs(decoder *Decoder) (types.OldSelectArgs, error) {
-  var result types.OldSelectArgs
-  var err error
+	var result types.OldSelectArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OldSelectArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OldSelectArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OldSelectArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OldSelectArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Nfds)
-      if err != nil {
-        return types.OldSelectArgs{}, err
-      }
-    case 1:
-      var dataReadfds uint64
-      err = decoder.DecodeUint64(&dataReadfds)
-      if err != nil {
-        return types.OldSelectArgs{}, err
-      }
-      result.Readfds = uintptr(dataReadfds)
-    case 2:
-      var dataWritefds uint64
-      err = decoder.DecodeUint64(&dataWritefds)
-      if err != nil {
-        return types.OldSelectArgs{}, err
-      }
-      result.Writefds = uintptr(dataWritefds)
-    case 3:
-      var dataExceptfds uint64
-      err = decoder.DecodeUint64(&dataExceptfds)
-      if err != nil {
-        return types.OldSelectArgs{}, err
-      }
-      result.Exceptfds = uintptr(dataExceptfds)
-    case 4:
-      var dataTimeout uint64
-      err = decoder.DecodeUint64(&dataTimeout)
-      if err != nil {
-        return types.OldSelectArgs{}, err
-      }
-      result.Timeout = uintptr(dataTimeout)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Nfds)
+			if err != nil {
+				return types.OldSelectArgs{}, err
+			}
+		case 1:
+			var dataReadfds uint64
+			err = decoder.DecodeUint64(&dataReadfds)
+			if err != nil {
+				return types.OldSelectArgs{}, err
+			}
+			result.Readfds = uintptr(dataReadfds)
+		case 2:
+			var dataWritefds uint64
+			err = decoder.DecodeUint64(&dataWritefds)
+			if err != nil {
+				return types.OldSelectArgs{}, err
+			}
+			result.Writefds = uintptr(dataWritefds)
+		case 3:
+			var dataExceptfds uint64
+			err = decoder.DecodeUint64(&dataExceptfds)
+			if err != nil {
+				return types.OldSelectArgs{}, err
+			}
+			result.Exceptfds = uintptr(dataExceptfds)
+		case 4:
+			var dataTimeout uint64
+			err = decoder.DecodeUint64(&dataTimeout)
+			if err != nil {
+				return types.OldSelectArgs{}, err
+			}
+			result.Timeout = uintptr(dataTimeout)
+		}
+	}
+	return result, nil
 }
 
 func ParseVm86Args(decoder *Decoder) (types.Vm86Args, error) {
-  var result types.Vm86Args
-  var err error
+	var result types.Vm86Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Vm86Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Vm86Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Vm86Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Vm86Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Fn)
-      if err != nil {
-        return types.Vm86Args{}, err
-      }
-    case 1:
-      var dataV86 uint64
-      err = decoder.DecodeUint64(&dataV86)
-      if err != nil {
-        return types.Vm86Args{}, err
-      }
-      result.V86 = uintptr(dataV86)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Fn)
+			if err != nil {
+				return types.Vm86Args{}, err
+			}
+		case 1:
+			var dataV86 uint64
+			err = decoder.DecodeUint64(&dataV86)
+			if err != nil {
+				return types.Vm86Args{}, err
+			}
+			result.V86 = uintptr(dataV86)
+		}
+	}
+	return result, nil
 }
 
 func ParseOldGetrlimitArgs(decoder *Decoder) (types.OldGetrlimitArgs, error) {
-  var result types.OldGetrlimitArgs
-  var err error
+	var result types.OldGetrlimitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.OldGetrlimitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.OldGetrlimitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.OldGetrlimitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.OldGetrlimitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Resource)
-      if err != nil {
-        return types.OldGetrlimitArgs{}, err
-      }
-    case 1:
-      var dataRlim uint64
-      err = decoder.DecodeUint64(&dataRlim)
-      if err != nil {
-        return types.OldGetrlimitArgs{}, err
-      }
-      result.Rlim = uintptr(dataRlim)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Resource)
+			if err != nil {
+				return types.OldGetrlimitArgs{}, err
+			}
+		case 1:
+			var dataRlim uint64
+			err = decoder.DecodeUint64(&dataRlim)
+			if err != nil {
+				return types.OldGetrlimitArgs{}, err
+			}
+			result.Rlim = uintptr(dataRlim)
+		}
+	}
+	return result, nil
 }
 
 func ParseMmap2Args(decoder *Decoder) (types.Mmap2Args, error) {
-  var result types.Mmap2Args
-  var err error
+	var result types.Mmap2Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Mmap2Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Mmap2Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Mmap2Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Mmap2Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Addr)
-      if err != nil {
-        return types.Mmap2Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.Mmap2Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Prot)
-      if err != nil {
-        return types.Mmap2Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.Mmap2Args{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Fd)
-      if err != nil {
-        return types.Mmap2Args{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.Pgoffset)
-      if err != nil {
-        return types.Mmap2Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Addr)
+			if err != nil {
+				return types.Mmap2Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.Mmap2Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Prot)
+			if err != nil {
+				return types.Mmap2Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.Mmap2Args{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Fd)
+			if err != nil {
+				return types.Mmap2Args{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.Pgoffset)
+			if err != nil {
+				return types.Mmap2Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTruncate64Args(decoder *Decoder) (types.Truncate64Args, error) {
-  var result types.Truncate64Args
-  var err error
+	var result types.Truncate64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Truncate64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Truncate64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Truncate64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Truncate64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Truncate64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.Truncate64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Truncate64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.Truncate64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFtruncate64Args(decoder *Decoder) (types.Ftruncate64Args, error) {
-  var result types.Ftruncate64Args
-  var err error
+	var result types.Ftruncate64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Ftruncate64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Ftruncate64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Ftruncate64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Ftruncate64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Ftruncate64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.Ftruncate64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Ftruncate64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.Ftruncate64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseStat64Args(decoder *Decoder) (types.Stat64Args, error) {
-  var result types.Stat64Args
-  var err error
+	var result types.Stat64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Stat64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Stat64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Stat64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Stat64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Stat64Args{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.Stat64Args{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Stat64Args{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.Stat64Args{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseLstat64Args(decoder *Decoder) (types.Lstat64Args, error) {
-  var result types.Lstat64Args
-  var err error
+	var result types.Lstat64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Lstat64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Lstat64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Lstat64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Lstat64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Lstat64Args{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.Lstat64Args{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Lstat64Args{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.Lstat64Args{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseFstat64Args(decoder *Decoder) (types.Fstat64Args, error) {
-  var result types.Fstat64Args
-  var err error
+	var result types.Fstat64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Fstat64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Fstat64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Fstat64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Fstat64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Fstat64Args{}, err
-      }
-    case 1:
-      var dataStatbuf uint64
-      err = decoder.DecodeUint64(&dataStatbuf)
-      if err != nil {
-        return types.Fstat64Args{}, err
-      }
-      result.Statbuf = uintptr(dataStatbuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Fstat64Args{}, err
+			}
+		case 1:
+			var dataStatbuf uint64
+			err = decoder.DecodeUint64(&dataStatbuf)
+			if err != nil {
+				return types.Fstat64Args{}, err
+			}
+			result.Statbuf = uintptr(dataStatbuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseLchown16Args(decoder *Decoder) (types.Lchown16Args, error) {
-  var result types.Lchown16Args
-  var err error
+	var result types.Lchown16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Lchown16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Lchown16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Lchown16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Lchown16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Lchown16Args{}, err
-      }
-    case 1:
-      var dataOwner uint64
-      err = decoder.DecodeUint64(&dataOwner)
-      if err != nil {
-        return types.Lchown16Args{}, err
-      }
-      result.Owner = uintptr(dataOwner)
-    case 2:
-      var dataGroup uint64
-      err = decoder.DecodeUint64(&dataGroup)
-      if err != nil {
-        return types.Lchown16Args{}, err
-      }
-      result.Group = uintptr(dataGroup)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Lchown16Args{}, err
+			}
+		case 1:
+			var dataOwner uint64
+			err = decoder.DecodeUint64(&dataOwner)
+			if err != nil {
+				return types.Lchown16Args{}, err
+			}
+			result.Owner = uintptr(dataOwner)
+		case 2:
+			var dataGroup uint64
+			err = decoder.DecodeUint64(&dataGroup)
+			if err != nil {
+				return types.Lchown16Args{}, err
+			}
+			result.Group = uintptr(dataGroup)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetuid16Args(decoder *Decoder) (types.Getuid16Args, error) {
-  return types.Getuid16Args{}, nil
+	return types.Getuid16Args{}, nil
 }
 
 func ParseGetgid16Args(decoder *Decoder) (types.Getgid16Args, error) {
-  return types.Getgid16Args{}, nil
+	return types.Getgid16Args{}, nil
 }
 
 func ParseGeteuid16Args(decoder *Decoder) (types.Geteuid16Args, error) {
-  return types.Geteuid16Args{}, nil
+	return types.Geteuid16Args{}, nil
 }
 
 func ParseGetegid16Args(decoder *Decoder) (types.Getegid16Args, error) {
-  return types.Getegid16Args{}, nil
+	return types.Getegid16Args{}, nil
 }
 
 func ParseSetreuid16Args(decoder *Decoder) (types.Setreuid16Args, error) {
-  var result types.Setreuid16Args
-  var err error
+	var result types.Setreuid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setreuid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setreuid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setreuid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setreuid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRuid uint64
-      err = decoder.DecodeUint64(&dataRuid)
-      if err != nil {
-        return types.Setreuid16Args{}, err
-      }
-      result.Ruid = uintptr(dataRuid)
-    case 1:
-      var dataEuid uint64
-      err = decoder.DecodeUint64(&dataEuid)
-      if err != nil {
-        return types.Setreuid16Args{}, err
-      }
-      result.Euid = uintptr(dataEuid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRuid uint64
+			err = decoder.DecodeUint64(&dataRuid)
+			if err != nil {
+				return types.Setreuid16Args{}, err
+			}
+			result.Ruid = uintptr(dataRuid)
+		case 1:
+			var dataEuid uint64
+			err = decoder.DecodeUint64(&dataEuid)
+			if err != nil {
+				return types.Setreuid16Args{}, err
+			}
+			result.Euid = uintptr(dataEuid)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetregid16Args(decoder *Decoder) (types.Setregid16Args, error) {
-  var result types.Setregid16Args
-  var err error
+	var result types.Setregid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setregid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setregid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setregid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setregid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRgid uint64
-      err = decoder.DecodeUint64(&dataRgid)
-      if err != nil {
-        return types.Setregid16Args{}, err
-      }
-      result.Rgid = uintptr(dataRgid)
-    case 1:
-      var dataEgid uint64
-      err = decoder.DecodeUint64(&dataEgid)
-      if err != nil {
-        return types.Setregid16Args{}, err
-      }
-      result.Egid = uintptr(dataEgid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRgid uint64
+			err = decoder.DecodeUint64(&dataRgid)
+			if err != nil {
+				return types.Setregid16Args{}, err
+			}
+			result.Rgid = uintptr(dataRgid)
+		case 1:
+			var dataEgid uint64
+			err = decoder.DecodeUint64(&dataEgid)
+			if err != nil {
+				return types.Setregid16Args{}, err
+			}
+			result.Egid = uintptr(dataEgid)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetgroups16Args(decoder *Decoder) (types.Getgroups16Args, error) {
-  var result types.Getgroups16Args
-  var err error
+	var result types.Getgroups16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Getgroups16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Getgroups16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Getgroups16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Getgroups16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Size)
-      if err != nil {
-        return types.Getgroups16Args{}, err
-      }
-    case 1:
-      var dataList uint64
-      err = decoder.DecodeUint64(&dataList)
-      if err != nil {
-        return types.Getgroups16Args{}, err
-      }
-      result.List = uintptr(dataList)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Size)
+			if err != nil {
+				return types.Getgroups16Args{}, err
+			}
+		case 1:
+			var dataList uint64
+			err = decoder.DecodeUint64(&dataList)
+			if err != nil {
+				return types.Getgroups16Args{}, err
+			}
+			result.List = uintptr(dataList)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetgroups16Args(decoder *Decoder) (types.Setgroups16Args, error) {
-  var result types.Setgroups16Args
-  var err error
+	var result types.Setgroups16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setgroups16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setgroups16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setgroups16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setgroups16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Size)
-      if err != nil {
-        return types.Setgroups16Args{}, err
-      }
-    case 1:
-      var dataList uint64
-      err = decoder.DecodeUint64(&dataList)
-      if err != nil {
-        return types.Setgroups16Args{}, err
-      }
-      result.List = uintptr(dataList)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Size)
+			if err != nil {
+				return types.Setgroups16Args{}, err
+			}
+		case 1:
+			var dataList uint64
+			err = decoder.DecodeUint64(&dataList)
+			if err != nil {
+				return types.Setgroups16Args{}, err
+			}
+			result.List = uintptr(dataList)
+		}
+	}
+	return result, nil
 }
 
 func ParseFchown16Args(decoder *Decoder) (types.Fchown16Args, error) {
-  var result types.Fchown16Args
-  var err error
+	var result types.Fchown16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Fchown16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Fchown16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Fchown16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Fchown16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Fd)
-      if err != nil {
-        return types.Fchown16Args{}, err
-      }
-    case 1:
-      var dataUser uint64
-      err = decoder.DecodeUint64(&dataUser)
-      if err != nil {
-        return types.Fchown16Args{}, err
-      }
-      result.User = uintptr(dataUser)
-    case 2:
-      var dataGroup uint64
-      err = decoder.DecodeUint64(&dataGroup)
-      if err != nil {
-        return types.Fchown16Args{}, err
-      }
-      result.Group = uintptr(dataGroup)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Fd)
+			if err != nil {
+				return types.Fchown16Args{}, err
+			}
+		case 1:
+			var dataUser uint64
+			err = decoder.DecodeUint64(&dataUser)
+			if err != nil {
+				return types.Fchown16Args{}, err
+			}
+			result.User = uintptr(dataUser)
+		case 2:
+			var dataGroup uint64
+			err = decoder.DecodeUint64(&dataGroup)
+			if err != nil {
+				return types.Fchown16Args{}, err
+			}
+			result.Group = uintptr(dataGroup)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetresuid16Args(decoder *Decoder) (types.Setresuid16Args, error) {
-  var result types.Setresuid16Args
-  var err error
+	var result types.Setresuid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setresuid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setresuid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setresuid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setresuid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRuid uint64
-      err = decoder.DecodeUint64(&dataRuid)
-      if err != nil {
-        return types.Setresuid16Args{}, err
-      }
-      result.Ruid = uintptr(dataRuid)
-    case 1:
-      var dataEuid uint64
-      err = decoder.DecodeUint64(&dataEuid)
-      if err != nil {
-        return types.Setresuid16Args{}, err
-      }
-      result.Euid = uintptr(dataEuid)
-    case 2:
-      var dataSuid uint64
-      err = decoder.DecodeUint64(&dataSuid)
-      if err != nil {
-        return types.Setresuid16Args{}, err
-      }
-      result.Suid = uintptr(dataSuid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRuid uint64
+			err = decoder.DecodeUint64(&dataRuid)
+			if err != nil {
+				return types.Setresuid16Args{}, err
+			}
+			result.Ruid = uintptr(dataRuid)
+		case 1:
+			var dataEuid uint64
+			err = decoder.DecodeUint64(&dataEuid)
+			if err != nil {
+				return types.Setresuid16Args{}, err
+			}
+			result.Euid = uintptr(dataEuid)
+		case 2:
+			var dataSuid uint64
+			err = decoder.DecodeUint64(&dataSuid)
+			if err != nil {
+				return types.Setresuid16Args{}, err
+			}
+			result.Suid = uintptr(dataSuid)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetresuid16Args(decoder *Decoder) (types.Getresuid16Args, error) {
-  var result types.Getresuid16Args
-  var err error
+	var result types.Getresuid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Getresuid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Getresuid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Getresuid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Getresuid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRuid uint64
-      err = decoder.DecodeUint64(&dataRuid)
-      if err != nil {
-        return types.Getresuid16Args{}, err
-      }
-      result.Ruid = uintptr(dataRuid)
-    case 1:
-      var dataEuid uint64
-      err = decoder.DecodeUint64(&dataEuid)
-      if err != nil {
-        return types.Getresuid16Args{}, err
-      }
-      result.Euid = uintptr(dataEuid)
-    case 2:
-      var dataSuid uint64
-      err = decoder.DecodeUint64(&dataSuid)
-      if err != nil {
-        return types.Getresuid16Args{}, err
-      }
-      result.Suid = uintptr(dataSuid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRuid uint64
+			err = decoder.DecodeUint64(&dataRuid)
+			if err != nil {
+				return types.Getresuid16Args{}, err
+			}
+			result.Ruid = uintptr(dataRuid)
+		case 1:
+			var dataEuid uint64
+			err = decoder.DecodeUint64(&dataEuid)
+			if err != nil {
+				return types.Getresuid16Args{}, err
+			}
+			result.Euid = uintptr(dataEuid)
+		case 2:
+			var dataSuid uint64
+			err = decoder.DecodeUint64(&dataSuid)
+			if err != nil {
+				return types.Getresuid16Args{}, err
+			}
+			result.Suid = uintptr(dataSuid)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetresgid16Args(decoder *Decoder) (types.Setresgid16Args, error) {
-  var result types.Setresgid16Args
-  var err error
+	var result types.Setresgid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setresgid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setresgid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setresgid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setresgid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRgid uint64
-      err = decoder.DecodeUint64(&dataRgid)
-      if err != nil {
-        return types.Setresgid16Args{}, err
-      }
-      result.Rgid = uintptr(dataRgid)
-    case 1:
-      var dataEuid uint64
-      err = decoder.DecodeUint64(&dataEuid)
-      if err != nil {
-        return types.Setresgid16Args{}, err
-      }
-      result.Euid = uintptr(dataEuid)
-    case 2:
-      var dataSuid uint64
-      err = decoder.DecodeUint64(&dataSuid)
-      if err != nil {
-        return types.Setresgid16Args{}, err
-      }
-      result.Suid = uintptr(dataSuid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRgid uint64
+			err = decoder.DecodeUint64(&dataRgid)
+			if err != nil {
+				return types.Setresgid16Args{}, err
+			}
+			result.Rgid = uintptr(dataRgid)
+		case 1:
+			var dataEuid uint64
+			err = decoder.DecodeUint64(&dataEuid)
+			if err != nil {
+				return types.Setresgid16Args{}, err
+			}
+			result.Euid = uintptr(dataEuid)
+		case 2:
+			var dataSuid uint64
+			err = decoder.DecodeUint64(&dataSuid)
+			if err != nil {
+				return types.Setresgid16Args{}, err
+			}
+			result.Suid = uintptr(dataSuid)
+		}
+	}
+	return result, nil
 }
 
 func ParseGetresgid16Args(decoder *Decoder) (types.Getresgid16Args, error) {
-  var result types.Getresgid16Args
-  var err error
+	var result types.Getresgid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Getresgid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Getresgid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Getresgid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Getresgid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataRgid uint64
-      err = decoder.DecodeUint64(&dataRgid)
-      if err != nil {
-        return types.Getresgid16Args{}, err
-      }
-      result.Rgid = uintptr(dataRgid)
-    case 1:
-      var dataEgid uint64
-      err = decoder.DecodeUint64(&dataEgid)
-      if err != nil {
-        return types.Getresgid16Args{}, err
-      }
-      result.Egid = uintptr(dataEgid)
-    case 2:
-      var dataSgid uint64
-      err = decoder.DecodeUint64(&dataSgid)
-      if err != nil {
-        return types.Getresgid16Args{}, err
-      }
-      result.Sgid = uintptr(dataSgid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataRgid uint64
+			err = decoder.DecodeUint64(&dataRgid)
+			if err != nil {
+				return types.Getresgid16Args{}, err
+			}
+			result.Rgid = uintptr(dataRgid)
+		case 1:
+			var dataEgid uint64
+			err = decoder.DecodeUint64(&dataEgid)
+			if err != nil {
+				return types.Getresgid16Args{}, err
+			}
+			result.Egid = uintptr(dataEgid)
+		case 2:
+			var dataSgid uint64
+			err = decoder.DecodeUint64(&dataSgid)
+			if err != nil {
+				return types.Getresgid16Args{}, err
+			}
+			result.Sgid = uintptr(dataSgid)
+		}
+	}
+	return result, nil
 }
 
 func ParseChown16Args(decoder *Decoder) (types.Chown16Args, error) {
-  var result types.Chown16Args
-  var err error
+	var result types.Chown16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Chown16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Chown16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Chown16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Chown16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Chown16Args{}, err
-      }
-    case 1:
-      var dataOwner uint64
-      err = decoder.DecodeUint64(&dataOwner)
-      if err != nil {
-        return types.Chown16Args{}, err
-      }
-      result.Owner = uintptr(dataOwner)
-    case 2:
-      var dataGroup uint64
-      err = decoder.DecodeUint64(&dataGroup)
-      if err != nil {
-        return types.Chown16Args{}, err
-      }
-      result.Group = uintptr(dataGroup)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Chown16Args{}, err
+			}
+		case 1:
+			var dataOwner uint64
+			err = decoder.DecodeUint64(&dataOwner)
+			if err != nil {
+				return types.Chown16Args{}, err
+			}
+			result.Owner = uintptr(dataOwner)
+		case 2:
+			var dataGroup uint64
+			err = decoder.DecodeUint64(&dataGroup)
+			if err != nil {
+				return types.Chown16Args{}, err
+			}
+			result.Group = uintptr(dataGroup)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetuid16Args(decoder *Decoder) (types.Setuid16Args, error) {
-  var result types.Setuid16Args
-  var err error
+	var result types.Setuid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setuid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setuid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setuid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setuid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataUid uint64
-      err = decoder.DecodeUint64(&dataUid)
-      if err != nil {
-        return types.Setuid16Args{}, err
-      }
-      result.Uid = uintptr(dataUid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataUid uint64
+			err = decoder.DecodeUint64(&dataUid)
+			if err != nil {
+				return types.Setuid16Args{}, err
+			}
+			result.Uid = uintptr(dataUid)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetgid16Args(decoder *Decoder) (types.Setgid16Args, error) {
-  var result types.Setgid16Args
-  var err error
+	var result types.Setgid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setgid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setgid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setgid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setgid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataGid uint64
-      err = decoder.DecodeUint64(&dataGid)
-      if err != nil {
-        return types.Setgid16Args{}, err
-      }
-      result.Gid = uintptr(dataGid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataGid uint64
+			err = decoder.DecodeUint64(&dataGid)
+			if err != nil {
+				return types.Setgid16Args{}, err
+			}
+			result.Gid = uintptr(dataGid)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetfsuid16Args(decoder *Decoder) (types.Setfsuid16Args, error) {
-  var result types.Setfsuid16Args
-  var err error
+	var result types.Setfsuid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setfsuid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setfsuid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setfsuid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setfsuid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataFsuid uint64
-      err = decoder.DecodeUint64(&dataFsuid)
-      if err != nil {
-        return types.Setfsuid16Args{}, err
-      }
-      result.Fsuid = uintptr(dataFsuid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataFsuid uint64
+			err = decoder.DecodeUint64(&dataFsuid)
+			if err != nil {
+				return types.Setfsuid16Args{}, err
+			}
+			result.Fsuid = uintptr(dataFsuid)
+		}
+	}
+	return result, nil
 }
 
 func ParseSetfsgid16Args(decoder *Decoder) (types.Setfsgid16Args, error) {
-  var result types.Setfsgid16Args
-  var err error
+	var result types.Setfsgid16Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Setfsgid16Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Setfsgid16Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Setfsgid16Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Setfsgid16Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataFsgid uint64
-      err = decoder.DecodeUint64(&dataFsgid)
-      if err != nil {
-        return types.Setfsgid16Args{}, err
-      }
-      result.Fsgid = uintptr(dataFsgid)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataFsgid uint64
+			err = decoder.DecodeUint64(&dataFsgid)
+			if err != nil {
+				return types.Setfsgid16Args{}, err
+			}
+			result.Fsgid = uintptr(dataFsgid)
+		}
+	}
+	return result, nil
 }
 
 func ParseFcntl64Args(decoder *Decoder) (types.Fcntl64Args, error) {
-  var result types.Fcntl64Args
-  var err error
+	var result types.Fcntl64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Fcntl64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Fcntl64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Fcntl64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Fcntl64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Fcntl64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.Fcntl64Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Arg)
-      if err != nil {
-        return types.Fcntl64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Fcntl64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.Fcntl64Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Arg)
+			if err != nil {
+				return types.Fcntl64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSendfile32Args(decoder *Decoder) (types.Sendfile32Args, error) {
-  var result types.Sendfile32Args
-  var err error
+	var result types.Sendfile32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Sendfile32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Sendfile32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Sendfile32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Sendfile32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.OutFd)
-      if err != nil {
-        return types.Sendfile32Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.InFd)
-      if err != nil {
-        return types.Sendfile32Args{}, err
-      }
-    case 2:
-      var dataOffset uint64
-      err = decoder.DecodeUint64(&dataOffset)
-      if err != nil {
-        return types.Sendfile32Args{}, err
-      }
-      result.Offset = uintptr(dataOffset)
-    case 3:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.Sendfile32Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.OutFd)
+			if err != nil {
+				return types.Sendfile32Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.InFd)
+			if err != nil {
+				return types.Sendfile32Args{}, err
+			}
+		case 2:
+			var dataOffset uint64
+			err = decoder.DecodeUint64(&dataOffset)
+			if err != nil {
+				return types.Sendfile32Args{}, err
+			}
+			result.Offset = uintptr(dataOffset)
+		case 3:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.Sendfile32Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseStatfs64Args(decoder *Decoder) (types.Statfs64Args, error) {
-  var result types.Statfs64Args
-  var err error
+	var result types.Statfs64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Statfs64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Statfs64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Statfs64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Statfs64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.Statfs64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Sz)
-      if err != nil {
-        return types.Statfs64Args{}, err
-      }
-    case 2:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.Statfs64Args{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.Statfs64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Sz)
+			if err != nil {
+				return types.Statfs64Args{}, err
+			}
+		case 2:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.Statfs64Args{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseFstatfs64Args(decoder *Decoder) (types.Fstatfs64Args, error) {
-  var result types.Fstatfs64Args
-  var err error
+	var result types.Fstatfs64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Fstatfs64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Fstatfs64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Fstatfs64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Fstatfs64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Fstatfs64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Sz)
-      if err != nil {
-        return types.Fstatfs64Args{}, err
-      }
-    case 2:
-      var dataBuf uint64
-      err = decoder.DecodeUint64(&dataBuf)
-      if err != nil {
-        return types.Fstatfs64Args{}, err
-      }
-      result.Buf = uintptr(dataBuf)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Fstatfs64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Sz)
+			if err != nil {
+				return types.Fstatfs64Args{}, err
+			}
+		case 2:
+			var dataBuf uint64
+			err = decoder.DecodeUint64(&dataBuf)
+			if err != nil {
+				return types.Fstatfs64Args{}, err
+			}
+			result.Buf = uintptr(dataBuf)
+		}
+	}
+	return result, nil
 }
 
 func ParseFadvise64_64Args(decoder *Decoder) (types.Fadvise64_64Args, error) {
-  var result types.Fadvise64_64Args
-  var err error
+	var result types.Fadvise64_64Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Fadvise64_64Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Fadvise64_64Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Fadvise64_64Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Fadvise64_64Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.Fadvise64_64Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Offset)
-      if err != nil {
-        return types.Fadvise64_64Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.Fadvise64_64Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Advice)
-      if err != nil {
-        return types.Fadvise64_64Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.Fadvise64_64Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Offset)
+			if err != nil {
+				return types.Fadvise64_64Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.Fadvise64_64Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Advice)
+			if err != nil {
+				return types.Fadvise64_64Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseClockGettime32Args(decoder *Decoder) (types.ClockGettime32Args, error) {
-  var result types.ClockGettime32Args
-  var err error
+	var result types.ClockGettime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockGettime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockGettime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockGettime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockGettime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.WhichClock)
-      if err != nil {
-        return types.ClockGettime32Args{}, err
-      }
-    case 1:
-      var dataTp uint64
-      err = decoder.DecodeUint64(&dataTp)
-      if err != nil {
-        return types.ClockGettime32Args{}, err
-      }
-      result.Tp = uintptr(dataTp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.WhichClock)
+			if err != nil {
+				return types.ClockGettime32Args{}, err
+			}
+		case 1:
+			var dataTp uint64
+			err = decoder.DecodeUint64(&dataTp)
+			if err != nil {
+				return types.ClockGettime32Args{}, err
+			}
+			result.Tp = uintptr(dataTp)
+		}
+	}
+	return result, nil
 }
 
 func ParseClockSettime32Args(decoder *Decoder) (types.ClockSettime32Args, error) {
-  var result types.ClockSettime32Args
-  var err error
+	var result types.ClockSettime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockSettime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockSettime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockSettime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockSettime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.WhichClock)
-      if err != nil {
-        return types.ClockSettime32Args{}, err
-      }
-    case 1:
-      var dataTp uint64
-      err = decoder.DecodeUint64(&dataTp)
-      if err != nil {
-        return types.ClockSettime32Args{}, err
-      }
-      result.Tp = uintptr(dataTp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.WhichClock)
+			if err != nil {
+				return types.ClockSettime32Args{}, err
+			}
+		case 1:
+			var dataTp uint64
+			err = decoder.DecodeUint64(&dataTp)
+			if err != nil {
+				return types.ClockSettime32Args{}, err
+			}
+			result.Tp = uintptr(dataTp)
+		}
+	}
+	return result, nil
 }
 
 func ParseClockAdjtime64Args(decoder *Decoder) (types.ClockAdjtime64Args, error) {
-  return types.ClockAdjtime64Args{}, nil
+	return types.ClockAdjtime64Args{}, nil
 }
 
 func ParseClockGetresTime32Args(decoder *Decoder) (types.ClockGetresTime32Args, error) {
-  var result types.ClockGetresTime32Args
-  var err error
+	var result types.ClockGetresTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockGetresTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockGetresTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockGetresTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockGetresTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.WhichClock)
-      if err != nil {
-        return types.ClockGetresTime32Args{}, err
-      }
-    case 1:
-      var dataTp uint64
-      err = decoder.DecodeUint64(&dataTp)
-      if err != nil {
-        return types.ClockGetresTime32Args{}, err
-      }
-      result.Tp = uintptr(dataTp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.WhichClock)
+			if err != nil {
+				return types.ClockGetresTime32Args{}, err
+			}
+		case 1:
+			var dataTp uint64
+			err = decoder.DecodeUint64(&dataTp)
+			if err != nil {
+				return types.ClockGetresTime32Args{}, err
+			}
+			result.Tp = uintptr(dataTp)
+		}
+	}
+	return result, nil
 }
 
 func ParseClockNanosleepTime32Args(decoder *Decoder) (types.ClockNanosleepTime32Args, error) {
-  var result types.ClockNanosleepTime32Args
-  var err error
+	var result types.ClockNanosleepTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ClockNanosleepTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ClockNanosleepTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ClockNanosleepTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ClockNanosleepTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.WhichClock)
-      if err != nil {
-        return types.ClockNanosleepTime32Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.ClockNanosleepTime32Args{}, err
-      }
-    case 2:
-      var dataRqtp uint64
-      err = decoder.DecodeUint64(&dataRqtp)
-      if err != nil {
-        return types.ClockNanosleepTime32Args{}, err
-      }
-      result.Rqtp = uintptr(dataRqtp)
-    case 3:
-      var dataRmtp uint64
-      err = decoder.DecodeUint64(&dataRmtp)
-      if err != nil {
-        return types.ClockNanosleepTime32Args{}, err
-      }
-      result.Rmtp = uintptr(dataRmtp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.WhichClock)
+			if err != nil {
+				return types.ClockNanosleepTime32Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.ClockNanosleepTime32Args{}, err
+			}
+		case 2:
+			var dataRqtp uint64
+			err = decoder.DecodeUint64(&dataRqtp)
+			if err != nil {
+				return types.ClockNanosleepTime32Args{}, err
+			}
+			result.Rqtp = uintptr(dataRqtp)
+		case 3:
+			var dataRmtp uint64
+			err = decoder.DecodeUint64(&dataRmtp)
+			if err != nil {
+				return types.ClockNanosleepTime32Args{}, err
+			}
+			result.Rmtp = uintptr(dataRmtp)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerGettime32Args(decoder *Decoder) (types.TimerGettime32Args, error) {
-  var result types.TimerGettime32Args
-  var err error
+	var result types.TimerGettime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerGettime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerGettime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerGettime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerGettime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.TimerId)
-      if err != nil {
-        return types.TimerGettime32Args{}, err
-      }
-    case 1:
-      var dataSetting uint64
-      err = decoder.DecodeUint64(&dataSetting)
-      if err != nil {
-        return types.TimerGettime32Args{}, err
-      }
-      result.Setting = uintptr(dataSetting)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.TimerId)
+			if err != nil {
+				return types.TimerGettime32Args{}, err
+			}
+		case 1:
+			var dataSetting uint64
+			err = decoder.DecodeUint64(&dataSetting)
+			if err != nil {
+				return types.TimerGettime32Args{}, err
+			}
+			result.Setting = uintptr(dataSetting)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerSettime32Args(decoder *Decoder) (types.TimerSettime32Args, error) {
-  var result types.TimerSettime32Args
-  var err error
+	var result types.TimerSettime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerSettime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerSettime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerSettime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerSettime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.TimerId)
-      if err != nil {
-        return types.TimerSettime32Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.TimerSettime32Args{}, err
-      }
-    case 2:
-      var dataNew uint64
-      err = decoder.DecodeUint64(&dataNew)
-      if err != nil {
-        return types.TimerSettime32Args{}, err
-      }
-      result.New = uintptr(dataNew)
-    case 3:
-      var dataOld uint64
-      err = decoder.DecodeUint64(&dataOld)
-      if err != nil {
-        return types.TimerSettime32Args{}, err
-      }
-      result.Old = uintptr(dataOld)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.TimerId)
+			if err != nil {
+				return types.TimerSettime32Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.TimerSettime32Args{}, err
+			}
+		case 2:
+			var dataNew uint64
+			err = decoder.DecodeUint64(&dataNew)
+			if err != nil {
+				return types.TimerSettime32Args{}, err
+			}
+			result.New = uintptr(dataNew)
+		case 3:
+			var dataOld uint64
+			err = decoder.DecodeUint64(&dataOld)
+			if err != nil {
+				return types.TimerSettime32Args{}, err
+			}
+			result.Old = uintptr(dataOld)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerfdGettime32Args(decoder *Decoder) (types.TimerfdGettime32Args, error) {
-  var result types.TimerfdGettime32Args
-  var err error
+	var result types.TimerfdGettime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerfdGettime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerfdGettime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerfdGettime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerfdGettime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Ufd)
-      if err != nil {
-        return types.TimerfdGettime32Args{}, err
-      }
-    case 1:
-      var dataOtmr uint64
-      err = decoder.DecodeUint64(&dataOtmr)
-      if err != nil {
-        return types.TimerfdGettime32Args{}, err
-      }
-      result.Otmr = uintptr(dataOtmr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Ufd)
+			if err != nil {
+				return types.TimerfdGettime32Args{}, err
+			}
+		case 1:
+			var dataOtmr uint64
+			err = decoder.DecodeUint64(&dataOtmr)
+			if err != nil {
+				return types.TimerfdGettime32Args{}, err
+			}
+			result.Otmr = uintptr(dataOtmr)
+		}
+	}
+	return result, nil
 }
 
 func ParseTimerfdSettime32Args(decoder *Decoder) (types.TimerfdSettime32Args, error) {
-  var result types.TimerfdSettime32Args
-  var err error
+	var result types.TimerfdSettime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TimerfdSettime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TimerfdSettime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TimerfdSettime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TimerfdSettime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Ufd)
-      if err != nil {
-        return types.TimerfdSettime32Args{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.TimerfdSettime32Args{}, err
-      }
-    case 2:
-      var dataUtmr uint64
-      err = decoder.DecodeUint64(&dataUtmr)
-      if err != nil {
-        return types.TimerfdSettime32Args{}, err
-      }
-      result.Utmr = uintptr(dataUtmr)
-    case 3:
-      var dataOtmr uint64
-      err = decoder.DecodeUint64(&dataOtmr)
-      if err != nil {
-        return types.TimerfdSettime32Args{}, err
-      }
-      result.Otmr = uintptr(dataOtmr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Ufd)
+			if err != nil {
+				return types.TimerfdSettime32Args{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.TimerfdSettime32Args{}, err
+			}
+		case 2:
+			var dataUtmr uint64
+			err = decoder.DecodeUint64(&dataUtmr)
+			if err != nil {
+				return types.TimerfdSettime32Args{}, err
+			}
+			result.Utmr = uintptr(dataUtmr)
+		case 3:
+			var dataOtmr uint64
+			err = decoder.DecodeUint64(&dataOtmr)
+			if err != nil {
+				return types.TimerfdSettime32Args{}, err
+			}
+			result.Otmr = uintptr(dataOtmr)
+		}
+	}
+	return result, nil
 }
 
 func ParseUtimensatTime32Args(decoder *Decoder) (types.UtimensatTime32Args, error) {
-  var result types.UtimensatTime32Args
-  var err error
+	var result types.UtimensatTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.UtimensatTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.UtimensatTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.UtimensatTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.UtimensatTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Dfd)
-      if err != nil {
-        return types.UtimensatTime32Args{}, err
-      }
-    case 1:
-      result.Filename, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.UtimensatTime32Args{}, err
-      }
-    case 2:
-      var dataT uint64
-      err = decoder.DecodeUint64(&dataT)
-      if err != nil {
-        return types.UtimensatTime32Args{}, err
-      }
-      result.T = uintptr(dataT)
-    case 3:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.UtimensatTime32Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Dfd)
+			if err != nil {
+				return types.UtimensatTime32Args{}, err
+			}
+		case 1:
+			result.Filename, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.UtimensatTime32Args{}, err
+			}
+		case 2:
+			var dataT uint64
+			err = decoder.DecodeUint64(&dataT)
+			if err != nil {
+				return types.UtimensatTime32Args{}, err
+			}
+			result.T = uintptr(dataT)
+		case 3:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.UtimensatTime32Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePselect6Time32Args(decoder *Decoder) (types.Pselect6Time32Args, error) {
-  var result types.Pselect6Time32Args
-  var err error
+	var result types.Pselect6Time32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.Pselect6Time32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.Pselect6Time32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.Pselect6Time32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.Pselect6Time32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.N)
-      if err != nil {
-        return types.Pselect6Time32Args{}, err
-      }
-    case 1:
-      var dataInp uint64
-      err = decoder.DecodeUint64(&dataInp)
-      if err != nil {
-        return types.Pselect6Time32Args{}, err
-      }
-      result.Inp = uintptr(dataInp)
-    case 2:
-      var dataOutp uint64
-      err = decoder.DecodeUint64(&dataOutp)
-      if err != nil {
-        return types.Pselect6Time32Args{}, err
-      }
-      result.Outp = uintptr(dataOutp)
-    case 3:
-      var dataExp uint64
-      err = decoder.DecodeUint64(&dataExp)
-      if err != nil {
-        return types.Pselect6Time32Args{}, err
-      }
-      result.Exp = uintptr(dataExp)
-    case 4:
-      var dataTsp uint64
-      err = decoder.DecodeUint64(&dataTsp)
-      if err != nil {
-        return types.Pselect6Time32Args{}, err
-      }
-      result.Tsp = uintptr(dataTsp)
-    case 5:
-      var dataSig uint64
-      err = decoder.DecodeUint64(&dataSig)
-      if err != nil {
-        return types.Pselect6Time32Args{}, err
-      }
-      result.Sig = uintptr(dataSig)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.N)
+			if err != nil {
+				return types.Pselect6Time32Args{}, err
+			}
+		case 1:
+			var dataInp uint64
+			err = decoder.DecodeUint64(&dataInp)
+			if err != nil {
+				return types.Pselect6Time32Args{}, err
+			}
+			result.Inp = uintptr(dataInp)
+		case 2:
+			var dataOutp uint64
+			err = decoder.DecodeUint64(&dataOutp)
+			if err != nil {
+				return types.Pselect6Time32Args{}, err
+			}
+			result.Outp = uintptr(dataOutp)
+		case 3:
+			var dataExp uint64
+			err = decoder.DecodeUint64(&dataExp)
+			if err != nil {
+				return types.Pselect6Time32Args{}, err
+			}
+			result.Exp = uintptr(dataExp)
+		case 4:
+			var dataTsp uint64
+			err = decoder.DecodeUint64(&dataTsp)
+			if err != nil {
+				return types.Pselect6Time32Args{}, err
+			}
+			result.Tsp = uintptr(dataTsp)
+		case 5:
+			var dataSig uint64
+			err = decoder.DecodeUint64(&dataSig)
+			if err != nil {
+				return types.Pselect6Time32Args{}, err
+			}
+			result.Sig = uintptr(dataSig)
+		}
+	}
+	return result, nil
 }
 
 func ParsePpollTime32Args(decoder *Decoder) (types.PpollTime32Args, error) {
-  var result types.PpollTime32Args
-  var err error
+	var result types.PpollTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PpollTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PpollTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PpollTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PpollTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataUfds uint64
-      err = decoder.DecodeUint64(&dataUfds)
-      if err != nil {
-        return types.PpollTime32Args{}, err
-      }
-      result.Ufds = uintptr(dataUfds)
-    case 1:
-      err = decoder.DecodeUint32(&result.Nfds)
-      if err != nil {
-        return types.PpollTime32Args{}, err
-      }
-    case 2:
-      var dataTsp uint64
-      err = decoder.DecodeUint64(&dataTsp)
-      if err != nil {
-        return types.PpollTime32Args{}, err
-      }
-      result.Tsp = uintptr(dataTsp)
-    case 3:
-      var dataSigmask uint64
-      err = decoder.DecodeUint64(&dataSigmask)
-      if err != nil {
-        return types.PpollTime32Args{}, err
-      }
-      result.Sigmask = uintptr(dataSigmask)
-    case 4:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.PpollTime32Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataUfds uint64
+			err = decoder.DecodeUint64(&dataUfds)
+			if err != nil {
+				return types.PpollTime32Args{}, err
+			}
+			result.Ufds = uintptr(dataUfds)
+		case 1:
+			err = decoder.DecodeUint32(&result.Nfds)
+			if err != nil {
+				return types.PpollTime32Args{}, err
+			}
+		case 2:
+			var dataTsp uint64
+			err = decoder.DecodeUint64(&dataTsp)
+			if err != nil {
+				return types.PpollTime32Args{}, err
+			}
+			result.Tsp = uintptr(dataTsp)
+		case 3:
+			var dataSigmask uint64
+			err = decoder.DecodeUint64(&dataSigmask)
+			if err != nil {
+				return types.PpollTime32Args{}, err
+			}
+			result.Sigmask = uintptr(dataSigmask)
+		case 4:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.PpollTime32Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseIoPgeteventsTime32Args(decoder *Decoder) (types.IoPgeteventsTime32Args, error) {
-  return types.IoPgeteventsTime32Args{}, nil
+	return types.IoPgeteventsTime32Args{}, nil
 }
 
 func ParseRecvmmsgTime32Args(decoder *Decoder) (types.RecvmmsgTime32Args, error) {
-  var result types.RecvmmsgTime32Args
-  var err error
+	var result types.RecvmmsgTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RecvmmsgTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RecvmmsgTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RecvmmsgTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RecvmmsgTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Fd)
-      if err != nil {
-        return types.RecvmmsgTime32Args{}, err
-      }
-    case 1:
-      var dataMmsg uint64
-      err = decoder.DecodeUint64(&dataMmsg)
-      if err != nil {
-        return types.RecvmmsgTime32Args{}, err
-      }
-      result.Mmsg = uintptr(dataMmsg)
-    case 2:
-      err = decoder.DecodeUint32(&result.Vlen)
-      if err != nil {
-        return types.RecvmmsgTime32Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.RecvmmsgTime32Args{}, err
-      }
-    case 4:
-      var dataTimeout uint64
-      err = decoder.DecodeUint64(&dataTimeout)
-      if err != nil {
-        return types.RecvmmsgTime32Args{}, err
-      }
-      result.Timeout = uintptr(dataTimeout)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Fd)
+			if err != nil {
+				return types.RecvmmsgTime32Args{}, err
+			}
+		case 1:
+			var dataMmsg uint64
+			err = decoder.DecodeUint64(&dataMmsg)
+			if err != nil {
+				return types.RecvmmsgTime32Args{}, err
+			}
+			result.Mmsg = uintptr(dataMmsg)
+		case 2:
+			err = decoder.DecodeUint32(&result.Vlen)
+			if err != nil {
+				return types.RecvmmsgTime32Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.RecvmmsgTime32Args{}, err
+			}
+		case 4:
+			var dataTimeout uint64
+			err = decoder.DecodeUint64(&dataTimeout)
+			if err != nil {
+				return types.RecvmmsgTime32Args{}, err
+			}
+			result.Timeout = uintptr(dataTimeout)
+		}
+	}
+	return result, nil
 }
 
 func ParseMqTimedsendTime32Args(decoder *Decoder) (types.MqTimedsendTime32Args, error) {
-  var result types.MqTimedsendTime32Args
-  var err error
+	var result types.MqTimedsendTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqTimedsendTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqTimedsendTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqTimedsendTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqTimedsendTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Mqdes)
-      if err != nil {
-        return types.MqTimedsendTime32Args{}, err
-      }
-    case 1:
-      result.UMsgPtr, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MqTimedsendTime32Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.MsgLen)
-      if err != nil {
-        return types.MqTimedsendTime32Args{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.MsgPrio)
-      if err != nil {
-        return types.MqTimedsendTime32Args{}, err
-      }
-    case 4:
-      var dataUAbsTimeout uint64
-      err = decoder.DecodeUint64(&dataUAbsTimeout)
-      if err != nil {
-        return types.MqTimedsendTime32Args{}, err
-      }
-      result.UAbsTimeout = uintptr(dataUAbsTimeout)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Mqdes)
+			if err != nil {
+				return types.MqTimedsendTime32Args{}, err
+			}
+		case 1:
+			result.UMsgPtr, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MqTimedsendTime32Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.MsgLen)
+			if err != nil {
+				return types.MqTimedsendTime32Args{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.MsgPrio)
+			if err != nil {
+				return types.MqTimedsendTime32Args{}, err
+			}
+		case 4:
+			var dataUAbsTimeout uint64
+			err = decoder.DecodeUint64(&dataUAbsTimeout)
+			if err != nil {
+				return types.MqTimedsendTime32Args{}, err
+			}
+			result.UAbsTimeout = uintptr(dataUAbsTimeout)
+		}
+	}
+	return result, nil
 }
 
 func ParseMqTimedreceiveTime32Args(decoder *Decoder) (types.MqTimedreceiveTime32Args, error) {
-  var result types.MqTimedreceiveTime32Args
-  var err error
+	var result types.MqTimedreceiveTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MqTimedreceiveTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MqTimedreceiveTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MqTimedreceiveTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MqTimedreceiveTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Mqdes)
-      if err != nil {
-        return types.MqTimedreceiveTime32Args{}, err
-      }
-    case 1:
-      result.UMsgPtr, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MqTimedreceiveTime32Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.MsgLen)
-      if err != nil {
-        return types.MqTimedreceiveTime32Args{}, err
-      }
-    case 3:
-      var dataUMsgPrio uint64
-      err = decoder.DecodeUint64(&dataUMsgPrio)
-      if err != nil {
-        return types.MqTimedreceiveTime32Args{}, err
-      }
-      result.UMsgPrio = uintptr(dataUMsgPrio)
-    case 4:
-      var dataUAbsTimeout uint64
-      err = decoder.DecodeUint64(&dataUAbsTimeout)
-      if err != nil {
-        return types.MqTimedreceiveTime32Args{}, err
-      }
-      result.UAbsTimeout = uintptr(dataUAbsTimeout)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Mqdes)
+			if err != nil {
+				return types.MqTimedreceiveTime32Args{}, err
+			}
+		case 1:
+			result.UMsgPtr, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MqTimedreceiveTime32Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.MsgLen)
+			if err != nil {
+				return types.MqTimedreceiveTime32Args{}, err
+			}
+		case 3:
+			var dataUMsgPrio uint64
+			err = decoder.DecodeUint64(&dataUMsgPrio)
+			if err != nil {
+				return types.MqTimedreceiveTime32Args{}, err
+			}
+			result.UMsgPrio = uintptr(dataUMsgPrio)
+		case 4:
+			var dataUAbsTimeout uint64
+			err = decoder.DecodeUint64(&dataUAbsTimeout)
+			if err != nil {
+				return types.MqTimedreceiveTime32Args{}, err
+			}
+			result.UAbsTimeout = uintptr(dataUAbsTimeout)
+		}
+	}
+	return result, nil
 }
 
 func ParseRtSigtimedwaitTime32Args(decoder *Decoder) (types.RtSigtimedwaitTime32Args, error) {
-  var result types.RtSigtimedwaitTime32Args
-  var err error
+	var result types.RtSigtimedwaitTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RtSigtimedwaitTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RtSigtimedwaitTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RtSigtimedwaitTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RtSigtimedwaitTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataUthese uint64
-      err = decoder.DecodeUint64(&dataUthese)
-      if err != nil {
-        return types.RtSigtimedwaitTime32Args{}, err
-      }
-      result.Uthese = uintptr(dataUthese)
-    case 1:
-      var dataUinfo uint64
-      err = decoder.DecodeUint64(&dataUinfo)
-      if err != nil {
-        return types.RtSigtimedwaitTime32Args{}, err
-      }
-      result.Uinfo = uintptr(dataUinfo)
-    case 2:
-      var dataUts uint64
-      err = decoder.DecodeUint64(&dataUts)
-      if err != nil {
-        return types.RtSigtimedwaitTime32Args{}, err
-      }
-      result.Uts = uintptr(dataUts)
-    case 3:
-      err = decoder.DecodeUint64(&result.Sigsetsize)
-      if err != nil {
-        return types.RtSigtimedwaitTime32Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataUthese uint64
+			err = decoder.DecodeUint64(&dataUthese)
+			if err != nil {
+				return types.RtSigtimedwaitTime32Args{}, err
+			}
+			result.Uthese = uintptr(dataUthese)
+		case 1:
+			var dataUinfo uint64
+			err = decoder.DecodeUint64(&dataUinfo)
+			if err != nil {
+				return types.RtSigtimedwaitTime32Args{}, err
+			}
+			result.Uinfo = uintptr(dataUinfo)
+		case 2:
+			var dataUts uint64
+			err = decoder.DecodeUint64(&dataUts)
+			if err != nil {
+				return types.RtSigtimedwaitTime32Args{}, err
+			}
+			result.Uts = uintptr(dataUts)
+		case 3:
+			err = decoder.DecodeUint64(&result.Sigsetsize)
+			if err != nil {
+				return types.RtSigtimedwaitTime32Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFutexTime32Args(decoder *Decoder) (types.FutexTime32Args, error) {
-  var result types.FutexTime32Args
-  var err error
+	var result types.FutexTime32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FutexTime32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FutexTime32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FutexTime32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FutexTime32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataUaddr uint64
-      err = decoder.DecodeUint64(&dataUaddr)
-      if err != nil {
-        return types.FutexTime32Args{}, err
-      }
-      result.Uaddr = uintptr(dataUaddr)
-    case 1:
-      err = decoder.DecodeInt32(&result.Op)
-      if err != nil {
-        return types.FutexTime32Args{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Val)
-      if err != nil {
-        return types.FutexTime32Args{}, err
-      }
-    case 3:
-      var dataUtime uint64
-      err = decoder.DecodeUint64(&dataUtime)
-      if err != nil {
-        return types.FutexTime32Args{}, err
-      }
-      result.Utime = uintptr(dataUtime)
-    case 4:
-      var dataUaddr2 uint64
-      err = decoder.DecodeUint64(&dataUaddr2)
-      if err != nil {
-        return types.FutexTime32Args{}, err
-      }
-      result.Uaddr2 = uintptr(dataUaddr2)
-    case 5:
-      err = decoder.DecodeUint32(&result.Val3)
-      if err != nil {
-        return types.FutexTime32Args{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataUaddr uint64
+			err = decoder.DecodeUint64(&dataUaddr)
+			if err != nil {
+				return types.FutexTime32Args{}, err
+			}
+			result.Uaddr = uintptr(dataUaddr)
+		case 1:
+			err = decoder.DecodeInt32(&result.Op)
+			if err != nil {
+				return types.FutexTime32Args{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Val)
+			if err != nil {
+				return types.FutexTime32Args{}, err
+			}
+		case 3:
+			var dataUtime uint64
+			err = decoder.DecodeUint64(&dataUtime)
+			if err != nil {
+				return types.FutexTime32Args{}, err
+			}
+			result.Utime = uintptr(dataUtime)
+		case 4:
+			var dataUaddr2 uint64
+			err = decoder.DecodeUint64(&dataUaddr2)
+			if err != nil {
+				return types.FutexTime32Args{}, err
+			}
+			result.Uaddr2 = uintptr(dataUaddr2)
+		case 5:
+			err = decoder.DecodeUint32(&result.Val3)
+			if err != nil {
+				return types.FutexTime32Args{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedRrGetInterval32Args(decoder *Decoder) (types.SchedRrGetInterval32Args, error) {
-  var result types.SchedRrGetInterval32Args
-  var err error
+	var result types.SchedRrGetInterval32Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedRrGetInterval32Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedRrGetInterval32Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedRrGetInterval32Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedRrGetInterval32Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SchedRrGetInterval32Args{}, err
-      }
-    case 1:
-      var dataInterval uint64
-      err = decoder.DecodeUint64(&dataInterval)
-      if err != nil {
-        return types.SchedRrGetInterval32Args{}, err
-      }
-      result.Interval = uintptr(dataInterval)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SchedRrGetInterval32Args{}, err
+			}
+		case 1:
+			var dataInterval uint64
+			err = decoder.DecodeUint64(&dataInterval)
+			if err != nil {
+				return types.SchedRrGetInterval32Args{}, err
+			}
+			result.Interval = uintptr(dataInterval)
+		}
+	}
+	return result, nil
 }
 
 func ParseSysEnterArgs(decoder *Decoder) (types.SysEnterArgs, error) {
-  var result types.SysEnterArgs
-  var err error
+	var result types.SysEnterArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SysEnterArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SysEnterArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SysEnterArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SysEnterArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Syscall)
-      if err != nil {
-        return types.SysEnterArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Syscall)
+			if err != nil {
+				return types.SysEnterArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSysExitArgs(decoder *Decoder) (types.SysExitArgs, error) {
-  var result types.SysExitArgs
-  var err error
+	var result types.SysExitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SysExitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SysExitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SysExitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SysExitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Syscall)
-      if err != nil {
-        return types.SysExitArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Syscall)
+			if err != nil {
+				return types.SysExitArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedProcessForkArgs(decoder *Decoder) (types.SchedProcessForkArgs, error) {
-  var result types.SchedProcessForkArgs
-  var err error
+	var result types.SchedProcessForkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedProcessForkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedProcessForkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedProcessForkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedProcessForkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.ParentTid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.ParentNsTid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.ParentPid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.ParentNsPid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.ChildTid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeInt32(&result.ChildNsTid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeInt32(&result.ChildPid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 7:
-      err = decoder.DecodeInt32(&result.ChildNsPid)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    case 8:
-      err = decoder.DecodeUint64(&result.StartTime)
-      if err != nil {
-        return types.SchedProcessForkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.ParentTid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.ParentNsTid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.ParentPid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.ParentNsPid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.ChildTid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeInt32(&result.ChildNsTid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeInt32(&result.ChildPid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 7:
+			err = decoder.DecodeInt32(&result.ChildNsPid)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		case 8:
+			err = decoder.DecodeUint64(&result.StartTime)
+			if err != nil {
+				return types.SchedProcessForkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedProcessExecArgs(decoder *Decoder) (types.SchedProcessExecArgs, error) {
-  var result types.SchedProcessExecArgs
-  var err error
+	var result types.SchedProcessExecArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedProcessExecArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedProcessExecArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedProcessExecArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedProcessExecArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Cmdpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint16(&result.InodeMode)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 6:
-      result.InterpreterPathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 7:
-      err = decoder.DecodeUint32(&result.InterpreterDev)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 8:
-      err = decoder.DecodeUint64(&result.InterpreterInode)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 9:
-      err = decoder.DecodeUint64(&result.InterpreterCtime)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 10:
-      result.Argv, err = decoder.ReadArgsArrayFromBuff()
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 11:
-      result.Interp, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 12:
-      err = decoder.DecodeUint16(&result.StdinType)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 13:
-      result.StdinPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 14:
-      err = decoder.DecodeInt32(&result.InvokedFromKernel)
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    case 15:
-      result.Env, err = decoder.ReadArgsArrayFromBuff()
-      if err != nil {
-        return types.SchedProcessExecArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Cmdpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint16(&result.InodeMode)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 6:
+			result.InterpreterPathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 7:
+			err = decoder.DecodeUint32(&result.InterpreterDev)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 8:
+			err = decoder.DecodeUint64(&result.InterpreterInode)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 9:
+			err = decoder.DecodeUint64(&result.InterpreterCtime)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 10:
+			result.Argv, err = decoder.ReadArgsArrayFromBuff()
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 11:
+			result.Interp, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 12:
+			err = decoder.DecodeUint16(&result.StdinType)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 13:
+			result.StdinPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 14:
+			err = decoder.DecodeInt32(&result.InvokedFromKernel)
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		case 15:
+			result.Env, err = decoder.ReadArgsArrayFromBuff()
+			if err != nil {
+				return types.SchedProcessExecArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedProcessExitArgs(decoder *Decoder) (types.SchedProcessExitArgs, error) {
-  var result types.SchedProcessExitArgs
-  var err error
+	var result types.SchedProcessExitArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedProcessExitArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedProcessExitArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedProcessExitArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedProcessExitArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt64(&result.ExitCode)
-      if err != nil {
-        return types.SchedProcessExitArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeBool(&result.ProcessGroupExit)
-      if err != nil {
-        return types.SchedProcessExitArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt64(&result.ExitCode)
+			if err != nil {
+				return types.SchedProcessExitArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeBool(&result.ProcessGroupExit)
+			if err != nil {
+				return types.SchedProcessExitArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSchedSwitchArgs(decoder *Decoder) (types.SchedSwitchArgs, error) {
-  var result types.SchedSwitchArgs
-  var err error
+	var result types.SchedSwitchArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SchedSwitchArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SchedSwitchArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SchedSwitchArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SchedSwitchArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Cpu)
-      if err != nil {
-        return types.SchedSwitchArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.PrevTid)
-      if err != nil {
-        return types.SchedSwitchArgs{}, err
-      }
-    case 2:
-      result.PrevComm, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SchedSwitchArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.NextTid)
-      if err != nil {
-        return types.SchedSwitchArgs{}, err
-      }
-    case 4:
-      result.NextComm, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SchedSwitchArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Cpu)
+			if err != nil {
+				return types.SchedSwitchArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.PrevTid)
+			if err != nil {
+				return types.SchedSwitchArgs{}, err
+			}
+		case 2:
+			result.PrevComm, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SchedSwitchArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.NextTid)
+			if err != nil {
+				return types.SchedSwitchArgs{}, err
+			}
+		case 4:
+			result.NextComm, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SchedSwitchArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseProcessOomKilledArgs(decoder *Decoder) (types.ProcessOomKilledArgs, error) {
-  var result types.ProcessOomKilledArgs
-  var err error
+	var result types.ProcessOomKilledArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ProcessOomKilledArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ProcessOomKilledArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ProcessOomKilledArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ProcessOomKilledArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt64(&result.ExitCode)
-      if err != nil {
-        return types.ProcessOomKilledArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeBool(&result.ProcessGroupExit)
-      if err != nil {
-        return types.ProcessOomKilledArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt64(&result.ExitCode)
+			if err != nil {
+				return types.ProcessOomKilledArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeBool(&result.ProcessGroupExit)
+			if err != nil {
+				return types.ProcessOomKilledArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDoExitArgs(decoder *Decoder) (types.DoExitArgs, error) {
-  return types.DoExitArgs{}, nil
+	return types.DoExitArgs{}, nil
 }
 
 func ParseCapCapableArgs(decoder *Decoder) (types.CapCapableArgs, error) {
-  var result types.CapCapableArgs
-  var err error
+	var result types.CapCapableArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CapCapableArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CapCapableArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CapCapableArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CapCapableArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Cap)
-      if err != nil {
-        return types.CapCapableArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Cap)
+			if err != nil {
+				return types.CapCapableArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseVfsWriteArgs(decoder *Decoder) (types.VfsWriteArgs, error) {
-  var result types.VfsWriteArgs
-  var err error
+	var result types.VfsWriteArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.VfsWriteArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.VfsWriteArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.VfsWriteArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.VfsWriteArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.VfsWriteArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.VfsWriteArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.VfsWriteArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.VfsWriteArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Pos)
-      if err != nil {
-        return types.VfsWriteArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.VfsWriteArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.VfsWriteArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.VfsWriteArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.VfsWriteArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Pos)
+			if err != nil {
+				return types.VfsWriteArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseVfsWritevArgs(decoder *Decoder) (types.VfsWritevArgs, error) {
-  var result types.VfsWritevArgs
-  var err error
+	var result types.VfsWritevArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.VfsWritevArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.VfsWritevArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.VfsWritevArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.VfsWritevArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.VfsWritevArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.VfsWritevArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.VfsWritevArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Vlen)
-      if err != nil {
-        return types.VfsWritevArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Pos)
-      if err != nil {
-        return types.VfsWritevArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.VfsWritevArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.VfsWritevArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.VfsWritevArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Vlen)
+			if err != nil {
+				return types.VfsWritevArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Pos)
+			if err != nil {
+				return types.VfsWritevArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMemProtAlertArgs(decoder *Decoder) (types.MemProtAlertArgs, error) {
-  var result types.MemProtAlertArgs
-  var err error
+	var result types.MemProtAlertArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MemProtAlertArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MemProtAlertArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MemProtAlertArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MemProtAlertArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Alert)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    case 1:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 2:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Prot)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeInt32(&result.PrevProt)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    case 5:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    case 7:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    case 8:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.MemProtAlertArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Alert)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		case 1:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 2:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Prot)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeInt32(&result.PrevProt)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		case 5:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		case 7:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		case 8:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.MemProtAlertArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCommitCredsArgs(decoder *Decoder) (types.CommitCredsArgs, error) {
-  var result types.CommitCredsArgs
-  var err error
+	var result types.CommitCredsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CommitCredsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CommitCredsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CommitCredsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CommitCredsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeSlimCred(&result.OldCred)
-      if err != nil {
-        return types.CommitCredsArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeSlimCred(&result.NewCred)
-      if err != nil {
-        return types.CommitCredsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeSlimCred(&result.OldCred)
+			if err != nil {
+				return types.CommitCredsArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeSlimCred(&result.NewCred)
+			if err != nil {
+				return types.CommitCredsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSwitchTaskNSArgs(decoder *Decoder) (types.SwitchTaskNSArgs, error) {
-  var result types.SwitchTaskNSArgs
-  var err error
+	var result types.SwitchTaskNSArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SwitchTaskNSArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SwitchTaskNSArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SwitchTaskNSArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SwitchTaskNSArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.SwitchTaskNSArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.NewMnt)
-      if err != nil {
-        return types.SwitchTaskNSArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.NewPid)
-      if err != nil {
-        return types.SwitchTaskNSArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.NewUts)
-      if err != nil {
-        return types.SwitchTaskNSArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint32(&result.NewIpc)
-      if err != nil {
-        return types.SwitchTaskNSArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint32(&result.NewNet)
-      if err != nil {
-        return types.SwitchTaskNSArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeUint32(&result.NewCgroup)
-      if err != nil {
-        return types.SwitchTaskNSArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.SwitchTaskNSArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.NewMnt)
+			if err != nil {
+				return types.SwitchTaskNSArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.NewPid)
+			if err != nil {
+				return types.SwitchTaskNSArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.NewUts)
+			if err != nil {
+				return types.SwitchTaskNSArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint32(&result.NewIpc)
+			if err != nil {
+				return types.SwitchTaskNSArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint32(&result.NewNet)
+			if err != nil {
+				return types.SwitchTaskNSArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeUint32(&result.NewCgroup)
+			if err != nil {
+				return types.SwitchTaskNSArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseMagicWriteArgs(decoder *Decoder) (types.MagicWriteArgs, error) {
-  var result types.MagicWriteArgs
-  var err error
+	var result types.MagicWriteArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.MagicWriteArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.MagicWriteArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.MagicWriteArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.MagicWriteArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.MagicWriteArgs{}, err
-      }
-    case 1:
-      result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.MagicWrite))
-      if err != nil {
-        return types.MagicWriteArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.MagicWriteArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.MagicWriteArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.MagicWriteArgs{}, err
+			}
+		case 1:
+			result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.MagicWrite))
+			if err != nil {
+				return types.MagicWriteArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.MagicWriteArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.MagicWriteArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCgroupAttachTaskArgs(decoder *Decoder) (types.CgroupAttachTaskArgs, error) {
-  var result types.CgroupAttachTaskArgs
-  var err error
+	var result types.CgroupAttachTaskArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CgroupAttachTaskArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CgroupAttachTaskArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CgroupAttachTaskArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CgroupAttachTaskArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.CgroupPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.CgroupAttachTaskArgs{}, err
-      }
-    case 1:
-      result.Comm, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.CgroupAttachTaskArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Pid)
-      if err != nil {
-        return types.CgroupAttachTaskArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.CgroupPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.CgroupAttachTaskArgs{}, err
+			}
+		case 1:
+			result.Comm, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.CgroupAttachTaskArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Pid)
+			if err != nil {
+				return types.CgroupAttachTaskArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCgroupMkdirArgs(decoder *Decoder) (types.CgroupMkdirArgs, error) {
-  var result types.CgroupMkdirArgs
-  var err error
+	var result types.CgroupMkdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CgroupMkdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CgroupMkdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CgroupMkdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CgroupMkdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.CgroupId)
-      if err != nil {
-        return types.CgroupMkdirArgs{}, err
-      }
-    case 1:
-      result.CgroupPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.CgroupMkdirArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.HierarchyId)
-      if err != nil {
-        return types.CgroupMkdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.CgroupId)
+			if err != nil {
+				return types.CgroupMkdirArgs{}, err
+			}
+		case 1:
+			result.CgroupPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.CgroupMkdirArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.HierarchyId)
+			if err != nil {
+				return types.CgroupMkdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCgroupRmdirArgs(decoder *Decoder) (types.CgroupRmdirArgs, error) {
-  var result types.CgroupRmdirArgs
-  var err error
+	var result types.CgroupRmdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CgroupRmdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CgroupRmdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CgroupRmdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CgroupRmdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.CgroupId)
-      if err != nil {
-        return types.CgroupRmdirArgs{}, err
-      }
-    case 1:
-      result.CgroupPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.CgroupRmdirArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.HierarchyId)
-      if err != nil {
-        return types.CgroupRmdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.CgroupId)
+			if err != nil {
+				return types.CgroupRmdirArgs{}, err
+			}
+		case 1:
+			result.CgroupPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.CgroupRmdirArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.HierarchyId)
+			if err != nil {
+				return types.CgroupRmdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityFileOpenArgs(decoder *Decoder) (types.SecurityFileOpenArgs, error) {
-  var result types.SecurityFileOpenArgs
-  var err error
+	var result types.SecurityFileOpenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityFileOpenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityFileOpenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityFileOpenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityFileOpenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityFileOpenArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SecurityFileOpenArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.SecurityFileOpenArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.SecurityFileOpenArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.SecurityFileOpenArgs{}, err
-      }
-    case 5:
-      result.SyscallPathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityFileOpenArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityFileOpenArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SecurityFileOpenArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.SecurityFileOpenArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.SecurityFileOpenArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.SecurityFileOpenArgs{}, err
+			}
+		case 5:
+			result.SyscallPathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityFileOpenArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityInodeUnlinkArgs(decoder *Decoder) (types.SecurityInodeUnlinkArgs, error) {
-  var result types.SecurityInodeUnlinkArgs
-  var err error
+	var result types.SecurityInodeUnlinkArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityInodeUnlinkArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityInodeUnlinkArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityInodeUnlinkArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityInodeUnlinkArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityInodeUnlinkArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.SecurityInodeUnlinkArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.SecurityInodeUnlinkArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.SecurityInodeUnlinkArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityInodeUnlinkArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.SecurityInodeUnlinkArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.SecurityInodeUnlinkArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.SecurityInodeUnlinkArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecuritySocketCreateArgs(decoder *Decoder) (types.SecuritySocketCreateArgs, error) {
-  var result types.SecuritySocketCreateArgs
-  var err error
+	var result types.SecuritySocketCreateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecuritySocketCreateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecuritySocketCreateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecuritySocketCreateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecuritySocketCreateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Family)
-      if err != nil {
-        return types.SecuritySocketCreateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.SecuritySocketCreateArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Protocol)
-      if err != nil {
-        return types.SecuritySocketCreateArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Kern)
-      if err != nil {
-        return types.SecuritySocketCreateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Family)
+			if err != nil {
+				return types.SecuritySocketCreateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.SecuritySocketCreateArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Protocol)
+			if err != nil {
+				return types.SecuritySocketCreateArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Kern)
+			if err != nil {
+				return types.SecuritySocketCreateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecuritySocketListenArgs(decoder *Decoder) (types.SecuritySocketListenArgs, error) {
-  var result types.SecuritySocketListenArgs
-  var err error
+	var result types.SecuritySocketListenArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecuritySocketListenArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecuritySocketListenArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecuritySocketListenArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecuritySocketListenArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SecuritySocketListenArgs{}, err
-      }
-    case 1:
-      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SecuritySocketListenArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Backlog)
-      if err != nil {
-        return types.SecuritySocketListenArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SecuritySocketListenArgs{}, err
+			}
+		case 1:
+			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SecuritySocketListenArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Backlog)
+			if err != nil {
+				return types.SecuritySocketListenArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecuritySocketConnectArgs(decoder *Decoder) (types.SecuritySocketConnectArgs, error) {
-  var result types.SecuritySocketConnectArgs
-  var err error
+	var result types.SecuritySocketConnectArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecuritySocketConnectArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecuritySocketConnectArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecuritySocketConnectArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecuritySocketConnectArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SecuritySocketConnectArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.SecuritySocketConnectArgs{}, err
-      }
-    case 2:
-      result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SecuritySocketConnectArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SecuritySocketConnectArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.SecuritySocketConnectArgs{}, err
+			}
+		case 2:
+			result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SecuritySocketConnectArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecuritySocketAcceptArgs(decoder *Decoder) (types.SecuritySocketAcceptArgs, error) {
-  var result types.SecuritySocketAcceptArgs
-  var err error
+	var result types.SecuritySocketAcceptArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecuritySocketAcceptArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecuritySocketAcceptArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecuritySocketAcceptArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecuritySocketAcceptArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SecuritySocketAcceptArgs{}, err
-      }
-    case 1:
-      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SecuritySocketAcceptArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SecuritySocketAcceptArgs{}, err
+			}
+		case 1:
+			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SecuritySocketAcceptArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecuritySocketBindArgs(decoder *Decoder) (types.SecuritySocketBindArgs, error) {
-  var result types.SecuritySocketBindArgs
-  var err error
+	var result types.SecuritySocketBindArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecuritySocketBindArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecuritySocketBindArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecuritySocketBindArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecuritySocketBindArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SecuritySocketBindArgs{}, err
-      }
-    case 1:
-      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SecuritySocketBindArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SecuritySocketBindArgs{}, err
+			}
+		case 1:
+			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SecuritySocketBindArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecuritySocketSetsockoptArgs(decoder *Decoder) (types.SecuritySocketSetsockoptArgs, error) {
-  var result types.SecuritySocketSetsockoptArgs
-  var err error
+	var result types.SecuritySocketSetsockoptArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecuritySocketSetsockoptArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecuritySocketSetsockoptArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecuritySocketSetsockoptArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecuritySocketSetsockoptArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SecuritySocketSetsockoptArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Level)
-      if err != nil {
-        return types.SecuritySocketSetsockoptArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Optname)
-      if err != nil {
-        return types.SecuritySocketSetsockoptArgs{}, err
-      }
-    case 3:
-      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SecuritySocketSetsockoptArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SecuritySocketSetsockoptArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Level)
+			if err != nil {
+				return types.SecuritySocketSetsockoptArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Optname)
+			if err != nil {
+				return types.SecuritySocketSetsockoptArgs{}, err
+			}
+		case 3:
+			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SecuritySocketSetsockoptArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecuritySbMountArgs(decoder *Decoder) (types.SecuritySbMountArgs, error) {
-  var result types.SecuritySbMountArgs
-  var err error
+	var result types.SecuritySbMountArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecuritySbMountArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecuritySbMountArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecuritySbMountArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecuritySbMountArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.DevName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecuritySbMountArgs{}, err
-      }
-    case 1:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecuritySbMountArgs{}, err
-      }
-    case 2:
-      result.Type, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecuritySbMountArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Flags)
-      if err != nil {
-        return types.SecuritySbMountArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.DevName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecuritySbMountArgs{}, err
+			}
+		case 1:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecuritySbMountArgs{}, err
+			}
+		case 2:
+			result.Type, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecuritySbMountArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Flags)
+			if err != nil {
+				return types.SecuritySbMountArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityBPFArgs(decoder *Decoder) (types.SecurityBPFArgs, error) {
-  var result types.SecurityBPFArgs
-  var err error
+	var result types.SecurityBPFArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityBPFArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityBPFArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityBPFArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityBPFArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Cmd)
-      if err != nil {
-        return types.SecurityBPFArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Cmd)
+			if err != nil {
+				return types.SecurityBPFArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityBPFMapArgs(decoder *Decoder) (types.SecurityBPFMapArgs, error) {
-  var result types.SecurityBPFMapArgs
-  var err error
+	var result types.SecurityBPFMapArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityBPFMapArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityBPFMapArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityBPFMapArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityBPFMapArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.MapId)
-      if err != nil {
-        return types.SecurityBPFMapArgs{}, err
-      }
-    case 1:
-      result.MapName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityBPFMapArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.MapId)
+			if err != nil {
+				return types.SecurityBPFMapArgs{}, err
+			}
+		case 1:
+			result.MapName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityBPFMapArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityKernelReadFileArgs(decoder *Decoder) (types.SecurityKernelReadFileArgs, error) {
-  var result types.SecurityKernelReadFileArgs
-  var err error
+	var result types.SecurityKernelReadFileArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityKernelReadFileArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityKernelReadFileArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityKernelReadFileArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityKernelReadFileArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityKernelReadFileArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.SecurityKernelReadFileArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.SecurityKernelReadFileArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.SecurityKernelReadFileArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.SecurityKernelReadFileArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityKernelReadFileArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.SecurityKernelReadFileArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.SecurityKernelReadFileArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.SecurityKernelReadFileArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.SecurityKernelReadFileArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityPostReadFileArgs(decoder *Decoder) (types.SecurityPostReadFileArgs, error) {
-  var result types.SecurityPostReadFileArgs
-  var err error
+	var result types.SecurityPostReadFileArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityPostReadFileArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityPostReadFileArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityPostReadFileArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityPostReadFileArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityPostReadFileArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt64(&result.Size)
-      if err != nil {
-        return types.SecurityPostReadFileArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeInt32(&result.Type)
-      if err != nil {
-        return types.SecurityPostReadFileArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityPostReadFileArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt64(&result.Size)
+			if err != nil {
+				return types.SecurityPostReadFileArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeInt32(&result.Type)
+			if err != nil {
+				return types.SecurityPostReadFileArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityInodeMknodArgs(decoder *Decoder) (types.SecurityInodeMknodArgs, error) {
-  var result types.SecurityInodeMknodArgs
-  var err error
+	var result types.SecurityInodeMknodArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityInodeMknodArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityInodeMknodArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityInodeMknodArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityInodeMknodArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.FileName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityInodeMknodArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint16(&result.Mode)
-      if err != nil {
-        return types.SecurityInodeMknodArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.SecurityInodeMknodArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.FileName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityInodeMknodArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint16(&result.Mode)
+			if err != nil {
+				return types.SecurityInodeMknodArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.SecurityInodeMknodArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityInodeSymlinkEventIdArgs(decoder *Decoder) (types.SecurityInodeSymlinkEventIdArgs, error) {
-  var result types.SecurityInodeSymlinkEventIdArgs
-  var err error
+	var result types.SecurityInodeSymlinkEventIdArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityInodeSymlinkEventIdArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityInodeSymlinkEventIdArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityInodeSymlinkEventIdArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityInodeSymlinkEventIdArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Linkpath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityInodeSymlinkEventIdArgs{}, err
-      }
-    case 1:
-      result.Target, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityInodeSymlinkEventIdArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Linkpath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityInodeSymlinkEventIdArgs{}, err
+			}
+		case 1:
+			result.Target, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityInodeSymlinkEventIdArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityMmapFileArgs(decoder *Decoder) (types.SecurityMmapFileArgs, error) {
-  var result types.SecurityMmapFileArgs
-  var err error
+	var result types.SecurityMmapFileArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityMmapFileArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityMmapFileArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityMmapFileArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityMmapFileArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityMmapFileArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SecurityMmapFileArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.SecurityMmapFileArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.SecurityMmapFileArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.SecurityMmapFileArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.Prot)
-      if err != nil {
-        return types.SecurityMmapFileArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeUint64(&result.MmapFlags)
-      if err != nil {
-        return types.SecurityMmapFileArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityMmapFileArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SecurityMmapFileArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.SecurityMmapFileArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.SecurityMmapFileArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.SecurityMmapFileArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.Prot)
+			if err != nil {
+				return types.SecurityMmapFileArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeUint64(&result.MmapFlags)
+			if err != nil {
+				return types.SecurityMmapFileArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDoMmapArgs(decoder *Decoder) (types.DoMmapArgs, error) {
-  var result types.DoMmapArgs
-  var err error
+	var result types.DoMmapArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DoMmapArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DoMmapArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DoMmapArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DoMmapArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 1:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeUint64(&result.Pgoff)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 7:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 8:
-      err = decoder.DecodeUint64(&result.Prot)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    case 9:
-      err = decoder.DecodeUint64(&result.MmapFlags)
-      if err != nil {
-        return types.DoMmapArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 1:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeUint64(&result.Pgoff)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 7:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 8:
+			err = decoder.DecodeUint64(&result.Prot)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		case 9:
+			err = decoder.DecodeUint64(&result.MmapFlags)
+			if err != nil {
+				return types.DoMmapArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityFileMprotectArgs(decoder *Decoder) (types.SecurityFileMprotectArgs, error) {
-  var result types.SecurityFileMprotectArgs
-  var err error
+	var result types.SecurityFileMprotectArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityFileMprotectArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityFileMprotectArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityFileMprotectArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityFileMprotectArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityFileMprotectArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Prot)
-      if err != nil {
-        return types.SecurityFileMprotectArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.SecurityFileMprotectArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.PrevProt)
-      if err != nil {
-        return types.SecurityFileMprotectArgs{}, err
-      }
-    case 4:
-      var dataAddr uint64
-      err = decoder.DecodeUint64(&dataAddr)
-      if err != nil {
-        return types.SecurityFileMprotectArgs{}, err
-      }
-      result.Addr = uintptr(dataAddr)
-    case 5:
-      err = decoder.DecodeUint64(&result.Len)
-      if err != nil {
-        return types.SecurityFileMprotectArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeInt32(&result.Pkey)
-      if err != nil {
-        return types.SecurityFileMprotectArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityFileMprotectArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Prot)
+			if err != nil {
+				return types.SecurityFileMprotectArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.SecurityFileMprotectArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.PrevProt)
+			if err != nil {
+				return types.SecurityFileMprotectArgs{}, err
+			}
+		case 4:
+			var dataAddr uint64
+			err = decoder.DecodeUint64(&dataAddr)
+			if err != nil {
+				return types.SecurityFileMprotectArgs{}, err
+			}
+			result.Addr = uintptr(dataAddr)
+		case 5:
+			err = decoder.DecodeUint64(&result.Len)
+			if err != nil {
+				return types.SecurityFileMprotectArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeInt32(&result.Pkey)
+			if err != nil {
+				return types.SecurityFileMprotectArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseInitNamespacesArgs(decoder *Decoder) (types.InitNamespacesArgs, error) {
-  var result types.InitNamespacesArgs
-  var err error
+	var result types.InitNamespacesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.InitNamespacesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.InitNamespacesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.InitNamespacesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.InitNamespacesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.Cgroup)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Ipc)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mnt)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint32(&result.Net)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint32(&result.Pid)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint32(&result.PidForChildren)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeUint32(&result.Time)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 7:
-      err = decoder.DecodeUint32(&result.TimeForChildren)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 8:
-      err = decoder.DecodeUint32(&result.User)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    case 9:
-      err = decoder.DecodeUint32(&result.Uts)
-      if err != nil {
-        return types.InitNamespacesArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.Cgroup)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Ipc)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mnt)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint32(&result.Net)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint32(&result.Pid)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint32(&result.PidForChildren)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeUint32(&result.Time)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 7:
+			err = decoder.DecodeUint32(&result.TimeForChildren)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 8:
+			err = decoder.DecodeUint32(&result.User)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		case 9:
+			err = decoder.DecodeUint32(&result.Uts)
+			if err != nil {
+				return types.InitNamespacesArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSocketDupArgs(decoder *Decoder) (types.SocketDupArgs, error) {
-  var result types.SocketDupArgs
-  var err error
+	var result types.SocketDupArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SocketDupArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SocketDupArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SocketDupArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SocketDupArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Oldfd)
-      if err != nil {
-        return types.SocketDupArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Newfd)
-      if err != nil {
-        return types.SocketDupArgs{}, err
-      }
-    case 2:
-      result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SocketDupArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Oldfd)
+			if err != nil {
+				return types.SocketDupArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Newfd)
+			if err != nil {
+				return types.SocketDupArgs{}, err
+			}
+		case 2:
+			result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SocketDupArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseHiddenInodesArgs(decoder *Decoder) (types.HiddenInodesArgs, error) {
-  var result types.HiddenInodesArgs
-  var err error
+	var result types.HiddenInodesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.HiddenInodesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.HiddenInodesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.HiddenInodesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.HiddenInodesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.HiddenProcess, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.HiddenInodesArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.HiddenProcess, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.HiddenInodesArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseKernelWriteArgs(decoder *Decoder) (types.KernelWriteArgs, error) {
-  var result types.KernelWriteArgs
-  var err error
+	var result types.KernelWriteArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KernelWriteArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KernelWriteArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KernelWriteArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KernelWriteArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.KernelWriteArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.KernelWriteArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.KernelWriteArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.KernelWriteArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Pos)
-      if err != nil {
-        return types.KernelWriteArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.KernelWriteArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.KernelWriteArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.KernelWriteArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.KernelWriteArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Pos)
+			if err != nil {
+				return types.KernelWriteArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDirtyPipeSpliceArgs(decoder *Decoder) (types.DirtyPipeSpliceArgs, error) {
-  var result types.DirtyPipeSpliceArgs
-  var err error
+	var result types.DirtyPipeSpliceArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DirtyPipeSpliceArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DirtyPipeSpliceArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DirtyPipeSpliceArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DirtyPipeSpliceArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.InodeIn)
-      if err != nil {
-        return types.DirtyPipeSpliceArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint16(&result.InFileType)
-      if err != nil {
-        return types.DirtyPipeSpliceArgs{}, err
-      }
-    case 2:
-      result.InFilePath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DirtyPipeSpliceArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.ExposedDataStartOffset)
-      if err != nil {
-        return types.DirtyPipeSpliceArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.ExposedDataLen)
-      if err != nil {
-        return types.DirtyPipeSpliceArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.InodeOut)
-      if err != nil {
-        return types.DirtyPipeSpliceArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeUint32(&result.OutPipeLastBufferFlags)
-      if err != nil {
-        return types.DirtyPipeSpliceArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.InodeIn)
+			if err != nil {
+				return types.DirtyPipeSpliceArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint16(&result.InFileType)
+			if err != nil {
+				return types.DirtyPipeSpliceArgs{}, err
+			}
+		case 2:
+			result.InFilePath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DirtyPipeSpliceArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.ExposedDataStartOffset)
+			if err != nil {
+				return types.DirtyPipeSpliceArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.ExposedDataLen)
+			if err != nil {
+				return types.DirtyPipeSpliceArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.InodeOut)
+			if err != nil {
+				return types.DirtyPipeSpliceArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeUint32(&result.OutPipeLastBufferFlags)
+			if err != nil {
+				return types.DirtyPipeSpliceArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseContainerCreateArgs(decoder *Decoder) (types.ContainerCreateArgs, error) {
-  var result types.ContainerCreateArgs
-  var err error
+	var result types.ContainerCreateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ContainerCreateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ContainerCreateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ContainerCreateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ContainerCreateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Runtime, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 1:
-      result.ContainerId, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 3:
-      result.ContainerImage, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 4:
-      result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 5:
-      result.ContainerName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 6:
-      result.PodName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 7:
-      result.PodNamespace, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 8:
-      result.PodUid, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    case 9:
-      err = decoder.DecodeBool(&result.PodSandbox)
-      if err != nil {
-        return types.ContainerCreateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Runtime, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 1:
+			result.ContainerId, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 3:
+			result.ContainerImage, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 4:
+			result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 5:
+			result.ContainerName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 6:
+			result.PodName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 7:
+			result.PodNamespace, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 8:
+			result.PodUid, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		case 9:
+			err = decoder.DecodeBool(&result.PodSandbox)
+			if err != nil {
+				return types.ContainerCreateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseContainerRemoveArgs(decoder *Decoder) (types.ContainerRemoveArgs, error) {
-  var result types.ContainerRemoveArgs
-  var err error
+	var result types.ContainerRemoveArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ContainerRemoveArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ContainerRemoveArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ContainerRemoveArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ContainerRemoveArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Runtime, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerRemoveArgs{}, err
-      }
-    case 1:
-      result.ContainerId, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ContainerRemoveArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Runtime, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerRemoveArgs{}, err
+			}
+		case 1:
+			result.ContainerId, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ContainerRemoveArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseExistingContainerArgs(decoder *Decoder) (types.ExistingContainerArgs, error) {
-  var result types.ExistingContainerArgs
-  var err error
+	var result types.ExistingContainerArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ExistingContainerArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ExistingContainerArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ExistingContainerArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ExistingContainerArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Runtime, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 1:
-      result.ContainerId, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 3:
-      result.ContainerImage, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 4:
-      result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 5:
-      result.ContainerName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 6:
-      result.PodName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 7:
-      result.PodNamespace, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 8:
-      result.PodUid, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    case 9:
-      err = decoder.DecodeBool(&result.PodSandbox)
-      if err != nil {
-        return types.ExistingContainerArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Runtime, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 1:
+			result.ContainerId, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 3:
+			result.ContainerImage, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 4:
+			result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 5:
+			result.ContainerName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 6:
+			result.PodName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 7:
+			result.PodNamespace, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 8:
+			result.PodUid, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		case 9:
+			err = decoder.DecodeBool(&result.PodSandbox)
+			if err != nil {
+				return types.ExistingContainerArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseProcCreateArgs(decoder *Decoder) (types.ProcCreateArgs, error) {
-  var result types.ProcCreateArgs
-  var err error
+	var result types.ProcCreateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ProcCreateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ProcCreateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ProcCreateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ProcCreateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ProcCreateArgs{}, err
-      }
-    case 1:
-      var dataProcOpsAddr uint64
-      err = decoder.DecodeUint64(&dataProcOpsAddr)
-      if err != nil {
-        return types.ProcCreateArgs{}, err
-      }
-      result.ProcOpsAddr = uintptr(dataProcOpsAddr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ProcCreateArgs{}, err
+			}
+		case 1:
+			var dataProcOpsAddr uint64
+			err = decoder.DecodeUint64(&dataProcOpsAddr)
+			if err != nil {
+				return types.ProcCreateArgs{}, err
+			}
+			result.ProcOpsAddr = uintptr(dataProcOpsAddr)
+		}
+	}
+	return result, nil
 }
 
 func ParseKprobeAttachArgs(decoder *Decoder) (types.KprobeAttachArgs, error) {
-  var result types.KprobeAttachArgs
-  var err error
+	var result types.KprobeAttachArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KprobeAttachArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KprobeAttachArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KprobeAttachArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KprobeAttachArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.SymbolName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.KprobeAttachArgs{}, err
-      }
-    case 1:
-      var dataPreHandlerAddr uint64
-      err = decoder.DecodeUint64(&dataPreHandlerAddr)
-      if err != nil {
-        return types.KprobeAttachArgs{}, err
-      }
-      result.PreHandlerAddr = uintptr(dataPreHandlerAddr)
-    case 2:
-      var dataPostHandlerAddr uint64
-      err = decoder.DecodeUint64(&dataPostHandlerAddr)
-      if err != nil {
-        return types.KprobeAttachArgs{}, err
-      }
-      result.PostHandlerAddr = uintptr(dataPostHandlerAddr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.SymbolName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.KprobeAttachArgs{}, err
+			}
+		case 1:
+			var dataPreHandlerAddr uint64
+			err = decoder.DecodeUint64(&dataPreHandlerAddr)
+			if err != nil {
+				return types.KprobeAttachArgs{}, err
+			}
+			result.PreHandlerAddr = uintptr(dataPreHandlerAddr)
+		case 2:
+			var dataPostHandlerAddr uint64
+			err = decoder.DecodeUint64(&dataPostHandlerAddr)
+			if err != nil {
+				return types.KprobeAttachArgs{}, err
+			}
+			result.PostHandlerAddr = uintptr(dataPostHandlerAddr)
+		}
+	}
+	return result, nil
 }
 
 func ParseCallUsermodeHelperArgs(decoder *Decoder) (types.CallUsermodeHelperArgs, error) {
-  var result types.CallUsermodeHelperArgs
-  var err error
+	var result types.CallUsermodeHelperArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.CallUsermodeHelperArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.CallUsermodeHelperArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.CallUsermodeHelperArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.CallUsermodeHelperArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.CallUsermodeHelperArgs{}, err
-      }
-    case 1:
-      result.Argv, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.CallUsermodeHelperArgs{}, err
-      }
-    case 2:
-      result.Envp, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.CallUsermodeHelperArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeInt32(&result.Wait)
-      if err != nil {
-        return types.CallUsermodeHelperArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.CallUsermodeHelperArgs{}, err
+			}
+		case 1:
+			result.Argv, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.CallUsermodeHelperArgs{}, err
+			}
+		case 2:
+			result.Envp, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.CallUsermodeHelperArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeInt32(&result.Wait)
+			if err != nil {
+				return types.CallUsermodeHelperArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDebugfsCreateFileArgs(decoder *Decoder) (types.DebugfsCreateFileArgs, error) {
-  var result types.DebugfsCreateFileArgs
-  var err error
+	var result types.DebugfsCreateFileArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DebugfsCreateFileArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DebugfsCreateFileArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DebugfsCreateFileArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DebugfsCreateFileArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.FileName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DebugfsCreateFileArgs{}, err
-      }
-    case 1:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DebugfsCreateFileArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Mode)
-      if err != nil {
-        return types.DebugfsCreateFileArgs{}, err
-      }
-    case 3:
-      var dataProcOpsAddr uint64
-      err = decoder.DecodeUint64(&dataProcOpsAddr)
-      if err != nil {
-        return types.DebugfsCreateFileArgs{}, err
-      }
-      result.ProcOpsAddr = uintptr(dataProcOpsAddr)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.FileName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DebugfsCreateFileArgs{}, err
+			}
+		case 1:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DebugfsCreateFileArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Mode)
+			if err != nil {
+				return types.DebugfsCreateFileArgs{}, err
+			}
+		case 3:
+			var dataProcOpsAddr uint64
+			err = decoder.DecodeUint64(&dataProcOpsAddr)
+			if err != nil {
+				return types.DebugfsCreateFileArgs{}, err
+			}
+			result.ProcOpsAddr = uintptr(dataProcOpsAddr)
+		}
+	}
+	return result, nil
 }
 
 func ParsePrintSyscallTableArgs(decoder *Decoder) (types.PrintSyscallTableArgs, error) {
-  var result types.PrintSyscallTableArgs
-  var err error
+	var result types.PrintSyscallTableArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PrintSyscallTableArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PrintSyscallTableArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PrintSyscallTableArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PrintSyscallTableArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64Array(&result.SyscallsAddresses)
-      if err != nil {
-        return types.PrintSyscallTableArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.CallerContextId)
-      if err != nil {
-        return types.PrintSyscallTableArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64Array(&result.SyscallsAddresses)
+			if err != nil {
+				return types.PrintSyscallTableArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.CallerContextId)
+			if err != nil {
+				return types.PrintSyscallTableArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseHiddenKernelModuleArgs(decoder *Decoder) (types.HiddenKernelModuleArgs, error) {
-  var result types.HiddenKernelModuleArgs
-  var err error
+	var result types.HiddenKernelModuleArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.HiddenKernelModuleArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.HiddenKernelModuleArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.HiddenKernelModuleArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.HiddenKernelModuleArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Address, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.HiddenKernelModuleArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.HiddenKernelModuleArgs{}, err
-      }
-    case 2:
-      result.Srcversion, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.HiddenKernelModuleArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Address, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.HiddenKernelModuleArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.HiddenKernelModuleArgs{}, err
+			}
+		case 2:
+			result.Srcversion, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.HiddenKernelModuleArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseHiddenKernelModuleSeekerArgs(decoder *Decoder) (types.HiddenKernelModuleSeekerArgs, error) {
-  var result types.HiddenKernelModuleSeekerArgs
-  var err error
+	var result types.HiddenKernelModuleSeekerArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.HiddenKernelModuleSeekerArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.HiddenKernelModuleSeekerArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.HiddenKernelModuleSeekerArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.HiddenKernelModuleSeekerArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.Address)
-      if err != nil {
-        return types.HiddenKernelModuleSeekerArgs{}, err
-      }
-    case 1:
-      result.Name, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
-      if err != nil {
-        return types.HiddenKernelModuleSeekerArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Flags)
-      if err != nil {
-        return types.HiddenKernelModuleSeekerArgs{}, err
-      }
-    case 3:
-      result.Srcversion, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
-      if err != nil {
-        return types.HiddenKernelModuleSeekerArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.Address)
+			if err != nil {
+				return types.HiddenKernelModuleSeekerArgs{}, err
+			}
+		case 1:
+			result.Name, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
+			if err != nil {
+				return types.HiddenKernelModuleSeekerArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Flags)
+			if err != nil {
+				return types.HiddenKernelModuleSeekerArgs{}, err
+			}
+		case 3:
+			result.Srcversion, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
+			if err != nil {
+				return types.HiddenKernelModuleSeekerArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseHookedSyscallsArgs(decoder *Decoder) (types.HookedSyscallsArgs, error) {
-  var result types.HookedSyscallsArgs
-  var err error
+	var result types.HookedSyscallsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.HookedSyscallsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.HookedSyscallsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.HookedSyscallsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.HookedSyscallsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataCheckSyscalls uint64
-      err = decoder.DecodeUint64(&dataCheckSyscalls)
-      if err != nil {
-        return types.HookedSyscallsArgs{}, err
-      }
-      result.CheckSyscalls = uintptr(dataCheckSyscalls)
-    case 1:
-      var dataHookedSyscalls uint64
-      err = decoder.DecodeUint64(&dataHookedSyscalls)
-      if err != nil {
-        return types.HookedSyscallsArgs{}, err
-      }
-      result.HookedSyscalls = uintptr(dataHookedSyscalls)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataCheckSyscalls uint64
+			err = decoder.DecodeUint64(&dataCheckSyscalls)
+			if err != nil {
+				return types.HookedSyscallsArgs{}, err
+			}
+			result.CheckSyscalls = uintptr(dataCheckSyscalls)
+		case 1:
+			var dataHookedSyscalls uint64
+			err = decoder.DecodeUint64(&dataHookedSyscalls)
+			if err != nil {
+				return types.HookedSyscallsArgs{}, err
+			}
+			result.HookedSyscalls = uintptr(dataHookedSyscalls)
+		}
+	}
+	return result, nil
 }
 
 func ParseDebugfsCreateDirArgs(decoder *Decoder) (types.DebugfsCreateDirArgs, error) {
-  var result types.DebugfsCreateDirArgs
-  var err error
+	var result types.DebugfsCreateDirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DebugfsCreateDirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DebugfsCreateDirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DebugfsCreateDirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DebugfsCreateDirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DebugfsCreateDirArgs{}, err
-      }
-    case 1:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DebugfsCreateDirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DebugfsCreateDirArgs{}, err
+			}
+		case 1:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DebugfsCreateDirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDeviceAddArgs(decoder *Decoder) (types.DeviceAddArgs, error) {
-  var result types.DeviceAddArgs
-  var err error
+	var result types.DeviceAddArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DeviceAddArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DeviceAddArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DeviceAddArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DeviceAddArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DeviceAddArgs{}, err
-      }
-    case 1:
-      result.ParentName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DeviceAddArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DeviceAddArgs{}, err
+			}
+		case 1:
+			result.ParentName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DeviceAddArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseRegisterChrdevArgs(decoder *Decoder) (types.RegisterChrdevArgs, error) {
-  var result types.RegisterChrdevArgs
-  var err error
+	var result types.RegisterChrdevArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.RegisterChrdevArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.RegisterChrdevArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.RegisterChrdevArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.RegisterChrdevArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.RequestedMajorNumber)
-      if err != nil {
-        return types.RegisterChrdevArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.GrantedMajorNumber)
-      if err != nil {
-        return types.RegisterChrdevArgs{}, err
-      }
-    case 2:
-      result.CharDeviceName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.RegisterChrdevArgs{}, err
-      }
-    case 3:
-      var dataCharDeviceFops uint64
-      err = decoder.DecodeUint64(&dataCharDeviceFops)
-      if err != nil {
-        return types.RegisterChrdevArgs{}, err
-      }
-      result.CharDeviceFops = uintptr(dataCharDeviceFops)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.RequestedMajorNumber)
+			if err != nil {
+				return types.RegisterChrdevArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.GrantedMajorNumber)
+			if err != nil {
+				return types.RegisterChrdevArgs{}, err
+			}
+		case 2:
+			result.CharDeviceName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.RegisterChrdevArgs{}, err
+			}
+		case 3:
+			var dataCharDeviceFops uint64
+			err = decoder.DecodeUint64(&dataCharDeviceFops)
+			if err != nil {
+				return types.RegisterChrdevArgs{}, err
+			}
+			result.CharDeviceFops = uintptr(dataCharDeviceFops)
+		}
+	}
+	return result, nil
 }
 
 func ParseSharedObjectLoadedArgs(decoder *Decoder) (types.SharedObjectLoadedArgs, error) {
-  var result types.SharedObjectLoadedArgs
-  var err error
+	var result types.SharedObjectLoadedArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SharedObjectLoadedArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SharedObjectLoadedArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SharedObjectLoadedArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SharedObjectLoadedArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SharedObjectLoadedArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeInt32(&result.Flags)
-      if err != nil {
-        return types.SharedObjectLoadedArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.SharedObjectLoadedArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.SharedObjectLoadedArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Ctime)
-      if err != nil {
-        return types.SharedObjectLoadedArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SharedObjectLoadedArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeInt32(&result.Flags)
+			if err != nil {
+				return types.SharedObjectLoadedArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.SharedObjectLoadedArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.SharedObjectLoadedArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Ctime)
+			if err != nil {
+				return types.SharedObjectLoadedArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSymbolsLoadedArgs(decoder *Decoder) (types.SymbolsLoadedArgs, error) {
-  var result types.SymbolsLoadedArgs
-  var err error
+	var result types.SymbolsLoadedArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SymbolsLoadedArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SymbolsLoadedArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SymbolsLoadedArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SymbolsLoadedArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.LibraryPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SymbolsLoadedArgs{}, err
-      }
-    case 1:
-      result.Symbols, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.SymbolsLoadedArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.LibraryPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SymbolsLoadedArgs{}, err
+			}
+		case 1:
+			result.Symbols, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.SymbolsLoadedArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSymbolsCollisionArgs(decoder *Decoder) (types.SymbolsCollisionArgs, error) {
-  var result types.SymbolsCollisionArgs
-  var err error
+	var result types.SymbolsCollisionArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SymbolsCollisionArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SymbolsCollisionArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SymbolsCollisionArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SymbolsCollisionArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.LoadedPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SymbolsCollisionArgs{}, err
-      }
-    case 1:
-      result.CollisionPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SymbolsCollisionArgs{}, err
-      }
-    case 2:
-      result.Symbols, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.SymbolsCollisionArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.LoadedPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SymbolsCollisionArgs{}, err
+			}
+		case 1:
+			result.CollisionPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SymbolsCollisionArgs{}, err
+			}
+		case 2:
+			result.Symbols, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.SymbolsCollisionArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCaptureFileWriteArgs(decoder *Decoder) (types.CaptureFileWriteArgs, error) {
-  return types.CaptureFileWriteArgs{}, nil
+	return types.CaptureFileWriteArgs{}, nil
 }
 
 func ParseCaptureFileReadArgs(decoder *Decoder) (types.CaptureFileReadArgs, error) {
-  return types.CaptureFileReadArgs{}, nil
+	return types.CaptureFileReadArgs{}, nil
 }
 
 func ParseCaptureExecArgs(decoder *Decoder) (types.CaptureExecArgs, error) {
-  return types.CaptureExecArgs{}, nil
+	return types.CaptureExecArgs{}, nil
 }
 
 func ParseCaptureModuleArgs(decoder *Decoder) (types.CaptureModuleArgs, error) {
-  return types.CaptureModuleArgs{}, nil
+	return types.CaptureModuleArgs{}, nil
 }
 
 func ParseCaptureMemArgs(decoder *Decoder) (types.CaptureMemArgs, error) {
-  return types.CaptureMemArgs{}, nil
+	return types.CaptureMemArgs{}, nil
 }
 
 func ParseCaptureBpfArgs(decoder *Decoder) (types.CaptureBpfArgs, error) {
-  return types.CaptureBpfArgs{}, nil
+	return types.CaptureBpfArgs{}, nil
 }
 
 func ParseDoInitModuleArgs(decoder *Decoder) (types.DoInitModuleArgs, error) {
-  var result types.DoInitModuleArgs
-  var err error
+	var result types.DoInitModuleArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DoInitModuleArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DoInitModuleArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DoInitModuleArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DoInitModuleArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DoInitModuleArgs{}, err
-      }
-    case 1:
-      result.Version, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DoInitModuleArgs{}, err
-      }
-    case 2:
-      result.SrcVersion, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DoInitModuleArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DoInitModuleArgs{}, err
+			}
+		case 1:
+			result.Version, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DoInitModuleArgs{}, err
+			}
+		case 2:
+			result.SrcVersion, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DoInitModuleArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseModuleLoadArgs(decoder *Decoder) (types.ModuleLoadArgs, error) {
-  var result types.ModuleLoadArgs
-  var err error
+	var result types.ModuleLoadArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ModuleLoadArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ModuleLoadArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ModuleLoadArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ModuleLoadArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ModuleLoadArgs{}, err
-      }
-    case 1:
-      result.Version, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ModuleLoadArgs{}, err
-      }
-    case 2:
-      result.SrcVersion, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ModuleLoadArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ModuleLoadArgs{}, err
+			}
+		case 1:
+			result.Version, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ModuleLoadArgs{}, err
+			}
+		case 2:
+			result.SrcVersion, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ModuleLoadArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseModuleFreeArgs(decoder *Decoder) (types.ModuleFreeArgs, error) {
-  var result types.ModuleFreeArgs
-  var err error
+	var result types.ModuleFreeArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ModuleFreeArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ModuleFreeArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ModuleFreeArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ModuleFreeArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Name, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ModuleFreeArgs{}, err
-      }
-    case 1:
-      result.Version, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ModuleFreeArgs{}, err
-      }
-    case 2:
-      result.SrcVersion, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ModuleFreeArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Name, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ModuleFreeArgs{}, err
+			}
+		case 1:
+			result.Version, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ModuleFreeArgs{}, err
+			}
+		case 2:
+			result.SrcVersion, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ModuleFreeArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSocketAcceptArgs(decoder *Decoder) (types.SocketAcceptArgs, error) {
-  var result types.SocketAcceptArgs
-  var err error
+	var result types.SocketAcceptArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SocketAcceptArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SocketAcceptArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SocketAcceptArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SocketAcceptArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sockfd)
-      if err != nil {
-        return types.SocketAcceptArgs{}, err
-      }
-    case 1:
-      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SocketAcceptArgs{}, err
-      }
-    case 2:
-      result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
-      if err != nil {
-        return types.SocketAcceptArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sockfd)
+			if err != nil {
+				return types.SocketAcceptArgs{}, err
+			}
+		case 1:
+			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SocketAcceptArgs{}, err
+			}
+		case 2:
+			result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
+			if err != nil {
+				return types.SocketAcceptArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseLoadElfPhdrsArgs(decoder *Decoder) (types.LoadElfPhdrsArgs, error) {
-  var result types.LoadElfPhdrsArgs
-  var err error
+	var result types.LoadElfPhdrsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.LoadElfPhdrsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.LoadElfPhdrsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.LoadElfPhdrsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.LoadElfPhdrsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.LoadElfPhdrsArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.LoadElfPhdrsArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.LoadElfPhdrsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.LoadElfPhdrsArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.LoadElfPhdrsArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.LoadElfPhdrsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParsePrintNetSeqOpsArgs(decoder *Decoder) (types.PrintNetSeqOpsArgs, error) {
-  var result types.PrintNetSeqOpsArgs
-  var err error
+	var result types.PrintNetSeqOpsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PrintNetSeqOpsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PrintNetSeqOpsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PrintNetSeqOpsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PrintNetSeqOpsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64Array(&result.NetSeqOps)
-      if err != nil {
-        return types.PrintNetSeqOpsArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.CallerContextId)
-      if err != nil {
-        return types.PrintNetSeqOpsArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64Array(&result.NetSeqOps)
+			if err != nil {
+				return types.PrintNetSeqOpsArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.CallerContextId)
+			if err != nil {
+				return types.PrintNetSeqOpsArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseHookedSeqOpsArgs(decoder *Decoder) (types.HookedSeqOpsArgs, error) {
-  var result types.HookedSeqOpsArgs
-  var err error
+	var result types.HookedSeqOpsArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.HookedSeqOpsArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.HookedSeqOpsArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.HookedSeqOpsArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.HookedSeqOpsArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataHookedSeqOps uint64
-      err = decoder.DecodeUint64(&dataHookedSeqOps)
-      if err != nil {
-        return types.HookedSeqOpsArgs{}, err
-      }
-      result.HookedSeqOps = uintptr(dataHookedSeqOps)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataHookedSeqOps uint64
+			err = decoder.DecodeUint64(&dataHookedSeqOps)
+			if err != nil {
+				return types.HookedSeqOpsArgs{}, err
+			}
+			result.HookedSeqOps = uintptr(dataHookedSeqOps)
+		}
+	}
+	return result, nil
 }
 
 func ParseTaskRenameArgs(decoder *Decoder) (types.TaskRenameArgs, error) {
-  var result types.TaskRenameArgs
-  var err error
+	var result types.TaskRenameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.TaskRenameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.TaskRenameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.TaskRenameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.TaskRenameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.OldName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.TaskRenameArgs{}, err
-      }
-    case 1:
-      result.NewName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.TaskRenameArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.OldName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.TaskRenameArgs{}, err
+			}
+		case 1:
+			result.NewName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.TaskRenameArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSecurityInodeRenameArgs(decoder *Decoder) (types.SecurityInodeRenameArgs, error) {
-  var result types.SecurityInodeRenameArgs
-  var err error
+	var result types.SecurityInodeRenameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SecurityInodeRenameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SecurityInodeRenameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SecurityInodeRenameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SecurityInodeRenameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.OldPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityInodeRenameArgs{}, err
-      }
-    case 1:
-      result.NewPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SecurityInodeRenameArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.OldPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityInodeRenameArgs{}, err
+			}
+		case 1:
+			result.NewPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SecurityInodeRenameArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDoSigactionArgs(decoder *Decoder) (types.DoSigactionArgs, error) {
-  var result types.DoSigactionArgs
-  var err error
+	var result types.DoSigactionArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DoSigactionArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DoSigactionArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DoSigactionArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DoSigactionArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.Sig)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeBool(&result.IsSaInitialized)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.SaFlags)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.SaMask)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint8(&result.SaHandleMethod)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 5:
-      var dataSaHandler uint64
-      err = decoder.DecodeUint64(&dataSaHandler)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-      result.SaHandler = uintptr(dataSaHandler)
-    case 6:
-      err = decoder.DecodeBool(&result.IsOldSaInitialized)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 7:
-      err = decoder.DecodeUint64(&result.OldSaFlags)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 8:
-      err = decoder.DecodeUint64(&result.OldSaMask)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 9:
-      err = decoder.DecodeUint8(&result.OldSaHandleMethod)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-    case 10:
-      var dataOldSaHandler uint64
-      err = decoder.DecodeUint64(&dataOldSaHandler)
-      if err != nil {
-        return types.DoSigactionArgs{}, err
-      }
-      result.OldSaHandler = uintptr(dataOldSaHandler)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.Sig)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeBool(&result.IsSaInitialized)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.SaFlags)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.SaMask)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint8(&result.SaHandleMethod)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 5:
+			var dataSaHandler uint64
+			err = decoder.DecodeUint64(&dataSaHandler)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+			result.SaHandler = uintptr(dataSaHandler)
+		case 6:
+			err = decoder.DecodeBool(&result.IsOldSaInitialized)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 7:
+			err = decoder.DecodeUint64(&result.OldSaFlags)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 8:
+			err = decoder.DecodeUint64(&result.OldSaMask)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 9:
+			err = decoder.DecodeUint8(&result.OldSaHandleMethod)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+		case 10:
+			var dataOldSaHandler uint64
+			err = decoder.DecodeUint64(&dataOldSaHandler)
+			if err != nil {
+				return types.DoSigactionArgs{}, err
+			}
+			result.OldSaHandler = uintptr(dataOldSaHandler)
+		}
+	}
+	return result, nil
 }
 
 func ParseBpfAttachArgs(decoder *Decoder) (types.BpfAttachArgs, error) {
-  var result types.BpfAttachArgs
-  var err error
+	var result types.BpfAttachArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.BpfAttachArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.BpfAttachArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.BpfAttachArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.BpfAttachArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeInt32(&result.ProgType)
-      if err != nil {
-        return types.BpfAttachArgs{}, err
-      }
-    case 1:
-      result.ProgName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.BpfAttachArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.ProgId)
-      if err != nil {
-        return types.BpfAttachArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64Array(&result.ProgHelpers)
-      if err != nil {
-        return types.BpfAttachArgs{}, err
-      }
-    case 4:
-      result.SymbolName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.BpfAttachArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint64(&result.SymbolAddr)
-      if err != nil {
-        return types.BpfAttachArgs{}, err
-      }
-    case 6:
-      err = decoder.DecodeInt32(&result.AttachType)
-      if err != nil {
-        return types.BpfAttachArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeInt32(&result.ProgType)
+			if err != nil {
+				return types.BpfAttachArgs{}, err
+			}
+		case 1:
+			result.ProgName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.BpfAttachArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.ProgId)
+			if err != nil {
+				return types.BpfAttachArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64Array(&result.ProgHelpers)
+			if err != nil {
+				return types.BpfAttachArgs{}, err
+			}
+		case 4:
+			result.SymbolName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.BpfAttachArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint64(&result.SymbolAddr)
+			if err != nil {
+				return types.BpfAttachArgs{}, err
+			}
+		case 6:
+			err = decoder.DecodeInt32(&result.AttachType)
+			if err != nil {
+				return types.BpfAttachArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseKallsymsLookupNameArgs(decoder *Decoder) (types.KallsymsLookupNameArgs, error) {
-  var result types.KallsymsLookupNameArgs
-  var err error
+	var result types.KallsymsLookupNameArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.KallsymsLookupNameArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.KallsymsLookupNameArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.KallsymsLookupNameArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.KallsymsLookupNameArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.SymbolName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.KallsymsLookupNameArgs{}, err
-      }
-    case 1:
-      var dataSymbolAddress uint64
-      err = decoder.DecodeUint64(&dataSymbolAddress)
-      if err != nil {
-        return types.KallsymsLookupNameArgs{}, err
-      }
-      result.SymbolAddress = uintptr(dataSymbolAddress)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.SymbolName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.KallsymsLookupNameArgs{}, err
+			}
+		case 1:
+			var dataSymbolAddress uint64
+			err = decoder.DecodeUint64(&dataSymbolAddress)
+			if err != nil {
+				return types.KallsymsLookupNameArgs{}, err
+			}
+			result.SymbolAddress = uintptr(dataSymbolAddress)
+		}
+	}
+	return result, nil
 }
 
 func ParsePrintMemDumpArgs(decoder *Decoder) (types.PrintMemDumpArgs, error) {
-  var result types.PrintMemDumpArgs
-  var err error
+	var result types.PrintMemDumpArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.PrintMemDumpArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.PrintMemDumpArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.PrintMemDumpArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.PrintMemDumpArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.PrintMemDump))
-      if err != nil {
-        return types.PrintMemDumpArgs{}, err
-      }
-    case 1:
-      var dataAddress uint64
-      err = decoder.DecodeUint64(&dataAddress)
-      if err != nil {
-        return types.PrintMemDumpArgs{}, err
-      }
-      result.Address = uintptr(dataAddress)
-    case 2:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.PrintMemDumpArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.CallerContextId)
-      if err != nil {
-        return types.PrintMemDumpArgs{}, err
-      }
-    case 4:
-      result.Arch, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.PrintMemDumpArgs{}, err
-      }
-    case 5:
-      result.SymbolName, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.PrintMemDumpArgs{}, err
-      }
-    case 6:
-      result.SymbolOwner, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.PrintMemDumpArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.PrintMemDump))
+			if err != nil {
+				return types.PrintMemDumpArgs{}, err
+			}
+		case 1:
+			var dataAddress uint64
+			err = decoder.DecodeUint64(&dataAddress)
+			if err != nil {
+				return types.PrintMemDumpArgs{}, err
+			}
+			result.Address = uintptr(dataAddress)
+		case 2:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.PrintMemDumpArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.CallerContextId)
+			if err != nil {
+				return types.PrintMemDumpArgs{}, err
+			}
+		case 4:
+			result.Arch, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.PrintMemDumpArgs{}, err
+			}
+		case 5:
+			result.SymbolName, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.PrintMemDumpArgs{}, err
+			}
+		case 6:
+			result.SymbolOwner, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.PrintMemDumpArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseVfsReadArgs(decoder *Decoder) (types.VfsReadArgs, error) {
-  var result types.VfsReadArgs
-  var err error
+	var result types.VfsReadArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.VfsReadArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.VfsReadArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.VfsReadArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.VfsReadArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.VfsReadArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.VfsReadArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.VfsReadArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Count)
-      if err != nil {
-        return types.VfsReadArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Pos)
-      if err != nil {
-        return types.VfsReadArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.VfsReadArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.VfsReadArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.VfsReadArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Count)
+			if err != nil {
+				return types.VfsReadArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Pos)
+			if err != nil {
+				return types.VfsReadArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseVfsReadvArgs(decoder *Decoder) (types.VfsReadvArgs, error) {
-  var result types.VfsReadvArgs
-  var err error
+	var result types.VfsReadvArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.VfsReadvArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.VfsReadvArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.VfsReadvArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.VfsReadvArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.VfsReadvArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.VfsReadvArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.VfsReadvArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Vlen)
-      if err != nil {
-        return types.VfsReadvArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Pos)
-      if err != nil {
-        return types.VfsReadvArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.VfsReadvArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.VfsReadvArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.VfsReadvArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Vlen)
+			if err != nil {
+				return types.VfsReadvArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Pos)
+			if err != nil {
+				return types.VfsReadvArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseVfsUtimesArgs(decoder *Decoder) (types.VfsUtimesArgs, error) {
-  var result types.VfsUtimesArgs
-  var err error
+	var result types.VfsUtimesArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.VfsUtimesArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.VfsUtimesArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.VfsUtimesArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.VfsUtimesArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.VfsUtimesArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.VfsUtimesArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.VfsUtimesArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Atime)
-      if err != nil {
-        return types.VfsUtimesArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.Mtime)
-      if err != nil {
-        return types.VfsUtimesArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.VfsUtimesArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.VfsUtimesArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.VfsUtimesArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Atime)
+			if err != nil {
+				return types.VfsUtimesArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.Mtime)
+			if err != nil {
+				return types.VfsUtimesArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseDoTruncateArgs(decoder *Decoder) (types.DoTruncateArgs, error) {
-  var result types.DoTruncateArgs
-  var err error
+	var result types.DoTruncateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.DoTruncateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.DoTruncateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.DoTruncateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.DoTruncateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.DoTruncateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.DoTruncateArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.DoTruncateArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.Length)
-      if err != nil {
-        return types.DoTruncateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.DoTruncateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.DoTruncateArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.DoTruncateArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.Length)
+			if err != nil {
+				return types.DoTruncateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseFileModificationArgs(decoder *Decoder) (types.FileModificationArgs, error) {
-  var result types.FileModificationArgs
-  var err error
+	var result types.FileModificationArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.FileModificationArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.FileModificationArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.FileModificationArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.FileModificationArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.FilePath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.FileModificationArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.FileModificationArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.FileModificationArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.OldCtime)
-      if err != nil {
-        return types.FileModificationArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.NewCtime)
-      if err != nil {
-        return types.FileModificationArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.FilePath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.FileModificationArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.FileModificationArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.FileModificationArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.OldCtime)
+			if err != nil {
+				return types.FileModificationArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.NewCtime)
+			if err != nil {
+				return types.FileModificationArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseInotifyWatchArgs(decoder *Decoder) (types.InotifyWatchArgs, error) {
-  var result types.InotifyWatchArgs
-  var err error
+	var result types.InotifyWatchArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.InotifyWatchArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.InotifyWatchArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.InotifyWatchArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.InotifyWatchArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Pathname, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.InotifyWatchArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint64(&result.Inode)
-      if err != nil {
-        return types.InotifyWatchArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.Dev)
-      if err != nil {
-        return types.InotifyWatchArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Pathname, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.InotifyWatchArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint64(&result.Inode)
+			if err != nil {
+				return types.InotifyWatchArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.Dev)
+			if err != nil {
+				return types.InotifyWatchArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseProcessExecuteFailedArgs(decoder *Decoder) (types.ProcessExecuteFailedArgs, error) {
-  var result types.ProcessExecuteFailedArgs
-  var err error
+	var result types.ProcessExecuteFailedArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.ProcessExecuteFailedArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.ProcessExecuteFailedArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.ProcessExecuteFailedArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.ProcessExecuteFailedArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Path, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 1:
-      result.BinaryPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.BinaryDeviceId)
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint64(&result.BinaryInodeNumber)
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 4:
-      err = decoder.DecodeUint64(&result.BinaryCtime)
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 5:
-      err = decoder.DecodeUint16(&result.BinaryInodeMode)
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 6:
-      result.InterpreterPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 7:
-      err = decoder.DecodeUint16(&result.StdinType)
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 8:
-      result.StdinPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 9:
-      err = decoder.DecodeInt32(&result.KernelInvoked)
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 10:
-      result.BinaryArguments, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    case 11:
-      result.Environment, err = decoder.ReadStringArrayFromBuff()
-      if err != nil {
-        return types.ProcessExecuteFailedArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Path, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 1:
+			result.BinaryPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.BinaryDeviceId)
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint64(&result.BinaryInodeNumber)
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 4:
+			err = decoder.DecodeUint64(&result.BinaryCtime)
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 5:
+			err = decoder.DecodeUint16(&result.BinaryInodeMode)
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 6:
+			result.InterpreterPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 7:
+			err = decoder.DecodeUint16(&result.StdinType)
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 8:
+			result.StdinPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 9:
+			err = decoder.DecodeInt32(&result.KernelInvoked)
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 10:
+			result.BinaryArguments, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		case 11:
+			result.Environment, err = decoder.ReadStringArrayFromBuff()
+			if err != nil {
+				return types.ProcessExecuteFailedArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketBaseArgs(decoder *Decoder) (types.NetPacketBaseArgs, error) {
-  return types.NetPacketBaseArgs{}, nil
+	return types.NetPacketBaseArgs{}, nil
 }
 
 func ParseNetPacketIPBaseArgs(decoder *Decoder) (types.NetPacketIPBaseArgs, error) {
-  var result types.NetPacketIPBaseArgs
-  var err error
+	var result types.NetPacketIPBaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketIPBaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketIPBaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketIPBaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketIPBaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketIPBase))
-      if err != nil {
-        return types.NetPacketIPBaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketIPBase))
+			if err != nil {
+				return types.NetPacketIPBaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketIPv4Args(decoder *Decoder) (types.NetPacketIPv4Args, error) {
-  var result types.NetPacketIPv4Args
-  var err error
+	var result types.NetPacketIPv4Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketIPv4Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketIPv4Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketIPv4Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketIPv4Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketIPv4Args{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketIPv4Args{}, err
-      }
-    case 2:
-      var dataProtoIpv4 uint64
-      err = decoder.DecodeUint64(&dataProtoIpv4)
-      if err != nil {
-        return types.NetPacketIPv4Args{}, err
-      }
-      result.ProtoIpv4 = uintptr(dataProtoIpv4)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketIPv4Args{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketIPv4Args{}, err
+			}
+		case 2:
+			var dataProtoIpv4 uint64
+			err = decoder.DecodeUint64(&dataProtoIpv4)
+			if err != nil {
+				return types.NetPacketIPv4Args{}, err
+			}
+			result.ProtoIpv4 = uintptr(dataProtoIpv4)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketIPv6Args(decoder *Decoder) (types.NetPacketIPv6Args, error) {
-  var result types.NetPacketIPv6Args
-  var err error
+	var result types.NetPacketIPv6Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketIPv6Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketIPv6Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketIPv6Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketIPv6Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketIPv6Args{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketIPv6Args{}, err
-      }
-    case 2:
-      var dataProtoIpv6 uint64
-      err = decoder.DecodeUint64(&dataProtoIpv6)
-      if err != nil {
-        return types.NetPacketIPv6Args{}, err
-      }
-      result.ProtoIpv6 = uintptr(dataProtoIpv6)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketIPv6Args{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketIPv6Args{}, err
+			}
+		case 2:
+			var dataProtoIpv6 uint64
+			err = decoder.DecodeUint64(&dataProtoIpv6)
+			if err != nil {
+				return types.NetPacketIPv6Args{}, err
+			}
+			result.ProtoIpv6 = uintptr(dataProtoIpv6)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketTCPBaseArgs(decoder *Decoder) (types.NetPacketTCPBaseArgs, error) {
-  var result types.NetPacketTCPBaseArgs
-  var err error
+	var result types.NetPacketTCPBaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketTCPBaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketTCPBaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketTCPBaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketTCPBaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketTCPBase))
-      if err != nil {
-        return types.NetPacketTCPBaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketTCPBase))
+			if err != nil {
+				return types.NetPacketTCPBaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketTCPArgs(decoder *Decoder) (types.NetPacketTCPArgs, error) {
-  var result types.NetPacketTCPArgs
-  var err error
+	var result types.NetPacketTCPArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketTCPArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketTCPArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketTCPArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketTCPArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketTCPArgs{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketTCPArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint16(&result.SrcPort)
-      if err != nil {
-        return types.NetPacketTCPArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint16(&result.DstPort)
-      if err != nil {
-        return types.NetPacketTCPArgs{}, err
-      }
-    case 4:
-      var dataProtoTcp uint64
-      err = decoder.DecodeUint64(&dataProtoTcp)
-      if err != nil {
-        return types.NetPacketTCPArgs{}, err
-      }
-      result.ProtoTcp = uintptr(dataProtoTcp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketTCPArgs{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketTCPArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint16(&result.SrcPort)
+			if err != nil {
+				return types.NetPacketTCPArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint16(&result.DstPort)
+			if err != nil {
+				return types.NetPacketTCPArgs{}, err
+			}
+		case 4:
+			var dataProtoTcp uint64
+			err = decoder.DecodeUint64(&dataProtoTcp)
+			if err != nil {
+				return types.NetPacketTCPArgs{}, err
+			}
+			result.ProtoTcp = uintptr(dataProtoTcp)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketUDPBaseArgs(decoder *Decoder) (types.NetPacketUDPBaseArgs, error) {
-  var result types.NetPacketUDPBaseArgs
-  var err error
+	var result types.NetPacketUDPBaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketUDPBaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketUDPBaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketUDPBaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketUDPBaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketUDPBase))
-      if err != nil {
-        return types.NetPacketUDPBaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketUDPBase))
+			if err != nil {
+				return types.NetPacketUDPBaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketUDPArgs(decoder *Decoder) (types.NetPacketUDPArgs, error) {
-  var result types.NetPacketUDPArgs
-  var err error
+	var result types.NetPacketUDPArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketUDPArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketUDPArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketUDPArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketUDPArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketUDPArgs{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketUDPArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint16(&result.SrcPort)
-      if err != nil {
-        return types.NetPacketUDPArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint16(&result.DstPort)
-      if err != nil {
-        return types.NetPacketUDPArgs{}, err
-      }
-    case 4:
-      var dataProtoUdp uint64
-      err = decoder.DecodeUint64(&dataProtoUdp)
-      if err != nil {
-        return types.NetPacketUDPArgs{}, err
-      }
-      result.ProtoUdp = uintptr(dataProtoUdp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketUDPArgs{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketUDPArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint16(&result.SrcPort)
+			if err != nil {
+				return types.NetPacketUDPArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint16(&result.DstPort)
+			if err != nil {
+				return types.NetPacketUDPArgs{}, err
+			}
+		case 4:
+			var dataProtoUdp uint64
+			err = decoder.DecodeUint64(&dataProtoUdp)
+			if err != nil {
+				return types.NetPacketUDPArgs{}, err
+			}
+			result.ProtoUdp = uintptr(dataProtoUdp)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketICMPBaseArgs(decoder *Decoder) (types.NetPacketICMPBaseArgs, error) {
-  var result types.NetPacketICMPBaseArgs
-  var err error
+	var result types.NetPacketICMPBaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketICMPBaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketICMPBaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketICMPBaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketICMPBaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPBase))
-      if err != nil {
-        return types.NetPacketICMPBaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPBase))
+			if err != nil {
+				return types.NetPacketICMPBaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketICMPArgs(decoder *Decoder) (types.NetPacketICMPArgs, error) {
-  var result types.NetPacketICMPArgs
-  var err error
+	var result types.NetPacketICMPArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketICMPArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketICMPArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketICMPArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketICMPArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketICMPArgs{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketICMPArgs{}, err
-      }
-    case 2:
-      var dataProtoIcmp uint64
-      err = decoder.DecodeUint64(&dataProtoIcmp)
-      if err != nil {
-        return types.NetPacketICMPArgs{}, err
-      }
-      result.ProtoIcmp = uintptr(dataProtoIcmp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketICMPArgs{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketICMPArgs{}, err
+			}
+		case 2:
+			var dataProtoIcmp uint64
+			err = decoder.DecodeUint64(&dataProtoIcmp)
+			if err != nil {
+				return types.NetPacketICMPArgs{}, err
+			}
+			result.ProtoIcmp = uintptr(dataProtoIcmp)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketICMPv6BaseArgs(decoder *Decoder) (types.NetPacketICMPv6BaseArgs, error) {
-  var result types.NetPacketICMPv6BaseArgs
-  var err error
+	var result types.NetPacketICMPv6BaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketICMPv6BaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketICMPv6BaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketICMPv6BaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketICMPv6BaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPv6Base))
-      if err != nil {
-        return types.NetPacketICMPv6BaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPv6Base))
+			if err != nil {
+				return types.NetPacketICMPv6BaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketICMPv6Args(decoder *Decoder) (types.NetPacketICMPv6Args, error) {
-  var result types.NetPacketICMPv6Args
-  var err error
+	var result types.NetPacketICMPv6Args
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketICMPv6Args{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketICMPv6Args{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketICMPv6Args{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketICMPv6Args{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketICMPv6Args{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketICMPv6Args{}, err
-      }
-    case 2:
-      var dataProtoIcmpv6 uint64
-      err = decoder.DecodeUint64(&dataProtoIcmpv6)
-      if err != nil {
-        return types.NetPacketICMPv6Args{}, err
-      }
-      result.ProtoIcmpv6 = uintptr(dataProtoIcmpv6)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketICMPv6Args{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketICMPv6Args{}, err
+			}
+		case 2:
+			var dataProtoIcmpv6 uint64
+			err = decoder.DecodeUint64(&dataProtoIcmpv6)
+			if err != nil {
+				return types.NetPacketICMPv6Args{}, err
+			}
+			result.ProtoIcmpv6 = uintptr(dataProtoIcmpv6)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketDNSBaseArgs(decoder *Decoder) (types.NetPacketDNSBaseArgs, error) {
-  var result types.NetPacketDNSBaseArgs
-  var err error
+	var result types.NetPacketDNSBaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketDNSBaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketDNSBaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketDNSBaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketDNSBaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketDNSBase))
-      if err != nil {
-        return types.NetPacketDNSBaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketDNSBase))
+			if err != nil {
+				return types.NetPacketDNSBaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketDNSArgs(decoder *Decoder) (types.NetPacketDNSArgs, error) {
-  var result types.NetPacketDNSArgs
-  var err error
+	var result types.NetPacketDNSArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketDNSArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketDNSArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketDNSArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketDNSArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketDNSArgs{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketDNSArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint16(&result.SrcPort)
-      if err != nil {
-        return types.NetPacketDNSArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint16(&result.DstPort)
-      if err != nil {
-        return types.NetPacketDNSArgs{}, err
-      }
-    case 4:
-      var dataProtoDns uint64
-      err = decoder.DecodeUint64(&dataProtoDns)
-      if err != nil {
-        return types.NetPacketDNSArgs{}, err
-      }
-      result.ProtoDns = uintptr(dataProtoDns)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketDNSArgs{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketDNSArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint16(&result.SrcPort)
+			if err != nil {
+				return types.NetPacketDNSArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint16(&result.DstPort)
+			if err != nil {
+				return types.NetPacketDNSArgs{}, err
+			}
+		case 4:
+			var dataProtoDns uint64
+			err = decoder.DecodeUint64(&dataProtoDns)
+			if err != nil {
+				return types.NetPacketDNSArgs{}, err
+			}
+			result.ProtoDns = uintptr(dataProtoDns)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketDNSRequestArgs(decoder *Decoder) (types.NetPacketDNSRequestArgs, error) {
-  var result types.NetPacketDNSRequestArgs
-  var err error
+	var result types.NetPacketDNSRequestArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketDNSRequestArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketDNSRequestArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketDNSRequestArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketDNSRequestArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataMetadata uint64
-      err = decoder.DecodeUint64(&dataMetadata)
-      if err != nil {
-        return types.NetPacketDNSRequestArgs{}, err
-      }
-      result.Metadata = uintptr(dataMetadata)
-    case 1:
-      var dataDnsQuestions uint64
-      err = decoder.DecodeUint64(&dataDnsQuestions)
-      if err != nil {
-        return types.NetPacketDNSRequestArgs{}, err
-      }
-      result.DnsQuestions = uintptr(dataDnsQuestions)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataMetadata uint64
+			err = decoder.DecodeUint64(&dataMetadata)
+			if err != nil {
+				return types.NetPacketDNSRequestArgs{}, err
+			}
+			result.Metadata = uintptr(dataMetadata)
+		case 1:
+			var dataDnsQuestions uint64
+			err = decoder.DecodeUint64(&dataDnsQuestions)
+			if err != nil {
+				return types.NetPacketDNSRequestArgs{}, err
+			}
+			result.DnsQuestions = uintptr(dataDnsQuestions)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketDNSResponseArgs(decoder *Decoder) (types.NetPacketDNSResponseArgs, error) {
-  var result types.NetPacketDNSResponseArgs
-  var err error
+	var result types.NetPacketDNSResponseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketDNSResponseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketDNSResponseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketDNSResponseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketDNSResponseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataMetadata uint64
-      err = decoder.DecodeUint64(&dataMetadata)
-      if err != nil {
-        return types.NetPacketDNSResponseArgs{}, err
-      }
-      result.Metadata = uintptr(dataMetadata)
-    case 1:
-      var dataDnsResponse uint64
-      err = decoder.DecodeUint64(&dataDnsResponse)
-      if err != nil {
-        return types.NetPacketDNSResponseArgs{}, err
-      }
-      result.DnsResponse = uintptr(dataDnsResponse)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataMetadata uint64
+			err = decoder.DecodeUint64(&dataMetadata)
+			if err != nil {
+				return types.NetPacketDNSResponseArgs{}, err
+			}
+			result.Metadata = uintptr(dataMetadata)
+		case 1:
+			var dataDnsResponse uint64
+			err = decoder.DecodeUint64(&dataDnsResponse)
+			if err != nil {
+				return types.NetPacketDNSResponseArgs{}, err
+			}
+			result.DnsResponse = uintptr(dataDnsResponse)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketHTTPBaseArgs(decoder *Decoder) (types.NetPacketHTTPBaseArgs, error) {
-  var result types.NetPacketHTTPBaseArgs
-  var err error
+	var result types.NetPacketHTTPBaseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketHTTPBaseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketHTTPBaseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketHTTPBaseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketHTTPBaseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketHTTPBase))
-      if err != nil {
-        return types.NetPacketHTTPBaseArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketHTTPBase))
+			if err != nil {
+				return types.NetPacketHTTPBaseArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketHTTPArgs(decoder *Decoder) (types.NetPacketHTTPArgs, error) {
-  var result types.NetPacketHTTPArgs
-  var err error
+	var result types.NetPacketHTTPArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketHTTPArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketHTTPArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketHTTPArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketHTTPArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Src, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketHTTPArgs{}, err
-      }
-    case 1:
-      result.Dst, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.NetPacketHTTPArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint16(&result.SrcPort)
-      if err != nil {
-        return types.NetPacketHTTPArgs{}, err
-      }
-    case 3:
-      err = decoder.DecodeUint16(&result.DstPort)
-      if err != nil {
-        return types.NetPacketHTTPArgs{}, err
-      }
-    case 4:
-      var dataProtoHttp uint64
-      err = decoder.DecodeUint64(&dataProtoHttp)
-      if err != nil {
-        return types.NetPacketHTTPArgs{}, err
-      }
-      result.ProtoHttp = uintptr(dataProtoHttp)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Src, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketHTTPArgs{}, err
+			}
+		case 1:
+			result.Dst, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.NetPacketHTTPArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint16(&result.SrcPort)
+			if err != nil {
+				return types.NetPacketHTTPArgs{}, err
+			}
+		case 3:
+			err = decoder.DecodeUint16(&result.DstPort)
+			if err != nil {
+				return types.NetPacketHTTPArgs{}, err
+			}
+		case 4:
+			var dataProtoHttp uint64
+			err = decoder.DecodeUint64(&dataProtoHttp)
+			if err != nil {
+				return types.NetPacketHTTPArgs{}, err
+			}
+			result.ProtoHttp = uintptr(dataProtoHttp)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketHTTPRequestArgs(decoder *Decoder) (types.NetPacketHTTPRequestArgs, error) {
-  var result types.NetPacketHTTPRequestArgs
-  var err error
+	var result types.NetPacketHTTPRequestArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketHTTPRequestArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketHTTPRequestArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketHTTPRequestArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketHTTPRequestArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataMetadata uint64
-      err = decoder.DecodeUint64(&dataMetadata)
-      if err != nil {
-        return types.NetPacketHTTPRequestArgs{}, err
-      }
-      result.Metadata = uintptr(dataMetadata)
-    case 1:
-      var dataHttpRequest uint64
-      err = decoder.DecodeUint64(&dataHttpRequest)
-      if err != nil {
-        return types.NetPacketHTTPRequestArgs{}, err
-      }
-      result.HttpRequest = uintptr(dataHttpRequest)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataMetadata uint64
+			err = decoder.DecodeUint64(&dataMetadata)
+			if err != nil {
+				return types.NetPacketHTTPRequestArgs{}, err
+			}
+			result.Metadata = uintptr(dataMetadata)
+		case 1:
+			var dataHttpRequest uint64
+			err = decoder.DecodeUint64(&dataHttpRequest)
+			if err != nil {
+				return types.NetPacketHTTPRequestArgs{}, err
+			}
+			result.HttpRequest = uintptr(dataHttpRequest)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketHTTPResponseArgs(decoder *Decoder) (types.NetPacketHTTPResponseArgs, error) {
-  var result types.NetPacketHTTPResponseArgs
-  var err error
+	var result types.NetPacketHTTPResponseArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketHTTPResponseArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketHTTPResponseArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketHTTPResponseArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketHTTPResponseArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      var dataMetadata uint64
-      err = decoder.DecodeUint64(&dataMetadata)
-      if err != nil {
-        return types.NetPacketHTTPResponseArgs{}, err
-      }
-      result.Metadata = uintptr(dataMetadata)
-    case 1:
-      var dataHttpResponse uint64
-      err = decoder.DecodeUint64(&dataHttpResponse)
-      if err != nil {
-        return types.NetPacketHTTPResponseArgs{}, err
-      }
-      result.HttpResponse = uintptr(dataHttpResponse)
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			var dataMetadata uint64
+			err = decoder.DecodeUint64(&dataMetadata)
+			if err != nil {
+				return types.NetPacketHTTPResponseArgs{}, err
+			}
+			result.Metadata = uintptr(dataMetadata)
+		case 1:
+			var dataHttpResponse uint64
+			err = decoder.DecodeUint64(&dataHttpResponse)
+			if err != nil {
+				return types.NetPacketHTTPResponseArgs{}, err
+			}
+			result.HttpResponse = uintptr(dataHttpResponse)
+		}
+	}
+	return result, nil
 }
 
 func ParseNetPacketCaptureArgs(decoder *Decoder) (types.NetPacketCaptureArgs, error) {
-  var result types.NetPacketCaptureArgs
-  var err error
+	var result types.NetPacketCaptureArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.NetPacketCaptureArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.NetPacketCaptureArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.NetPacketCaptureArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.NetPacketCaptureArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketCapture))
-      if err != nil {
-        return types.NetPacketCaptureArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketCapture))
+			if err != nil {
+				return types.NetPacketCaptureArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseCaptureNetPacketArgs(decoder *Decoder) (types.CaptureNetPacketArgs, error) {
-  return types.CaptureNetPacketArgs{}, nil
+	return types.CaptureNetPacketArgs{}, nil
 }
 
 func ParseSockSetStateArgs(decoder *Decoder) (types.SockSetStateArgs, error) {
-  var result types.SockSetStateArgs
-  var err error
+	var result types.SockSetStateArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SockSetStateArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SockSetStateArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SockSetStateArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SockSetStateArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint32(&result.OldState)
-      if err != nil {
-        return types.SockSetStateArgs{}, err
-      }
-    case 1:
-      err = decoder.DecodeUint32(&result.NewState)
-      if err != nil {
-        return types.SockSetStateArgs{}, err
-      }
-    case 2:
-      result.Tuple, err = decoder.ReadAddrTuple()
-      if err != nil {
-        return types.SockSetStateArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint32(&result.OldState)
+			if err != nil {
+				return types.SockSetStateArgs{}, err
+			}
+		case 1:
+			err = decoder.DecodeUint32(&result.NewState)
+			if err != nil {
+				return types.SockSetStateArgs{}, err
+			}
+		case 2:
+			result.Tuple, err = decoder.ReadAddrTuple()
+			if err != nil {
+				return types.SockSetStateArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseTrackSyscallStatsArgs(decoder *Decoder) (types.TrackSyscallStatsArgs, error) {
-  return types.TrackSyscallStatsArgs{}, nil
+	return types.TrackSyscallStatsArgs{}, nil
 }
 
 func ParseTestEventArgs(decoder *Decoder) (types.TestEventArgs, error) {
-  return types.TestEventArgs{}, nil
+	return types.TestEventArgs{}, nil
 }
 
 func ParseSignalCgroupMkdirArgs(decoder *Decoder) (types.SignalCgroupMkdirArgs, error) {
-  var result types.SignalCgroupMkdirArgs
-  var err error
+	var result types.SignalCgroupMkdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SignalCgroupMkdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SignalCgroupMkdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SignalCgroupMkdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SignalCgroupMkdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.CgroupId)
-      if err != nil {
-        return types.SignalCgroupMkdirArgs{}, err
-      }
-    case 1:
-      result.CgroupPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SignalCgroupMkdirArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.HierarchyId)
-      if err != nil {
-        return types.SignalCgroupMkdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.CgroupId)
+			if err != nil {
+				return types.SignalCgroupMkdirArgs{}, err
+			}
+		case 1:
+			result.CgroupPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SignalCgroupMkdirArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.HierarchyId)
+			if err != nil {
+				return types.SignalCgroupMkdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseSignalCgroupRmdirArgs(decoder *Decoder) (types.SignalCgroupRmdirArgs, error) {
-  var result types.SignalCgroupRmdirArgs
-  var err error
+	var result types.SignalCgroupRmdirArgs
+	var err error
 
-  var numArgs uint8
-  err = decoder.DecodeUint8(&numArgs)
-  if err != nil {
-    return types.SignalCgroupRmdirArgs{}, err
-  }
+	var numArgs uint8
+	err = decoder.DecodeUint8(&numArgs)
+	if err != nil {
+		return types.SignalCgroupRmdirArgs{}, err
+	}
 
-  for arg := 0; arg < int(numArgs); arg++ {
-    var currArg uint8
-    err = decoder.DecodeUint8(&currArg)
-    if err != nil {
-      return types.SignalCgroupRmdirArgs{}, err
-    }
+	for arg := 0; arg < int(numArgs); arg++ {
+		var currArg uint8
+		err = decoder.DecodeUint8(&currArg)
+		if err != nil {
+			return types.SignalCgroupRmdirArgs{}, err
+		}
 
-    switch currArg {
-    case 0:
-      err = decoder.DecodeUint64(&result.CgroupId)
-      if err != nil {
-        return types.SignalCgroupRmdirArgs{}, err
-      }
-    case 1:
-      result.CgroupPath, err = decoder.ReadStringFromBuff()
-      if err != nil {
-        return types.SignalCgroupRmdirArgs{}, err
-      }
-    case 2:
-      err = decoder.DecodeUint32(&result.HierarchyId)
-      if err != nil {
-        return types.SignalCgroupRmdirArgs{}, err
-      }
-    }
-  }
-  return result, nil
+		switch currArg {
+		case 0:
+			err = decoder.DecodeUint64(&result.CgroupId)
+			if err != nil {
+				return types.SignalCgroupRmdirArgs{}, err
+			}
+		case 1:
+			result.CgroupPath, err = decoder.ReadStringFromBuff()
+			if err != nil {
+				return types.SignalCgroupRmdirArgs{}, err
+			}
+		case 2:
+			err = decoder.DecodeUint32(&result.HierarchyId)
+			if err != nil {
+				return types.SignalCgroupRmdirArgs{}, err
+			}
+		}
+	}
+	return result, nil
 }
 
 func ParseArgs(decoder *Decoder, event events.ID) (types.Args, error) {
-  switch event {
-  case events.Read:
-    return ParseReadArgs(decoder)
-  case events.Write:
-    return ParseWriteArgs(decoder)
-  case events.Open:
-    return ParseOpenArgs(decoder)
-  case events.Close:
-    return ParseCloseArgs(decoder)
-  case events.Stat:
-    return ParseStatArgs(decoder)
-  case events.Fstat:
-    return ParseFstatArgs(decoder)
-  case events.Lstat:
-    return ParseLstatArgs(decoder)
-  case events.Poll:
-    return ParsePollArgs(decoder)
-  case events.Lseek:
-    return ParseLseekArgs(decoder)
-  case events.Mmap:
-    return ParseMmapArgs(decoder)
-  case events.Mprotect:
-    return ParseMprotectArgs(decoder)
-  case events.Munmap:
-    return ParseMunmapArgs(decoder)
-  case events.Brk:
-    return ParseBrkArgs(decoder)
-  case events.RtSigaction:
-    return ParseRtSigactionArgs(decoder)
-  case events.RtSigprocmask:
-    return ParseRtSigprocmaskArgs(decoder)
-  case events.RtSigreturn:
-    return ParseRtSigreturnArgs(decoder)
-  case events.Ioctl:
-    return ParseIoctlArgs(decoder)
-  case events.Pread64:
-    return ParsePread64Args(decoder)
-  case events.Pwrite64:
-    return ParsePwrite64Args(decoder)
-  case events.Readv:
-    return ParseReadvArgs(decoder)
-  case events.Writev:
-    return ParseWritevArgs(decoder)
-  case events.Access:
-    return ParseAccessArgs(decoder)
-  case events.Pipe:
-    return ParsePipeArgs(decoder)
-  case events.Select:
-    return ParseSelectArgs(decoder)
-  case events.SchedYield:
-    return ParseSchedYieldArgs(decoder)
-  case events.Mremap:
-    return ParseMremapArgs(decoder)
-  case events.Msync:
-    return ParseMsyncArgs(decoder)
-  case events.Mincore:
-    return ParseMincoreArgs(decoder)
-  case events.Madvise:
-    return ParseMadviseArgs(decoder)
-  case events.Shmget:
-    return ParseShmgetArgs(decoder)
-  case events.Shmat:
-    return ParseShmatArgs(decoder)
-  case events.Shmctl:
-    return ParseShmctlArgs(decoder)
-  case events.Dup:
-    return ParseDupArgs(decoder)
-  case events.Dup2:
-    return ParseDup2Args(decoder)
-  case events.Pause:
-    return ParsePauseArgs(decoder)
-  case events.Nanosleep:
-    return ParseNanosleepArgs(decoder)
-  case events.Getitimer:
-    return ParseGetitimerArgs(decoder)
-  case events.Alarm:
-    return ParseAlarmArgs(decoder)
-  case events.Setitimer:
-    return ParseSetitimerArgs(decoder)
-  case events.Getpid:
-    return ParseGetpidArgs(decoder)
-  case events.Sendfile:
-    return ParseSendfileArgs(decoder)
-  case events.Socket:
-    return ParseSocketArgs(decoder)
-  case events.Connect:
-    return ParseConnectArgs(decoder)
-  case events.Accept:
-    return ParseAcceptArgs(decoder)
-  case events.Sendto:
-    return ParseSendtoArgs(decoder)
-  case events.Recvfrom:
-    return ParseRecvfromArgs(decoder)
-  case events.Sendmsg:
-    return ParseSendmsgArgs(decoder)
-  case events.Recvmsg:
-    return ParseRecvmsgArgs(decoder)
-  case events.Shutdown:
-    return ParseShutdownArgs(decoder)
-  case events.Bind:
-    return ParseBindArgs(decoder)
-  case events.Listen:
-    return ParseListenArgs(decoder)
-  case events.Getsockname:
-    return ParseGetsocknameArgs(decoder)
-  case events.Getpeername:
-    return ParseGetpeernameArgs(decoder)
-  case events.Socketpair:
-    return ParseSocketpairArgs(decoder)
-  case events.Setsockopt:
-    return ParseSetsockoptArgs(decoder)
-  case events.Getsockopt:
-    return ParseGetsockoptArgs(decoder)
-  case events.Clone:
-    return ParseCloneArgs(decoder)
-  case events.Fork:
-    return ParseForkArgs(decoder)
-  case events.Vfork:
-    return ParseVforkArgs(decoder)
-  case events.Execve:
-    return ParseExecveArgs(decoder)
-  case events.Exit:
-    return ParseExitArgs(decoder)
-  case events.Wait4:
-    return ParseWait4Args(decoder)
-  case events.Kill:
-    return ParseKillArgs(decoder)
-  case events.Uname:
-    return ParseUnameArgs(decoder)
-  case events.Semget:
-    return ParseSemgetArgs(decoder)
-  case events.Semop:
-    return ParseSemopArgs(decoder)
-  case events.Semctl:
-    return ParseSemctlArgs(decoder)
-  case events.Shmdt:
-    return ParseShmdtArgs(decoder)
-  case events.Msgget:
-    return ParseMsggetArgs(decoder)
-  case events.Msgsnd:
-    return ParseMsgsndArgs(decoder)
-  case events.Msgrcv:
-    return ParseMsgrcvArgs(decoder)
-  case events.Msgctl:
-    return ParseMsgctlArgs(decoder)
-  case events.Fcntl:
-    return ParseFcntlArgs(decoder)
-  case events.Flock:
-    return ParseFlockArgs(decoder)
-  case events.Fsync:
-    return ParseFsyncArgs(decoder)
-  case events.Fdatasync:
-    return ParseFdatasyncArgs(decoder)
-  case events.Truncate:
-    return ParseTruncateArgs(decoder)
-  case events.Ftruncate:
-    return ParseFtruncateArgs(decoder)
-  case events.Getdents:
-    return ParseGetdentsArgs(decoder)
-  case events.Getcwd:
-    return ParseGetcwdArgs(decoder)
-  case events.Chdir:
-    return ParseChdirArgs(decoder)
-  case events.Fchdir:
-    return ParseFchdirArgs(decoder)
-  case events.Rename:
-    return ParseRenameArgs(decoder)
-  case events.Mkdir:
-    return ParseMkdirArgs(decoder)
-  case events.Rmdir:
-    return ParseRmdirArgs(decoder)
-  case events.Creat:
-    return ParseCreatArgs(decoder)
-  case events.Link:
-    return ParseLinkArgs(decoder)
-  case events.Unlink:
-    return ParseUnlinkArgs(decoder)
-  case events.Symlink:
-    return ParseSymlinkArgs(decoder)
-  case events.Readlink:
-    return ParseReadlinkArgs(decoder)
-  case events.Chmod:
-    return ParseChmodArgs(decoder)
-  case events.Fchmod:
-    return ParseFchmodArgs(decoder)
-  case events.Chown:
-    return ParseChownArgs(decoder)
-  case events.Fchown:
-    return ParseFchownArgs(decoder)
-  case events.Lchown:
-    return ParseLchownArgs(decoder)
-  case events.Umask:
-    return ParseUmaskArgs(decoder)
-  case events.Gettimeofday:
-    return ParseGettimeofdayArgs(decoder)
-  case events.Getrlimit:
-    return ParseGetrlimitArgs(decoder)
-  case events.Getrusage:
-    return ParseGetrusageArgs(decoder)
-  case events.Sysinfo:
-    return ParseSysinfoArgs(decoder)
-  case events.Times:
-    return ParseTimesArgs(decoder)
-  case events.Ptrace:
-    return ParsePtraceArgs(decoder)
-  case events.Getuid:
-    return ParseGetuidArgs(decoder)
-  case events.Syslog:
-    return ParseSyslogArgs(decoder)
-  case events.Getgid:
-    return ParseGetgidArgs(decoder)
-  case events.Setuid:
-    return ParseSetuidArgs(decoder)
-  case events.Setgid:
-    return ParseSetgidArgs(decoder)
-  case events.Geteuid:
-    return ParseGeteuidArgs(decoder)
-  case events.Getegid:
-    return ParseGetegidArgs(decoder)
-  case events.Setpgid:
-    return ParseSetpgidArgs(decoder)
-  case events.Getppid:
-    return ParseGetppidArgs(decoder)
-  case events.Getpgrp:
-    return ParseGetpgrpArgs(decoder)
-  case events.Setsid:
-    return ParseSetsidArgs(decoder)
-  case events.Setreuid:
-    return ParseSetreuidArgs(decoder)
-  case events.Setregid:
-    return ParseSetregidArgs(decoder)
-  case events.Getgroups:
-    return ParseGetgroupsArgs(decoder)
-  case events.Setgroups:
-    return ParseSetgroupsArgs(decoder)
-  case events.Setresuid:
-    return ParseSetresuidArgs(decoder)
-  case events.Getresuid:
-    return ParseGetresuidArgs(decoder)
-  case events.Setresgid:
-    return ParseSetresgidArgs(decoder)
-  case events.Getresgid:
-    return ParseGetresgidArgs(decoder)
-  case events.Getpgid:
-    return ParseGetpgidArgs(decoder)
-  case events.Setfsuid:
-    return ParseSetfsuidArgs(decoder)
-  case events.Setfsgid:
-    return ParseSetfsgidArgs(decoder)
-  case events.Getsid:
-    return ParseGetsidArgs(decoder)
-  case events.Capget:
-    return ParseCapgetArgs(decoder)
-  case events.Capset:
-    return ParseCapsetArgs(decoder)
-  case events.RtSigpending:
-    return ParseRtSigpendingArgs(decoder)
-  case events.RtSigtimedwait:
-    return ParseRtSigtimedwaitArgs(decoder)
-  case events.RtSigqueueinfo:
-    return ParseRtSigqueueinfoArgs(decoder)
-  case events.RtSigsuspend:
-    return ParseRtSigsuspendArgs(decoder)
-  case events.Sigaltstack:
-    return ParseSigaltstackArgs(decoder)
-  case events.Utime:
-    return ParseUtimeArgs(decoder)
-  case events.Mknod:
-    return ParseMknodArgs(decoder)
-  case events.Uselib:
-    return ParseUselibArgs(decoder)
-  case events.Personality:
-    return ParsePersonalityArgs(decoder)
-  case events.Ustat:
-    return ParseUstatArgs(decoder)
-  case events.Statfs:
-    return ParseStatfsArgs(decoder)
-  case events.Fstatfs:
-    return ParseFstatfsArgs(decoder)
-  case events.Sysfs:
-    return ParseSysfsArgs(decoder)
-  case events.Getpriority:
-    return ParseGetpriorityArgs(decoder)
-  case events.Setpriority:
-    return ParseSetpriorityArgs(decoder)
-  case events.SchedSetparam:
-    return ParseSchedSetparamArgs(decoder)
-  case events.SchedGetparam:
-    return ParseSchedGetparamArgs(decoder)
-  case events.SchedSetscheduler:
-    return ParseSchedSetschedulerArgs(decoder)
-  case events.SchedGetscheduler:
-    return ParseSchedGetschedulerArgs(decoder)
-  case events.SchedGetPriorityMax:
-    return ParseSchedGetPriorityMaxArgs(decoder)
-  case events.SchedGetPriorityMin:
-    return ParseSchedGetPriorityMinArgs(decoder)
-  case events.SchedRrGetInterval:
-    return ParseSchedRrGetIntervalArgs(decoder)
-  case events.Mlock:
-    return ParseMlockArgs(decoder)
-  case events.Munlock:
-    return ParseMunlockArgs(decoder)
-  case events.Mlockall:
-    return ParseMlockallArgs(decoder)
-  case events.Munlockall:
-    return ParseMunlockallArgs(decoder)
-  case events.Vhangup:
-    return ParseVhangupArgs(decoder)
-  case events.ModifyLdt:
-    return ParseModifyLdtArgs(decoder)
-  case events.PivotRoot:
-    return ParsePivotRootArgs(decoder)
-  case events.Sysctl:
-    return ParseSysctlArgs(decoder)
-  case events.Prctl:
-    return ParsePrctlArgs(decoder)
-  case events.ArchPrctl:
-    return ParseArchPrctlArgs(decoder)
-  case events.Adjtimex:
-    return ParseAdjtimexArgs(decoder)
-  case events.Setrlimit:
-    return ParseSetrlimitArgs(decoder)
-  case events.Chroot:
-    return ParseChrootArgs(decoder)
-  case events.Sync:
-    return ParseSyncArgs(decoder)
-  case events.Acct:
-    return ParseAcctArgs(decoder)
-  case events.Settimeofday:
-    return ParseSettimeofdayArgs(decoder)
-  case events.Mount:
-    return ParseMountArgs(decoder)
-  case events.Umount2:
-    return ParseUmount2Args(decoder)
-  case events.Swapon:
-    return ParseSwaponArgs(decoder)
-  case events.Swapoff:
-    return ParseSwapoffArgs(decoder)
-  case events.Reboot:
-    return ParseRebootArgs(decoder)
-  case events.Sethostname:
-    return ParseSethostnameArgs(decoder)
-  case events.Setdomainname:
-    return ParseSetdomainnameArgs(decoder)
-  case events.Iopl:
-    return ParseIoplArgs(decoder)
-  case events.Ioperm:
-    return ParseIopermArgs(decoder)
-  case events.CreateModule:
-    return ParseCreateModuleArgs(decoder)
-  case events.InitModule:
-    return ParseInitModuleArgs(decoder)
-  case events.DeleteModule:
-    return ParseDeleteModuleArgs(decoder)
-  case events.GetKernelSyms:
-    return ParseGetKernelSymsArgs(decoder)
-  case events.QueryModule:
-    return ParseQueryModuleArgs(decoder)
-  case events.Quotactl:
-    return ParseQuotactlArgs(decoder)
-  case events.Nfsservctl:
-    return ParseNfsservctlArgs(decoder)
-  case events.Getpmsg:
-    return ParseGetpmsgArgs(decoder)
-  case events.Putpmsg:
-    return ParsePutpmsgArgs(decoder)
-  case events.Afs:
-    return ParseAfsArgs(decoder)
-  case events.Tuxcall:
-    return ParseTuxcallArgs(decoder)
-  case events.Security:
-    return ParseSecurityArgs(decoder)
-  case events.Gettid:
-    return ParseGettidArgs(decoder)
-  case events.Readahead:
-    return ParseReadaheadArgs(decoder)
-  case events.Setxattr:
-    return ParseSetxattrArgs(decoder)
-  case events.Lsetxattr:
-    return ParseLsetxattrArgs(decoder)
-  case events.Fsetxattr:
-    return ParseFsetxattrArgs(decoder)
-  case events.Getxattr:
-    return ParseGetxattrArgs(decoder)
-  case events.Lgetxattr:
-    return ParseLgetxattrArgs(decoder)
-  case events.Fgetxattr:
-    return ParseFgetxattrArgs(decoder)
-  case events.Listxattr:
-    return ParseListxattrArgs(decoder)
-  case events.Llistxattr:
-    return ParseLlistxattrArgs(decoder)
-  case events.Flistxattr:
-    return ParseFlistxattrArgs(decoder)
-  case events.Removexattr:
-    return ParseRemovexattrArgs(decoder)
-  case events.Lremovexattr:
-    return ParseLremovexattrArgs(decoder)
-  case events.Fremovexattr:
-    return ParseFremovexattrArgs(decoder)
-  case events.Tkill:
-    return ParseTkillArgs(decoder)
-  case events.Time:
-    return ParseTimeArgs(decoder)
-  case events.Futex:
-    return ParseFutexArgs(decoder)
-  case events.SchedSetaffinity:
-    return ParseSchedSetaffinityArgs(decoder)
-  case events.SchedGetaffinity:
-    return ParseSchedGetaffinityArgs(decoder)
-  case events.SetThreadArea:
-    return ParseSetThreadAreaArgs(decoder)
-  case events.IoSetup:
-    return ParseIoSetupArgs(decoder)
-  case events.IoDestroy:
-    return ParseIoDestroyArgs(decoder)
-  case events.IoGetevents:
-    return ParseIoGeteventsArgs(decoder)
-  case events.IoSubmit:
-    return ParseIoSubmitArgs(decoder)
-  case events.IoCancel:
-    return ParseIoCancelArgs(decoder)
-  case events.GetThreadArea:
-    return ParseGetThreadAreaArgs(decoder)
-  case events.LookupDcookie:
-    return ParseLookupDcookieArgs(decoder)
-  case events.EpollCreate:
-    return ParseEpollCreateArgs(decoder)
-  case events.EpollCtlOld:
-    return ParseEpollCtlOldArgs(decoder)
-  case events.EpollWaitOld:
-    return ParseEpollWaitOldArgs(decoder)
-  case events.RemapFilePages:
-    return ParseRemapFilePagesArgs(decoder)
-  case events.Getdents64:
-    return ParseGetdents64Args(decoder)
-  case events.SetTidAddress:
-    return ParseSetTidAddressArgs(decoder)
-  case events.RestartSyscall:
-    return ParseRestartSyscallArgs(decoder)
-  case events.Semtimedop:
-    return ParseSemtimedopArgs(decoder)
-  case events.Fadvise64:
-    return ParseFadvise64Args(decoder)
-  case events.TimerCreate:
-    return ParseTimerCreateArgs(decoder)
-  case events.TimerSettime:
-    return ParseTimerSettimeArgs(decoder)
-  case events.TimerGettime:
-    return ParseTimerGettimeArgs(decoder)
-  case events.TimerGetoverrun:
-    return ParseTimerGetoverrunArgs(decoder)
-  case events.TimerDelete:
-    return ParseTimerDeleteArgs(decoder)
-  case events.ClockSettime:
-    return ParseClockSettimeArgs(decoder)
-  case events.ClockGettime:
-    return ParseClockGettimeArgs(decoder)
-  case events.ClockGetres:
-    return ParseClockGetresArgs(decoder)
-  case events.ClockNanosleep:
-    return ParseClockNanosleepArgs(decoder)
-  case events.ExitGroup:
-    return ParseExitGroupArgs(decoder)
-  case events.EpollWait:
-    return ParseEpollWaitArgs(decoder)
-  case events.EpollCtl:
-    return ParseEpollCtlArgs(decoder)
-  case events.Tgkill:
-    return ParseTgkillArgs(decoder)
-  case events.Utimes:
-    return ParseUtimesArgs(decoder)
-  case events.Vserver:
-    return ParseVserverArgs(decoder)
-  case events.Mbind:
-    return ParseMbindArgs(decoder)
-  case events.SetMempolicy:
-    return ParseSetMempolicyArgs(decoder)
-  case events.GetMempolicy:
-    return ParseGetMempolicyArgs(decoder)
-  case events.MqOpen:
-    return ParseMqOpenArgs(decoder)
-  case events.MqUnlink:
-    return ParseMqUnlinkArgs(decoder)
-  case events.MqTimedsend:
-    return ParseMqTimedsendArgs(decoder)
-  case events.MqTimedreceive:
-    return ParseMqTimedreceiveArgs(decoder)
-  case events.MqNotify:
-    return ParseMqNotifyArgs(decoder)
-  case events.MqGetsetattr:
-    return ParseMqGetsetattrArgs(decoder)
-  case events.KexecLoad:
-    return ParseKexecLoadArgs(decoder)
-  case events.Waitid:
-    return ParseWaitidArgs(decoder)
-  case events.AddKey:
-    return ParseAddKeyArgs(decoder)
-  case events.RequestKey:
-    return ParseRequestKeyArgs(decoder)
-  case events.Keyctl:
-    return ParseKeyctlArgs(decoder)
-  case events.IoprioSet:
-    return ParseIoprioSetArgs(decoder)
-  case events.IoprioGet:
-    return ParseIoprioGetArgs(decoder)
-  case events.InotifyInit:
-    return ParseInotifyInitArgs(decoder)
-  case events.InotifyAddWatch:
-    return ParseInotifyAddWatchArgs(decoder)
-  case events.InotifyRmWatch:
-    return ParseInotifyRmWatchArgs(decoder)
-  case events.MigratePages:
-    return ParseMigratePagesArgs(decoder)
-  case events.Openat:
-    return ParseOpenatArgs(decoder)
-  case events.Mkdirat:
-    return ParseMkdiratArgs(decoder)
-  case events.Mknodat:
-    return ParseMknodatArgs(decoder)
-  case events.Fchownat:
-    return ParseFchownatArgs(decoder)
-  case events.Futimesat:
-    return ParseFutimesatArgs(decoder)
-  case events.Newfstatat:
-    return ParseNewfstatatArgs(decoder)
-  case events.Unlinkat:
-    return ParseUnlinkatArgs(decoder)
-  case events.Renameat:
-    return ParseRenameatArgs(decoder)
-  case events.Linkat:
-    return ParseLinkatArgs(decoder)
-  case events.Symlinkat:
-    return ParseSymlinkatArgs(decoder)
-  case events.Readlinkat:
-    return ParseReadlinkatArgs(decoder)
-  case events.Fchmodat:
-    return ParseFchmodatArgs(decoder)
-  case events.Faccessat:
-    return ParseFaccessatArgs(decoder)
-  case events.Pselect6:
-    return ParsePselect6Args(decoder)
-  case events.Ppoll:
-    return ParsePpollArgs(decoder)
-  case events.Unshare:
-    return ParseUnshareArgs(decoder)
-  case events.SetRobustList:
-    return ParseSetRobustListArgs(decoder)
-  case events.GetRobustList:
-    return ParseGetRobustListArgs(decoder)
-  case events.Splice:
-    return ParseSpliceArgs(decoder)
-  case events.Tee:
-    return ParseTeeArgs(decoder)
-  case events.SyncFileRange:
-    return ParseSyncFileRangeArgs(decoder)
-  case events.Vmsplice:
-    return ParseVmspliceArgs(decoder)
-  case events.MovePages:
-    return ParseMovePagesArgs(decoder)
-  case events.Utimensat:
-    return ParseUtimensatArgs(decoder)
-  case events.EpollPwait:
-    return ParseEpollPwaitArgs(decoder)
-  case events.Signalfd:
-    return ParseSignalfdArgs(decoder)
-  case events.TimerfdCreate:
-    return ParseTimerfdCreateArgs(decoder)
-  case events.Eventfd:
-    return ParseEventfdArgs(decoder)
-  case events.Fallocate:
-    return ParseFallocateArgs(decoder)
-  case events.TimerfdSettime:
-    return ParseTimerfdSettimeArgs(decoder)
-  case events.TimerfdGettime:
-    return ParseTimerfdGettimeArgs(decoder)
-  case events.Accept4:
-    return ParseAccept4Args(decoder)
-  case events.Signalfd4:
-    return ParseSignalfd4Args(decoder)
-  case events.Eventfd2:
-    return ParseEventfd2Args(decoder)
-  case events.EpollCreate1:
-    return ParseEpollCreate1Args(decoder)
-  case events.Dup3:
-    return ParseDup3Args(decoder)
-  case events.Pipe2:
-    return ParsePipe2Args(decoder)
-  case events.InotifyInit1:
-    return ParseInotifyInit1Args(decoder)
-  case events.Preadv:
-    return ParsePreadvArgs(decoder)
-  case events.Pwritev:
-    return ParsePwritevArgs(decoder)
-  case events.RtTgsigqueueinfo:
-    return ParseRtTgsigqueueinfoArgs(decoder)
-  case events.PerfEventOpen:
-    return ParsePerfEventOpenArgs(decoder)
-  case events.Recvmmsg:
-    return ParseRecvmmsgArgs(decoder)
-  case events.FanotifyInit:
-    return ParseFanotifyInitArgs(decoder)
-  case events.FanotifyMark:
-    return ParseFanotifyMarkArgs(decoder)
-  case events.Prlimit64:
-    return ParsePrlimit64Args(decoder)
-  case events.NameToHandleAt:
-    return ParseNameToHandleAtArgs(decoder)
-  case events.OpenByHandleAt:
-    return ParseOpenByHandleAtArgs(decoder)
-  case events.ClockAdjtime:
-    return ParseClockAdjtimeArgs(decoder)
-  case events.Syncfs:
-    return ParseSyncfsArgs(decoder)
-  case events.Sendmmsg:
-    return ParseSendmmsgArgs(decoder)
-  case events.Setns:
-    return ParseSetnsArgs(decoder)
-  case events.Getcpu:
-    return ParseGetcpuArgs(decoder)
-  case events.ProcessVmReadv:
-    return ParseProcessVmReadvArgs(decoder)
-  case events.ProcessVmWritev:
-    return ParseProcessVmWritevArgs(decoder)
-  case events.Kcmp:
-    return ParseKcmpArgs(decoder)
-  case events.FinitModule:
-    return ParseFinitModuleArgs(decoder)
-  case events.SchedSetattr:
-    return ParseSchedSetattrArgs(decoder)
-  case events.SchedGetattr:
-    return ParseSchedGetattrArgs(decoder)
-  case events.Renameat2:
-    return ParseRenameat2Args(decoder)
-  case events.Seccomp:
-    return ParseSeccompArgs(decoder)
-  case events.Getrandom:
-    return ParseGetrandomArgs(decoder)
-  case events.MemfdCreate:
-    return ParseMemfdCreateArgs(decoder)
-  case events.KexecFileLoad:
-    return ParseKexecFileLoadArgs(decoder)
-  case events.Bpf:
-    return ParseBpfArgs(decoder)
-  case events.Execveat:
-    return ParseExecveatArgs(decoder)
-  case events.Userfaultfd:
-    return ParseUserfaultfdArgs(decoder)
-  case events.Membarrier:
-    return ParseMembarrierArgs(decoder)
-  case events.Mlock2:
-    return ParseMlock2Args(decoder)
-  case events.CopyFileRange:
-    return ParseCopyFileRangeArgs(decoder)
-  case events.Preadv2:
-    return ParsePreadv2Args(decoder)
-  case events.Pwritev2:
-    return ParsePwritev2Args(decoder)
-  case events.PkeyMprotect:
-    return ParsePkeyMprotectArgs(decoder)
-  case events.PkeyAlloc:
-    return ParsePkeyAllocArgs(decoder)
-  case events.PkeyFree:
-    return ParsePkeyFreeArgs(decoder)
-  case events.Statx:
-    return ParseStatxArgs(decoder)
-  case events.IoPgetevents:
-    return ParseIoPgeteventsArgs(decoder)
-  case events.Rseq:
-    return ParseRseqArgs(decoder)
-  case events.PidfdSendSignal:
-    return ParsePidfdSendSignalArgs(decoder)
-  case events.IoUringSetup:
-    return ParseIoUringSetupArgs(decoder)
-  case events.IoUringEnter:
-    return ParseIoUringEnterArgs(decoder)
-  case events.IoUringRegister:
-    return ParseIoUringRegisterArgs(decoder)
-  case events.OpenTree:
-    return ParseOpenTreeArgs(decoder)
-  case events.MoveMount:
-    return ParseMoveMountArgs(decoder)
-  case events.Fsopen:
-    return ParseFsopenArgs(decoder)
-  case events.Fsconfig:
-    return ParseFsconfigArgs(decoder)
-  case events.Fsmount:
-    return ParseFsmountArgs(decoder)
-  case events.Fspick:
-    return ParseFspickArgs(decoder)
-  case events.PidfdOpen:
-    return ParsePidfdOpenArgs(decoder)
-  case events.Clone3:
-    return ParseClone3Args(decoder)
-  case events.CloseRange:
-    return ParseCloseRangeArgs(decoder)
-  case events.Openat2:
-    return ParseOpenat2Args(decoder)
-  case events.PidfdGetfd:
-    return ParsePidfdGetfdArgs(decoder)
-  case events.Faccessat2:
-    return ParseFaccessat2Args(decoder)
-  case events.ProcessMadvise:
-    return ParseProcessMadviseArgs(decoder)
-  case events.EpollPwait2:
-    return ParseEpollPwait2Args(decoder)
-  case events.MountSetatt:
-    return ParseMountSetattArgs(decoder)
-  case events.QuotactlFd:
-    return ParseQuotactlFdArgs(decoder)
-  case events.LandlockCreateRuleset:
-    return ParseLandlockCreateRulesetArgs(decoder)
-  case events.LandlockAddRule:
-    return ParseLandlockAddRuleArgs(decoder)
-  case events.LandloclRestrictSet:
-    return ParseLandloclRestrictSetArgs(decoder)
-  case events.MemfdSecret:
-    return ParseMemfdSecretArgs(decoder)
-  case events.ProcessMrelease:
-    return ParseProcessMreleaseArgs(decoder)
-  case events.Waitpid:
-    return ParseWaitpidArgs(decoder)
-  case events.Oldfstat:
-    return ParseOldfstatArgs(decoder)
-  case events.Break:
-    return ParseBreakArgs(decoder)
-  case events.Oldstat:
-    return ParseOldstatArgs(decoder)
-  case events.Umount:
-    return ParseUmountArgs(decoder)
-  case events.Stime:
-    return ParseStimeArgs(decoder)
-  case events.Stty:
-    return ParseSttyArgs(decoder)
-  case events.Gtty:
-    return ParseGttyArgs(decoder)
-  case events.Nice:
-    return ParseNiceArgs(decoder)
-  case events.Ftime:
-    return ParseFtimeArgs(decoder)
-  case events.Prof:
-    return ParseProfArgs(decoder)
-  case events.Signal:
-    return ParseSignalArgs(decoder)
-  case events.Lock:
-    return ParseLockArgs(decoder)
-  case events.Mpx:
-    return ParseMpxArgs(decoder)
-  case events.Ulimit:
-    return ParseUlimitArgs(decoder)
-  case events.Oldolduname:
-    return ParseOldoldunameArgs(decoder)
-  case events.Sigaction:
-    return ParseSigactionArgs(decoder)
-  case events.Sgetmask:
-    return ParseSgetmaskArgs(decoder)
-  case events.Ssetmask:
-    return ParseSsetmaskArgs(decoder)
-  case events.Sigsuspend:
-    return ParseSigsuspendArgs(decoder)
-  case events.Sigpending:
-    return ParseSigpendingArgs(decoder)
-  case events.Oldlstat:
-    return ParseOldlstatArgs(decoder)
-  case events.Readdir:
-    return ParseReaddirArgs(decoder)
-  case events.Profil:
-    return ParseProfilArgs(decoder)
-  case events.Socketcall:
-    return ParseSocketcallArgs(decoder)
-  case events.Olduname:
-    return ParseOldunameArgs(decoder)
-  case events.Idle:
-    return ParseIdleArgs(decoder)
-  case events.Vm86old:
-    return ParseVm86oldArgs(decoder)
-  case events.Ipc:
-    return ParseIpcArgs(decoder)
-  case events.Sigreturn:
-    return ParseSigreturnArgs(decoder)
-  case events.Sigprocmask:
-    return ParseSigprocmaskArgs(decoder)
-  case events.Bdflush:
-    return ParseBdflushArgs(decoder)
-  case events.Afs_syscall:
-    return ParseAfs_syscallArgs(decoder)
-  case events.Llseek:
-    return ParseLlseekArgs(decoder)
-  case events.OldSelect:
-    return ParseOldSelectArgs(decoder)
-  case events.Vm86:
-    return ParseVm86Args(decoder)
-  case events.OldGetrlimit:
-    return ParseOldGetrlimitArgs(decoder)
-  case events.Mmap2:
-    return ParseMmap2Args(decoder)
-  case events.Truncate64:
-    return ParseTruncate64Args(decoder)
-  case events.Ftruncate64:
-    return ParseFtruncate64Args(decoder)
-  case events.Stat64:
-    return ParseStat64Args(decoder)
-  case events.Lstat64:
-    return ParseLstat64Args(decoder)
-  case events.Fstat64:
-    return ParseFstat64Args(decoder)
-  case events.Lchown16:
-    return ParseLchown16Args(decoder)
-  case events.Getuid16:
-    return ParseGetuid16Args(decoder)
-  case events.Getgid16:
-    return ParseGetgid16Args(decoder)
-  case events.Geteuid16:
-    return ParseGeteuid16Args(decoder)
-  case events.Getegid16:
-    return ParseGetegid16Args(decoder)
-  case events.Setreuid16:
-    return ParseSetreuid16Args(decoder)
-  case events.Setregid16:
-    return ParseSetregid16Args(decoder)
-  case events.Getgroups16:
-    return ParseGetgroups16Args(decoder)
-  case events.Setgroups16:
-    return ParseSetgroups16Args(decoder)
-  case events.Fchown16:
-    return ParseFchown16Args(decoder)
-  case events.Setresuid16:
-    return ParseSetresuid16Args(decoder)
-  case events.Getresuid16:
-    return ParseGetresuid16Args(decoder)
-  case events.Setresgid16:
-    return ParseSetresgid16Args(decoder)
-  case events.Getresgid16:
-    return ParseGetresgid16Args(decoder)
-  case events.Chown16:
-    return ParseChown16Args(decoder)
-  case events.Setuid16:
-    return ParseSetuid16Args(decoder)
-  case events.Setgid16:
-    return ParseSetgid16Args(decoder)
-  case events.Setfsuid16:
-    return ParseSetfsuid16Args(decoder)
-  case events.Setfsgid16:
-    return ParseSetfsgid16Args(decoder)
-  case events.Fcntl64:
-    return ParseFcntl64Args(decoder)
-  case events.Sendfile32:
-    return ParseSendfile32Args(decoder)
-  case events.Statfs64:
-    return ParseStatfs64Args(decoder)
-  case events.Fstatfs64:
-    return ParseFstatfs64Args(decoder)
-  case events.Fadvise64_64:
-    return ParseFadvise64_64Args(decoder)
-  case events.ClockGettime32:
-    return ParseClockGettime32Args(decoder)
-  case events.ClockSettime32:
-    return ParseClockSettime32Args(decoder)
-  case events.ClockAdjtime64:
-    return ParseClockAdjtime64Args(decoder)
-  case events.ClockGetresTime32:
-    return ParseClockGetresTime32Args(decoder)
-  case events.ClockNanosleepTime32:
-    return ParseClockNanosleepTime32Args(decoder)
-  case events.TimerGettime32:
-    return ParseTimerGettime32Args(decoder)
-  case events.TimerSettime32:
-    return ParseTimerSettime32Args(decoder)
-  case events.TimerfdGettime32:
-    return ParseTimerfdGettime32Args(decoder)
-  case events.TimerfdSettime32:
-    return ParseTimerfdSettime32Args(decoder)
-  case events.UtimensatTime32:
-    return ParseUtimensatTime32Args(decoder)
-  case events.Pselect6Time32:
-    return ParsePselect6Time32Args(decoder)
-  case events.PpollTime32:
-    return ParsePpollTime32Args(decoder)
-  case events.IoPgeteventsTime32:
-    return ParseIoPgeteventsTime32Args(decoder)
-  case events.RecvmmsgTime32:
-    return ParseRecvmmsgTime32Args(decoder)
-  case events.MqTimedsendTime32:
-    return ParseMqTimedsendTime32Args(decoder)
-  case events.MqTimedreceiveTime32:
-    return ParseMqTimedreceiveTime32Args(decoder)
-  case events.RtSigtimedwaitTime32:
-    return ParseRtSigtimedwaitTime32Args(decoder)
-  case events.FutexTime32:
-    return ParseFutexTime32Args(decoder)
-  case events.SchedRrGetInterval32:
-    return ParseSchedRrGetInterval32Args(decoder)
-  case events.SysEnter:
-    return ParseSysEnterArgs(decoder)
-  case events.SysExit:
-    return ParseSysExitArgs(decoder)
-  case events.SchedProcessFork:
-    return ParseSchedProcessForkArgs(decoder)
-  case events.SchedProcessExec:
-    return ParseSchedProcessExecArgs(decoder)
-  case events.SchedProcessExit:
-    return ParseSchedProcessExitArgs(decoder)
-  case events.SchedSwitch:
-    return ParseSchedSwitchArgs(decoder)
-  case events.ProcessOomKilled:
-    return ParseProcessOomKilledArgs(decoder)
-  case events.DoExit:
-    return ParseDoExitArgs(decoder)
-  case events.CapCapable:
-    return ParseCapCapableArgs(decoder)
-  case events.VfsWrite:
-    return ParseVfsWriteArgs(decoder)
-  case events.VfsWritev:
-    return ParseVfsWritevArgs(decoder)
-  case events.MemProtAlert:
-    return ParseMemProtAlertArgs(decoder)
-  case events.CommitCreds:
-    return ParseCommitCredsArgs(decoder)
-  case events.SwitchTaskNS:
-    return ParseSwitchTaskNSArgs(decoder)
-  case events.MagicWrite:
-    return ParseMagicWriteArgs(decoder)
-  case events.CgroupAttachTask:
-    return ParseCgroupAttachTaskArgs(decoder)
-  case events.CgroupMkdir:
-    return ParseCgroupMkdirArgs(decoder)
-  case events.CgroupRmdir:
-    return ParseCgroupRmdirArgs(decoder)
-  case events.SecurityFileOpen:
-    return ParseSecurityFileOpenArgs(decoder)
-  case events.SecurityInodeUnlink:
-    return ParseSecurityInodeUnlinkArgs(decoder)
-  case events.SecuritySocketCreate:
-    return ParseSecuritySocketCreateArgs(decoder)
-  case events.SecuritySocketListen:
-    return ParseSecuritySocketListenArgs(decoder)
-  case events.SecuritySocketConnect:
-    return ParseSecuritySocketConnectArgs(decoder)
-  case events.SecuritySocketAccept:
-    return ParseSecuritySocketAcceptArgs(decoder)
-  case events.SecuritySocketBind:
-    return ParseSecuritySocketBindArgs(decoder)
-  case events.SecuritySocketSetsockopt:
-    return ParseSecuritySocketSetsockoptArgs(decoder)
-  case events.SecuritySbMount:
-    return ParseSecuritySbMountArgs(decoder)
-  case events.SecurityBPF:
-    return ParseSecurityBPFArgs(decoder)
-  case events.SecurityBPFMap:
-    return ParseSecurityBPFMapArgs(decoder)
-  case events.SecurityKernelReadFile:
-    return ParseSecurityKernelReadFileArgs(decoder)
-  case events.SecurityPostReadFile:
-    return ParseSecurityPostReadFileArgs(decoder)
-  case events.SecurityInodeMknod:
-    return ParseSecurityInodeMknodArgs(decoder)
-  case events.SecurityInodeSymlinkEventId:
-    return ParseSecurityInodeSymlinkEventIdArgs(decoder)
-  case events.SecurityMmapFile:
-    return ParseSecurityMmapFileArgs(decoder)
-  case events.DoMmap:
-    return ParseDoMmapArgs(decoder)
-  case events.SecurityFileMprotect:
-    return ParseSecurityFileMprotectArgs(decoder)
-  case events.InitNamespaces:
-    return ParseInitNamespacesArgs(decoder)
-  case events.SocketDup:
-    return ParseSocketDupArgs(decoder)
-  case events.HiddenInodes:
-    return ParseHiddenInodesArgs(decoder)
-  case events.KernelWrite:
-    return ParseKernelWriteArgs(decoder)
-  case events.DirtyPipeSplice:
-    return ParseDirtyPipeSpliceArgs(decoder)
-  case events.ContainerCreate:
-    return ParseContainerCreateArgs(decoder)
-  case events.ContainerRemove:
-    return ParseContainerRemoveArgs(decoder)
-  case events.ExistingContainer:
-    return ParseExistingContainerArgs(decoder)
-  case events.ProcCreate:
-    return ParseProcCreateArgs(decoder)
-  case events.KprobeAttach:
-    return ParseKprobeAttachArgs(decoder)
-  case events.CallUsermodeHelper:
-    return ParseCallUsermodeHelperArgs(decoder)
-  case events.DebugfsCreateFile:
-    return ParseDebugfsCreateFileArgs(decoder)
-  case events.PrintSyscallTable:
-    return ParsePrintSyscallTableArgs(decoder)
-  case events.HiddenKernelModule:
-    return ParseHiddenKernelModuleArgs(decoder)
-  case events.HiddenKernelModuleSeeker:
-    return ParseHiddenKernelModuleSeekerArgs(decoder)
-  case events.HookedSyscalls:
-    return ParseHookedSyscallsArgs(decoder)
-  case events.DebugfsCreateDir:
-    return ParseDebugfsCreateDirArgs(decoder)
-  case events.DeviceAdd:
-    return ParseDeviceAddArgs(decoder)
-  case events.RegisterChrdev:
-    return ParseRegisterChrdevArgs(decoder)
-  case events.SharedObjectLoaded:
-    return ParseSharedObjectLoadedArgs(decoder)
-  case events.SymbolsLoaded:
-    return ParseSymbolsLoadedArgs(decoder)
-  case events.SymbolsCollision:
-    return ParseSymbolsCollisionArgs(decoder)
-  case events.CaptureFileWrite:
-    return ParseCaptureFileWriteArgs(decoder)
-  case events.CaptureFileRead:
-    return ParseCaptureFileReadArgs(decoder)
-  case events.CaptureExec:
-    return ParseCaptureExecArgs(decoder)
-  case events.CaptureModule:
-    return ParseCaptureModuleArgs(decoder)
-  case events.CaptureMem:
-    return ParseCaptureMemArgs(decoder)
-  case events.CaptureBpf:
-    return ParseCaptureBpfArgs(decoder)
-  case events.DoInitModule:
-    return ParseDoInitModuleArgs(decoder)
-  case events.ModuleLoad:
-    return ParseModuleLoadArgs(decoder)
-  case events.ModuleFree:
-    return ParseModuleFreeArgs(decoder)
-  case events.SocketAccept:
-    return ParseSocketAcceptArgs(decoder)
-  case events.LoadElfPhdrs:
-    return ParseLoadElfPhdrsArgs(decoder)
-  case events.PrintNetSeqOps:
-    return ParsePrintNetSeqOpsArgs(decoder)
-  case events.HookedSeqOps:
-    return ParseHookedSeqOpsArgs(decoder)
-  case events.TaskRename:
-    return ParseTaskRenameArgs(decoder)
-  case events.SecurityInodeRename:
-    return ParseSecurityInodeRenameArgs(decoder)
-  case events.DoSigaction:
-    return ParseDoSigactionArgs(decoder)
-  case events.BpfAttach:
-    return ParseBpfAttachArgs(decoder)
-  case events.KallsymsLookupName:
-    return ParseKallsymsLookupNameArgs(decoder)
-  case events.PrintMemDump:
-    return ParsePrintMemDumpArgs(decoder)
-  case events.VfsRead:
-    return ParseVfsReadArgs(decoder)
-  case events.VfsReadv:
-    return ParseVfsReadvArgs(decoder)
-  case events.VfsUtimes:
-    return ParseVfsUtimesArgs(decoder)
-  case events.DoTruncate:
-    return ParseDoTruncateArgs(decoder)
-  case events.FileModification:
-    return ParseFileModificationArgs(decoder)
-  case events.InotifyWatch:
-    return ParseInotifyWatchArgs(decoder)
-  case events.ProcessExecuteFailed:
-    return ParseProcessExecuteFailedArgs(decoder)
-  case events.NetPacketBase:
-    return ParseNetPacketBaseArgs(decoder)
-  case events.NetPacketIPBase:
-    return ParseNetPacketIPBaseArgs(decoder)
-  case events.NetPacketIPv4:
-    return ParseNetPacketIPv4Args(decoder)
-  case events.NetPacketIPv6:
-    return ParseNetPacketIPv6Args(decoder)
-  case events.NetPacketTCPBase:
-    return ParseNetPacketTCPBaseArgs(decoder)
-  case events.NetPacketTCP:
-    return ParseNetPacketTCPArgs(decoder)
-  case events.NetPacketUDPBase:
-    return ParseNetPacketUDPBaseArgs(decoder)
-  case events.NetPacketUDP:
-    return ParseNetPacketUDPArgs(decoder)
-  case events.NetPacketICMPBase:
-    return ParseNetPacketICMPBaseArgs(decoder)
-  case events.NetPacketICMP:
-    return ParseNetPacketICMPArgs(decoder)
-  case events.NetPacketICMPv6Base:
-    return ParseNetPacketICMPv6BaseArgs(decoder)
-  case events.NetPacketICMPv6:
-    return ParseNetPacketICMPv6Args(decoder)
-  case events.NetPacketDNSBase:
-    return ParseNetPacketDNSBaseArgs(decoder)
-  case events.NetPacketDNS:
-    return ParseNetPacketDNSArgs(decoder)
-  case events.NetPacketDNSRequest:
-    return ParseNetPacketDNSRequestArgs(decoder)
-  case events.NetPacketDNSResponse:
-    return ParseNetPacketDNSResponseArgs(decoder)
-  case events.NetPacketHTTPBase:
-    return ParseNetPacketHTTPBaseArgs(decoder)
-  case events.NetPacketHTTP:
-    return ParseNetPacketHTTPArgs(decoder)
-  case events.NetPacketHTTPRequest:
-    return ParseNetPacketHTTPRequestArgs(decoder)
-  case events.NetPacketHTTPResponse:
-    return ParseNetPacketHTTPResponseArgs(decoder)
-  case events.NetPacketCapture:
-    return ParseNetPacketCaptureArgs(decoder)
-  case events.CaptureNetPacket:
-    return ParseCaptureNetPacketArgs(decoder)
-  case events.SockSetState:
-    return ParseSockSetStateArgs(decoder)
-  case events.TrackSyscallStats:
-    return ParseTrackSyscallStatsArgs(decoder)
-  case events.TestEvent:
-    return ParseTestEventArgs(decoder)
-  case events.SignalCgroupMkdir:
-    return ParseSignalCgroupMkdirArgs(decoder)
-  case events.SignalCgroupRmdir:
-    return ParseSignalCgroupRmdirArgs(decoder)
-  }
+	switch event {
+	case events.Read:
+		return ParseReadArgs(decoder)
+	case events.Write:
+		return ParseWriteArgs(decoder)
+	case events.Open:
+		return ParseOpenArgs(decoder)
+	case events.Close:
+		return ParseCloseArgs(decoder)
+	case events.Stat:
+		return ParseStatArgs(decoder)
+	case events.Fstat:
+		return ParseFstatArgs(decoder)
+	case events.Lstat:
+		return ParseLstatArgs(decoder)
+	case events.Poll:
+		return ParsePollArgs(decoder)
+	case events.Lseek:
+		return ParseLseekArgs(decoder)
+	case events.Mmap:
+		return ParseMmapArgs(decoder)
+	case events.Mprotect:
+		return ParseMprotectArgs(decoder)
+	case events.Munmap:
+		return ParseMunmapArgs(decoder)
+	case events.Brk:
+		return ParseBrkArgs(decoder)
+	case events.RtSigaction:
+		return ParseRtSigactionArgs(decoder)
+	case events.RtSigprocmask:
+		return ParseRtSigprocmaskArgs(decoder)
+	case events.RtSigreturn:
+		return ParseRtSigreturnArgs(decoder)
+	case events.Ioctl:
+		return ParseIoctlArgs(decoder)
+	case events.Pread64:
+		return ParsePread64Args(decoder)
+	case events.Pwrite64:
+		return ParsePwrite64Args(decoder)
+	case events.Readv:
+		return ParseReadvArgs(decoder)
+	case events.Writev:
+		return ParseWritevArgs(decoder)
+	case events.Access:
+		return ParseAccessArgs(decoder)
+	case events.Pipe:
+		return ParsePipeArgs(decoder)
+	case events.Select:
+		return ParseSelectArgs(decoder)
+	case events.SchedYield:
+		return ParseSchedYieldArgs(decoder)
+	case events.Mremap:
+		return ParseMremapArgs(decoder)
+	case events.Msync:
+		return ParseMsyncArgs(decoder)
+	case events.Mincore:
+		return ParseMincoreArgs(decoder)
+	case events.Madvise:
+		return ParseMadviseArgs(decoder)
+	case events.Shmget:
+		return ParseShmgetArgs(decoder)
+	case events.Shmat:
+		return ParseShmatArgs(decoder)
+	case events.Shmctl:
+		return ParseShmctlArgs(decoder)
+	case events.Dup:
+		return ParseDupArgs(decoder)
+	case events.Dup2:
+		return ParseDup2Args(decoder)
+	case events.Pause:
+		return ParsePauseArgs(decoder)
+	case events.Nanosleep:
+		return ParseNanosleepArgs(decoder)
+	case events.Getitimer:
+		return ParseGetitimerArgs(decoder)
+	case events.Alarm:
+		return ParseAlarmArgs(decoder)
+	case events.Setitimer:
+		return ParseSetitimerArgs(decoder)
+	case events.Getpid:
+		return ParseGetpidArgs(decoder)
+	case events.Sendfile:
+		return ParseSendfileArgs(decoder)
+	case events.Socket:
+		return ParseSocketArgs(decoder)
+	case events.Connect:
+		return ParseConnectArgs(decoder)
+	case events.Accept:
+		return ParseAcceptArgs(decoder)
+	case events.Sendto:
+		return ParseSendtoArgs(decoder)
+	case events.Recvfrom:
+		return ParseRecvfromArgs(decoder)
+	case events.Sendmsg:
+		return ParseSendmsgArgs(decoder)
+	case events.Recvmsg:
+		return ParseRecvmsgArgs(decoder)
+	case events.Shutdown:
+		return ParseShutdownArgs(decoder)
+	case events.Bind:
+		return ParseBindArgs(decoder)
+	case events.Listen:
+		return ParseListenArgs(decoder)
+	case events.Getsockname:
+		return ParseGetsocknameArgs(decoder)
+	case events.Getpeername:
+		return ParseGetpeernameArgs(decoder)
+	case events.Socketpair:
+		return ParseSocketpairArgs(decoder)
+	case events.Setsockopt:
+		return ParseSetsockoptArgs(decoder)
+	case events.Getsockopt:
+		return ParseGetsockoptArgs(decoder)
+	case events.Clone:
+		return ParseCloneArgs(decoder)
+	case events.Fork:
+		return ParseForkArgs(decoder)
+	case events.Vfork:
+		return ParseVforkArgs(decoder)
+	case events.Execve:
+		return ParseExecveArgs(decoder)
+	case events.Exit:
+		return ParseExitArgs(decoder)
+	case events.Wait4:
+		return ParseWait4Args(decoder)
+	case events.Kill:
+		return ParseKillArgs(decoder)
+	case events.Uname:
+		return ParseUnameArgs(decoder)
+	case events.Semget:
+		return ParseSemgetArgs(decoder)
+	case events.Semop:
+		return ParseSemopArgs(decoder)
+	case events.Semctl:
+		return ParseSemctlArgs(decoder)
+	case events.Shmdt:
+		return ParseShmdtArgs(decoder)
+	case events.Msgget:
+		return ParseMsggetArgs(decoder)
+	case events.Msgsnd:
+		return ParseMsgsndArgs(decoder)
+	case events.Msgrcv:
+		return ParseMsgrcvArgs(decoder)
+	case events.Msgctl:
+		return ParseMsgctlArgs(decoder)
+	case events.Fcntl:
+		return ParseFcntlArgs(decoder)
+	case events.Flock:
+		return ParseFlockArgs(decoder)
+	case events.Fsync:
+		return ParseFsyncArgs(decoder)
+	case events.Fdatasync:
+		return ParseFdatasyncArgs(decoder)
+	case events.Truncate:
+		return ParseTruncateArgs(decoder)
+	case events.Ftruncate:
+		return ParseFtruncateArgs(decoder)
+	case events.Getdents:
+		return ParseGetdentsArgs(decoder)
+	case events.Getcwd:
+		return ParseGetcwdArgs(decoder)
+	case events.Chdir:
+		return ParseChdirArgs(decoder)
+	case events.Fchdir:
+		return ParseFchdirArgs(decoder)
+	case events.Rename:
+		return ParseRenameArgs(decoder)
+	case events.Mkdir:
+		return ParseMkdirArgs(decoder)
+	case events.Rmdir:
+		return ParseRmdirArgs(decoder)
+	case events.Creat:
+		return ParseCreatArgs(decoder)
+	case events.Link:
+		return ParseLinkArgs(decoder)
+	case events.Unlink:
+		return ParseUnlinkArgs(decoder)
+	case events.Symlink:
+		return ParseSymlinkArgs(decoder)
+	case events.Readlink:
+		return ParseReadlinkArgs(decoder)
+	case events.Chmod:
+		return ParseChmodArgs(decoder)
+	case events.Fchmod:
+		return ParseFchmodArgs(decoder)
+	case events.Chown:
+		return ParseChownArgs(decoder)
+	case events.Fchown:
+		return ParseFchownArgs(decoder)
+	case events.Lchown:
+		return ParseLchownArgs(decoder)
+	case events.Umask:
+		return ParseUmaskArgs(decoder)
+	case events.Gettimeofday:
+		return ParseGettimeofdayArgs(decoder)
+	case events.Getrlimit:
+		return ParseGetrlimitArgs(decoder)
+	case events.Getrusage:
+		return ParseGetrusageArgs(decoder)
+	case events.Sysinfo:
+		return ParseSysinfoArgs(decoder)
+	case events.Times:
+		return ParseTimesArgs(decoder)
+	case events.Ptrace:
+		return ParsePtraceArgs(decoder)
+	case events.Getuid:
+		return ParseGetuidArgs(decoder)
+	case events.Syslog:
+		return ParseSyslogArgs(decoder)
+	case events.Getgid:
+		return ParseGetgidArgs(decoder)
+	case events.Setuid:
+		return ParseSetuidArgs(decoder)
+	case events.Setgid:
+		return ParseSetgidArgs(decoder)
+	case events.Geteuid:
+		return ParseGeteuidArgs(decoder)
+	case events.Getegid:
+		return ParseGetegidArgs(decoder)
+	case events.Setpgid:
+		return ParseSetpgidArgs(decoder)
+	case events.Getppid:
+		return ParseGetppidArgs(decoder)
+	case events.Getpgrp:
+		return ParseGetpgrpArgs(decoder)
+	case events.Setsid:
+		return ParseSetsidArgs(decoder)
+	case events.Setreuid:
+		return ParseSetreuidArgs(decoder)
+	case events.Setregid:
+		return ParseSetregidArgs(decoder)
+	case events.Getgroups:
+		return ParseGetgroupsArgs(decoder)
+	case events.Setgroups:
+		return ParseSetgroupsArgs(decoder)
+	case events.Setresuid:
+		return ParseSetresuidArgs(decoder)
+	case events.Getresuid:
+		return ParseGetresuidArgs(decoder)
+	case events.Setresgid:
+		return ParseSetresgidArgs(decoder)
+	case events.Getresgid:
+		return ParseGetresgidArgs(decoder)
+	case events.Getpgid:
+		return ParseGetpgidArgs(decoder)
+	case events.Setfsuid:
+		return ParseSetfsuidArgs(decoder)
+	case events.Setfsgid:
+		return ParseSetfsgidArgs(decoder)
+	case events.Getsid:
+		return ParseGetsidArgs(decoder)
+	case events.Capget:
+		return ParseCapgetArgs(decoder)
+	case events.Capset:
+		return ParseCapsetArgs(decoder)
+	case events.RtSigpending:
+		return ParseRtSigpendingArgs(decoder)
+	case events.RtSigtimedwait:
+		return ParseRtSigtimedwaitArgs(decoder)
+	case events.RtSigqueueinfo:
+		return ParseRtSigqueueinfoArgs(decoder)
+	case events.RtSigsuspend:
+		return ParseRtSigsuspendArgs(decoder)
+	case events.Sigaltstack:
+		return ParseSigaltstackArgs(decoder)
+	case events.Utime:
+		return ParseUtimeArgs(decoder)
+	case events.Mknod:
+		return ParseMknodArgs(decoder)
+	case events.Uselib:
+		return ParseUselibArgs(decoder)
+	case events.Personality:
+		return ParsePersonalityArgs(decoder)
+	case events.Ustat:
+		return ParseUstatArgs(decoder)
+	case events.Statfs:
+		return ParseStatfsArgs(decoder)
+	case events.Fstatfs:
+		return ParseFstatfsArgs(decoder)
+	case events.Sysfs:
+		return ParseSysfsArgs(decoder)
+	case events.Getpriority:
+		return ParseGetpriorityArgs(decoder)
+	case events.Setpriority:
+		return ParseSetpriorityArgs(decoder)
+	case events.SchedSetparam:
+		return ParseSchedSetparamArgs(decoder)
+	case events.SchedGetparam:
+		return ParseSchedGetparamArgs(decoder)
+	case events.SchedSetscheduler:
+		return ParseSchedSetschedulerArgs(decoder)
+	case events.SchedGetscheduler:
+		return ParseSchedGetschedulerArgs(decoder)
+	case events.SchedGetPriorityMax:
+		return ParseSchedGetPriorityMaxArgs(decoder)
+	case events.SchedGetPriorityMin:
+		return ParseSchedGetPriorityMinArgs(decoder)
+	case events.SchedRrGetInterval:
+		return ParseSchedRrGetIntervalArgs(decoder)
+	case events.Mlock:
+		return ParseMlockArgs(decoder)
+	case events.Munlock:
+		return ParseMunlockArgs(decoder)
+	case events.Mlockall:
+		return ParseMlockallArgs(decoder)
+	case events.Munlockall:
+		return ParseMunlockallArgs(decoder)
+	case events.Vhangup:
+		return ParseVhangupArgs(decoder)
+	case events.ModifyLdt:
+		return ParseModifyLdtArgs(decoder)
+	case events.PivotRoot:
+		return ParsePivotRootArgs(decoder)
+	case events.Sysctl:
+		return ParseSysctlArgs(decoder)
+	case events.Prctl:
+		return ParsePrctlArgs(decoder)
+	case events.ArchPrctl:
+		return ParseArchPrctlArgs(decoder)
+	case events.Adjtimex:
+		return ParseAdjtimexArgs(decoder)
+	case events.Setrlimit:
+		return ParseSetrlimitArgs(decoder)
+	case events.Chroot:
+		return ParseChrootArgs(decoder)
+	case events.Sync:
+		return ParseSyncArgs(decoder)
+	case events.Acct:
+		return ParseAcctArgs(decoder)
+	case events.Settimeofday:
+		return ParseSettimeofdayArgs(decoder)
+	case events.Mount:
+		return ParseMountArgs(decoder)
+	case events.Umount2:
+		return ParseUmount2Args(decoder)
+	case events.Swapon:
+		return ParseSwaponArgs(decoder)
+	case events.Swapoff:
+		return ParseSwapoffArgs(decoder)
+	case events.Reboot:
+		return ParseRebootArgs(decoder)
+	case events.Sethostname:
+		return ParseSethostnameArgs(decoder)
+	case events.Setdomainname:
+		return ParseSetdomainnameArgs(decoder)
+	case events.Iopl:
+		return ParseIoplArgs(decoder)
+	case events.Ioperm:
+		return ParseIopermArgs(decoder)
+	case events.CreateModule:
+		return ParseCreateModuleArgs(decoder)
+	case events.InitModule:
+		return ParseInitModuleArgs(decoder)
+	case events.DeleteModule:
+		return ParseDeleteModuleArgs(decoder)
+	case events.GetKernelSyms:
+		return ParseGetKernelSymsArgs(decoder)
+	case events.QueryModule:
+		return ParseQueryModuleArgs(decoder)
+	case events.Quotactl:
+		return ParseQuotactlArgs(decoder)
+	case events.Nfsservctl:
+		return ParseNfsservctlArgs(decoder)
+	case events.Getpmsg:
+		return ParseGetpmsgArgs(decoder)
+	case events.Putpmsg:
+		return ParsePutpmsgArgs(decoder)
+	case events.Afs:
+		return ParseAfsArgs(decoder)
+	case events.Tuxcall:
+		return ParseTuxcallArgs(decoder)
+	case events.Security:
+		return ParseSecurityArgs(decoder)
+	case events.Gettid:
+		return ParseGettidArgs(decoder)
+	case events.Readahead:
+		return ParseReadaheadArgs(decoder)
+	case events.Setxattr:
+		return ParseSetxattrArgs(decoder)
+	case events.Lsetxattr:
+		return ParseLsetxattrArgs(decoder)
+	case events.Fsetxattr:
+		return ParseFsetxattrArgs(decoder)
+	case events.Getxattr:
+		return ParseGetxattrArgs(decoder)
+	case events.Lgetxattr:
+		return ParseLgetxattrArgs(decoder)
+	case events.Fgetxattr:
+		return ParseFgetxattrArgs(decoder)
+	case events.Listxattr:
+		return ParseListxattrArgs(decoder)
+	case events.Llistxattr:
+		return ParseLlistxattrArgs(decoder)
+	case events.Flistxattr:
+		return ParseFlistxattrArgs(decoder)
+	case events.Removexattr:
+		return ParseRemovexattrArgs(decoder)
+	case events.Lremovexattr:
+		return ParseLremovexattrArgs(decoder)
+	case events.Fremovexattr:
+		return ParseFremovexattrArgs(decoder)
+	case events.Tkill:
+		return ParseTkillArgs(decoder)
+	case events.Time:
+		return ParseTimeArgs(decoder)
+	case events.Futex:
+		return ParseFutexArgs(decoder)
+	case events.SchedSetaffinity:
+		return ParseSchedSetaffinityArgs(decoder)
+	case events.SchedGetaffinity:
+		return ParseSchedGetaffinityArgs(decoder)
+	case events.SetThreadArea:
+		return ParseSetThreadAreaArgs(decoder)
+	case events.IoSetup:
+		return ParseIoSetupArgs(decoder)
+	case events.IoDestroy:
+		return ParseIoDestroyArgs(decoder)
+	case events.IoGetevents:
+		return ParseIoGeteventsArgs(decoder)
+	case events.IoSubmit:
+		return ParseIoSubmitArgs(decoder)
+	case events.IoCancel:
+		return ParseIoCancelArgs(decoder)
+	case events.GetThreadArea:
+		return ParseGetThreadAreaArgs(decoder)
+	case events.LookupDcookie:
+		return ParseLookupDcookieArgs(decoder)
+	case events.EpollCreate:
+		return ParseEpollCreateArgs(decoder)
+	case events.EpollCtlOld:
+		return ParseEpollCtlOldArgs(decoder)
+	case events.EpollWaitOld:
+		return ParseEpollWaitOldArgs(decoder)
+	case events.RemapFilePages:
+		return ParseRemapFilePagesArgs(decoder)
+	case events.Getdents64:
+		return ParseGetdents64Args(decoder)
+	case events.SetTidAddress:
+		return ParseSetTidAddressArgs(decoder)
+	case events.RestartSyscall:
+		return ParseRestartSyscallArgs(decoder)
+	case events.Semtimedop:
+		return ParseSemtimedopArgs(decoder)
+	case events.Fadvise64:
+		return ParseFadvise64Args(decoder)
+	case events.TimerCreate:
+		return ParseTimerCreateArgs(decoder)
+	case events.TimerSettime:
+		return ParseTimerSettimeArgs(decoder)
+	case events.TimerGettime:
+		return ParseTimerGettimeArgs(decoder)
+	case events.TimerGetoverrun:
+		return ParseTimerGetoverrunArgs(decoder)
+	case events.TimerDelete:
+		return ParseTimerDeleteArgs(decoder)
+	case events.ClockSettime:
+		return ParseClockSettimeArgs(decoder)
+	case events.ClockGettime:
+		return ParseClockGettimeArgs(decoder)
+	case events.ClockGetres:
+		return ParseClockGetresArgs(decoder)
+	case events.ClockNanosleep:
+		return ParseClockNanosleepArgs(decoder)
+	case events.ExitGroup:
+		return ParseExitGroupArgs(decoder)
+	case events.EpollWait:
+		return ParseEpollWaitArgs(decoder)
+	case events.EpollCtl:
+		return ParseEpollCtlArgs(decoder)
+	case events.Tgkill:
+		return ParseTgkillArgs(decoder)
+	case events.Utimes:
+		return ParseUtimesArgs(decoder)
+	case events.Vserver:
+		return ParseVserverArgs(decoder)
+	case events.Mbind:
+		return ParseMbindArgs(decoder)
+	case events.SetMempolicy:
+		return ParseSetMempolicyArgs(decoder)
+	case events.GetMempolicy:
+		return ParseGetMempolicyArgs(decoder)
+	case events.MqOpen:
+		return ParseMqOpenArgs(decoder)
+	case events.MqUnlink:
+		return ParseMqUnlinkArgs(decoder)
+	case events.MqTimedsend:
+		return ParseMqTimedsendArgs(decoder)
+	case events.MqTimedreceive:
+		return ParseMqTimedreceiveArgs(decoder)
+	case events.MqNotify:
+		return ParseMqNotifyArgs(decoder)
+	case events.MqGetsetattr:
+		return ParseMqGetsetattrArgs(decoder)
+	case events.KexecLoad:
+		return ParseKexecLoadArgs(decoder)
+	case events.Waitid:
+		return ParseWaitidArgs(decoder)
+	case events.AddKey:
+		return ParseAddKeyArgs(decoder)
+	case events.RequestKey:
+		return ParseRequestKeyArgs(decoder)
+	case events.Keyctl:
+		return ParseKeyctlArgs(decoder)
+	case events.IoprioSet:
+		return ParseIoprioSetArgs(decoder)
+	case events.IoprioGet:
+		return ParseIoprioGetArgs(decoder)
+	case events.InotifyInit:
+		return ParseInotifyInitArgs(decoder)
+	case events.InotifyAddWatch:
+		return ParseInotifyAddWatchArgs(decoder)
+	case events.InotifyRmWatch:
+		return ParseInotifyRmWatchArgs(decoder)
+	case events.MigratePages:
+		return ParseMigratePagesArgs(decoder)
+	case events.Openat:
+		return ParseOpenatArgs(decoder)
+	case events.Mkdirat:
+		return ParseMkdiratArgs(decoder)
+	case events.Mknodat:
+		return ParseMknodatArgs(decoder)
+	case events.Fchownat:
+		return ParseFchownatArgs(decoder)
+	case events.Futimesat:
+		return ParseFutimesatArgs(decoder)
+	case events.Newfstatat:
+		return ParseNewfstatatArgs(decoder)
+	case events.Unlinkat:
+		return ParseUnlinkatArgs(decoder)
+	case events.Renameat:
+		return ParseRenameatArgs(decoder)
+	case events.Linkat:
+		return ParseLinkatArgs(decoder)
+	case events.Symlinkat:
+		return ParseSymlinkatArgs(decoder)
+	case events.Readlinkat:
+		return ParseReadlinkatArgs(decoder)
+	case events.Fchmodat:
+		return ParseFchmodatArgs(decoder)
+	case events.Faccessat:
+		return ParseFaccessatArgs(decoder)
+	case events.Pselect6:
+		return ParsePselect6Args(decoder)
+	case events.Ppoll:
+		return ParsePpollArgs(decoder)
+	case events.Unshare:
+		return ParseUnshareArgs(decoder)
+	case events.SetRobustList:
+		return ParseSetRobustListArgs(decoder)
+	case events.GetRobustList:
+		return ParseGetRobustListArgs(decoder)
+	case events.Splice:
+		return ParseSpliceArgs(decoder)
+	case events.Tee:
+		return ParseTeeArgs(decoder)
+	case events.SyncFileRange:
+		return ParseSyncFileRangeArgs(decoder)
+	case events.Vmsplice:
+		return ParseVmspliceArgs(decoder)
+	case events.MovePages:
+		return ParseMovePagesArgs(decoder)
+	case events.Utimensat:
+		return ParseUtimensatArgs(decoder)
+	case events.EpollPwait:
+		return ParseEpollPwaitArgs(decoder)
+	case events.Signalfd:
+		return ParseSignalfdArgs(decoder)
+	case events.TimerfdCreate:
+		return ParseTimerfdCreateArgs(decoder)
+	case events.Eventfd:
+		return ParseEventfdArgs(decoder)
+	case events.Fallocate:
+		return ParseFallocateArgs(decoder)
+	case events.TimerfdSettime:
+		return ParseTimerfdSettimeArgs(decoder)
+	case events.TimerfdGettime:
+		return ParseTimerfdGettimeArgs(decoder)
+	case events.Accept4:
+		return ParseAccept4Args(decoder)
+	case events.Signalfd4:
+		return ParseSignalfd4Args(decoder)
+	case events.Eventfd2:
+		return ParseEventfd2Args(decoder)
+	case events.EpollCreate1:
+		return ParseEpollCreate1Args(decoder)
+	case events.Dup3:
+		return ParseDup3Args(decoder)
+	case events.Pipe2:
+		return ParsePipe2Args(decoder)
+	case events.InotifyInit1:
+		return ParseInotifyInit1Args(decoder)
+	case events.Preadv:
+		return ParsePreadvArgs(decoder)
+	case events.Pwritev:
+		return ParsePwritevArgs(decoder)
+	case events.RtTgsigqueueinfo:
+		return ParseRtTgsigqueueinfoArgs(decoder)
+	case events.PerfEventOpen:
+		return ParsePerfEventOpenArgs(decoder)
+	case events.Recvmmsg:
+		return ParseRecvmmsgArgs(decoder)
+	case events.FanotifyInit:
+		return ParseFanotifyInitArgs(decoder)
+	case events.FanotifyMark:
+		return ParseFanotifyMarkArgs(decoder)
+	case events.Prlimit64:
+		return ParsePrlimit64Args(decoder)
+	case events.NameToHandleAt:
+		return ParseNameToHandleAtArgs(decoder)
+	case events.OpenByHandleAt:
+		return ParseOpenByHandleAtArgs(decoder)
+	case events.ClockAdjtime:
+		return ParseClockAdjtimeArgs(decoder)
+	case events.Syncfs:
+		return ParseSyncfsArgs(decoder)
+	case events.Sendmmsg:
+		return ParseSendmmsgArgs(decoder)
+	case events.Setns:
+		return ParseSetnsArgs(decoder)
+	case events.Getcpu:
+		return ParseGetcpuArgs(decoder)
+	case events.ProcessVmReadv:
+		return ParseProcessVmReadvArgs(decoder)
+	case events.ProcessVmWritev:
+		return ParseProcessVmWritevArgs(decoder)
+	case events.Kcmp:
+		return ParseKcmpArgs(decoder)
+	case events.FinitModule:
+		return ParseFinitModuleArgs(decoder)
+	case events.SchedSetattr:
+		return ParseSchedSetattrArgs(decoder)
+	case events.SchedGetattr:
+		return ParseSchedGetattrArgs(decoder)
+	case events.Renameat2:
+		return ParseRenameat2Args(decoder)
+	case events.Seccomp:
+		return ParseSeccompArgs(decoder)
+	case events.Getrandom:
+		return ParseGetrandomArgs(decoder)
+	case events.MemfdCreate:
+		return ParseMemfdCreateArgs(decoder)
+	case events.KexecFileLoad:
+		return ParseKexecFileLoadArgs(decoder)
+	case events.Bpf:
+		return ParseBpfArgs(decoder)
+	case events.Execveat:
+		return ParseExecveatArgs(decoder)
+	case events.Userfaultfd:
+		return ParseUserfaultfdArgs(decoder)
+	case events.Membarrier:
+		return ParseMembarrierArgs(decoder)
+	case events.Mlock2:
+		return ParseMlock2Args(decoder)
+	case events.CopyFileRange:
+		return ParseCopyFileRangeArgs(decoder)
+	case events.Preadv2:
+		return ParsePreadv2Args(decoder)
+	case events.Pwritev2:
+		return ParsePwritev2Args(decoder)
+	case events.PkeyMprotect:
+		return ParsePkeyMprotectArgs(decoder)
+	case events.PkeyAlloc:
+		return ParsePkeyAllocArgs(decoder)
+	case events.PkeyFree:
+		return ParsePkeyFreeArgs(decoder)
+	case events.Statx:
+		return ParseStatxArgs(decoder)
+	case events.IoPgetevents:
+		return ParseIoPgeteventsArgs(decoder)
+	case events.Rseq:
+		return ParseRseqArgs(decoder)
+	case events.PidfdSendSignal:
+		return ParsePidfdSendSignalArgs(decoder)
+	case events.IoUringSetup:
+		return ParseIoUringSetupArgs(decoder)
+	case events.IoUringEnter:
+		return ParseIoUringEnterArgs(decoder)
+	case events.IoUringRegister:
+		return ParseIoUringRegisterArgs(decoder)
+	case events.OpenTree:
+		return ParseOpenTreeArgs(decoder)
+	case events.MoveMount:
+		return ParseMoveMountArgs(decoder)
+	case events.Fsopen:
+		return ParseFsopenArgs(decoder)
+	case events.Fsconfig:
+		return ParseFsconfigArgs(decoder)
+	case events.Fsmount:
+		return ParseFsmountArgs(decoder)
+	case events.Fspick:
+		return ParseFspickArgs(decoder)
+	case events.PidfdOpen:
+		return ParsePidfdOpenArgs(decoder)
+	case events.Clone3:
+		return ParseClone3Args(decoder)
+	case events.CloseRange:
+		return ParseCloseRangeArgs(decoder)
+	case events.Openat2:
+		return ParseOpenat2Args(decoder)
+	case events.PidfdGetfd:
+		return ParsePidfdGetfdArgs(decoder)
+	case events.Faccessat2:
+		return ParseFaccessat2Args(decoder)
+	case events.ProcessMadvise:
+		return ParseProcessMadviseArgs(decoder)
+	case events.EpollPwait2:
+		return ParseEpollPwait2Args(decoder)
+	case events.MountSetatt:
+		return ParseMountSetattArgs(decoder)
+	case events.QuotactlFd:
+		return ParseQuotactlFdArgs(decoder)
+	case events.LandlockCreateRuleset:
+		return ParseLandlockCreateRulesetArgs(decoder)
+	case events.LandlockAddRule:
+		return ParseLandlockAddRuleArgs(decoder)
+	case events.LandloclRestrictSet:
+		return ParseLandloclRestrictSetArgs(decoder)
+	case events.MemfdSecret:
+		return ParseMemfdSecretArgs(decoder)
+	case events.ProcessMrelease:
+		return ParseProcessMreleaseArgs(decoder)
+	case events.Waitpid:
+		return ParseWaitpidArgs(decoder)
+	case events.Oldfstat:
+		return ParseOldfstatArgs(decoder)
+	case events.Break:
+		return ParseBreakArgs(decoder)
+	case events.Oldstat:
+		return ParseOldstatArgs(decoder)
+	case events.Umount:
+		return ParseUmountArgs(decoder)
+	case events.Stime:
+		return ParseStimeArgs(decoder)
+	case events.Stty:
+		return ParseSttyArgs(decoder)
+	case events.Gtty:
+		return ParseGttyArgs(decoder)
+	case events.Nice:
+		return ParseNiceArgs(decoder)
+	case events.Ftime:
+		return ParseFtimeArgs(decoder)
+	case events.Prof:
+		return ParseProfArgs(decoder)
+	case events.Signal:
+		return ParseSignalArgs(decoder)
+	case events.Lock:
+		return ParseLockArgs(decoder)
+	case events.Mpx:
+		return ParseMpxArgs(decoder)
+	case events.Ulimit:
+		return ParseUlimitArgs(decoder)
+	case events.Oldolduname:
+		return ParseOldoldunameArgs(decoder)
+	case events.Sigaction:
+		return ParseSigactionArgs(decoder)
+	case events.Sgetmask:
+		return ParseSgetmaskArgs(decoder)
+	case events.Ssetmask:
+		return ParseSsetmaskArgs(decoder)
+	case events.Sigsuspend:
+		return ParseSigsuspendArgs(decoder)
+	case events.Sigpending:
+		return ParseSigpendingArgs(decoder)
+	case events.Oldlstat:
+		return ParseOldlstatArgs(decoder)
+	case events.Readdir:
+		return ParseReaddirArgs(decoder)
+	case events.Profil:
+		return ParseProfilArgs(decoder)
+	case events.Socketcall:
+		return ParseSocketcallArgs(decoder)
+	case events.Olduname:
+		return ParseOldunameArgs(decoder)
+	case events.Idle:
+		return ParseIdleArgs(decoder)
+	case events.Vm86old:
+		return ParseVm86oldArgs(decoder)
+	case events.Ipc:
+		return ParseIpcArgs(decoder)
+	case events.Sigreturn:
+		return ParseSigreturnArgs(decoder)
+	case events.Sigprocmask:
+		return ParseSigprocmaskArgs(decoder)
+	case events.Bdflush:
+		return ParseBdflushArgs(decoder)
+	case events.Afs_syscall:
+		return ParseAfs_syscallArgs(decoder)
+	case events.Llseek:
+		return ParseLlseekArgs(decoder)
+	case events.OldSelect:
+		return ParseOldSelectArgs(decoder)
+	case events.Vm86:
+		return ParseVm86Args(decoder)
+	case events.OldGetrlimit:
+		return ParseOldGetrlimitArgs(decoder)
+	case events.Mmap2:
+		return ParseMmap2Args(decoder)
+	case events.Truncate64:
+		return ParseTruncate64Args(decoder)
+	case events.Ftruncate64:
+		return ParseFtruncate64Args(decoder)
+	case events.Stat64:
+		return ParseStat64Args(decoder)
+	case events.Lstat64:
+		return ParseLstat64Args(decoder)
+	case events.Fstat64:
+		return ParseFstat64Args(decoder)
+	case events.Lchown16:
+		return ParseLchown16Args(decoder)
+	case events.Getuid16:
+		return ParseGetuid16Args(decoder)
+	case events.Getgid16:
+		return ParseGetgid16Args(decoder)
+	case events.Geteuid16:
+		return ParseGeteuid16Args(decoder)
+	case events.Getegid16:
+		return ParseGetegid16Args(decoder)
+	case events.Setreuid16:
+		return ParseSetreuid16Args(decoder)
+	case events.Setregid16:
+		return ParseSetregid16Args(decoder)
+	case events.Getgroups16:
+		return ParseGetgroups16Args(decoder)
+	case events.Setgroups16:
+		return ParseSetgroups16Args(decoder)
+	case events.Fchown16:
+		return ParseFchown16Args(decoder)
+	case events.Setresuid16:
+		return ParseSetresuid16Args(decoder)
+	case events.Getresuid16:
+		return ParseGetresuid16Args(decoder)
+	case events.Setresgid16:
+		return ParseSetresgid16Args(decoder)
+	case events.Getresgid16:
+		return ParseGetresgid16Args(decoder)
+	case events.Chown16:
+		return ParseChown16Args(decoder)
+	case events.Setuid16:
+		return ParseSetuid16Args(decoder)
+	case events.Setgid16:
+		return ParseSetgid16Args(decoder)
+	case events.Setfsuid16:
+		return ParseSetfsuid16Args(decoder)
+	case events.Setfsgid16:
+		return ParseSetfsgid16Args(decoder)
+	case events.Fcntl64:
+		return ParseFcntl64Args(decoder)
+	case events.Sendfile32:
+		return ParseSendfile32Args(decoder)
+	case events.Statfs64:
+		return ParseStatfs64Args(decoder)
+	case events.Fstatfs64:
+		return ParseFstatfs64Args(decoder)
+	case events.Fadvise64_64:
+		return ParseFadvise64_64Args(decoder)
+	case events.ClockGettime32:
+		return ParseClockGettime32Args(decoder)
+	case events.ClockSettime32:
+		return ParseClockSettime32Args(decoder)
+	case events.ClockAdjtime64:
+		return ParseClockAdjtime64Args(decoder)
+	case events.ClockGetresTime32:
+		return ParseClockGetresTime32Args(decoder)
+	case events.ClockNanosleepTime32:
+		return ParseClockNanosleepTime32Args(decoder)
+	case events.TimerGettime32:
+		return ParseTimerGettime32Args(decoder)
+	case events.TimerSettime32:
+		return ParseTimerSettime32Args(decoder)
+	case events.TimerfdGettime32:
+		return ParseTimerfdGettime32Args(decoder)
+	case events.TimerfdSettime32:
+		return ParseTimerfdSettime32Args(decoder)
+	case events.UtimensatTime32:
+		return ParseUtimensatTime32Args(decoder)
+	case events.Pselect6Time32:
+		return ParsePselect6Time32Args(decoder)
+	case events.PpollTime32:
+		return ParsePpollTime32Args(decoder)
+	case events.IoPgeteventsTime32:
+		return ParseIoPgeteventsTime32Args(decoder)
+	case events.RecvmmsgTime32:
+		return ParseRecvmmsgTime32Args(decoder)
+	case events.MqTimedsendTime32:
+		return ParseMqTimedsendTime32Args(decoder)
+	case events.MqTimedreceiveTime32:
+		return ParseMqTimedreceiveTime32Args(decoder)
+	case events.RtSigtimedwaitTime32:
+		return ParseRtSigtimedwaitTime32Args(decoder)
+	case events.FutexTime32:
+		return ParseFutexTime32Args(decoder)
+	case events.SchedRrGetInterval32:
+		return ParseSchedRrGetInterval32Args(decoder)
+	case events.SysEnter:
+		return ParseSysEnterArgs(decoder)
+	case events.SysExit:
+		return ParseSysExitArgs(decoder)
+	case events.SchedProcessFork:
+		return ParseSchedProcessForkArgs(decoder)
+	case events.SchedProcessExec:
+		return ParseSchedProcessExecArgs(decoder)
+	case events.SchedProcessExit:
+		return ParseSchedProcessExitArgs(decoder)
+	case events.SchedSwitch:
+		return ParseSchedSwitchArgs(decoder)
+	case events.ProcessOomKilled:
+		return ParseProcessOomKilledArgs(decoder)
+	case events.DoExit:
+		return ParseDoExitArgs(decoder)
+	case events.CapCapable:
+		return ParseCapCapableArgs(decoder)
+	case events.VfsWrite:
+		return ParseVfsWriteArgs(decoder)
+	case events.VfsWritev:
+		return ParseVfsWritevArgs(decoder)
+	case events.MemProtAlert:
+		return ParseMemProtAlertArgs(decoder)
+	case events.CommitCreds:
+		return ParseCommitCredsArgs(decoder)
+	case events.SwitchTaskNS:
+		return ParseSwitchTaskNSArgs(decoder)
+	case events.MagicWrite:
+		return ParseMagicWriteArgs(decoder)
+	case events.CgroupAttachTask:
+		return ParseCgroupAttachTaskArgs(decoder)
+	case events.CgroupMkdir:
+		return ParseCgroupMkdirArgs(decoder)
+	case events.CgroupRmdir:
+		return ParseCgroupRmdirArgs(decoder)
+	case events.SecurityFileOpen:
+		return ParseSecurityFileOpenArgs(decoder)
+	case events.SecurityInodeUnlink:
+		return ParseSecurityInodeUnlinkArgs(decoder)
+	case events.SecuritySocketCreate:
+		return ParseSecuritySocketCreateArgs(decoder)
+	case events.SecuritySocketListen:
+		return ParseSecuritySocketListenArgs(decoder)
+	case events.SecuritySocketConnect:
+		return ParseSecuritySocketConnectArgs(decoder)
+	case events.SecuritySocketAccept:
+		return ParseSecuritySocketAcceptArgs(decoder)
+	case events.SecuritySocketBind:
+		return ParseSecuritySocketBindArgs(decoder)
+	case events.SecuritySocketSetsockopt:
+		return ParseSecuritySocketSetsockoptArgs(decoder)
+	case events.SecuritySbMount:
+		return ParseSecuritySbMountArgs(decoder)
+	case events.SecurityBPF:
+		return ParseSecurityBPFArgs(decoder)
+	case events.SecurityBPFMap:
+		return ParseSecurityBPFMapArgs(decoder)
+	case events.SecurityKernelReadFile:
+		return ParseSecurityKernelReadFileArgs(decoder)
+	case events.SecurityPostReadFile:
+		return ParseSecurityPostReadFileArgs(decoder)
+	case events.SecurityInodeMknod:
+		return ParseSecurityInodeMknodArgs(decoder)
+	case events.SecurityInodeSymlinkEventId:
+		return ParseSecurityInodeSymlinkEventIdArgs(decoder)
+	case events.SecurityMmapFile:
+		return ParseSecurityMmapFileArgs(decoder)
+	case events.DoMmap:
+		return ParseDoMmapArgs(decoder)
+	case events.SecurityFileMprotect:
+		return ParseSecurityFileMprotectArgs(decoder)
+	case events.InitNamespaces:
+		return ParseInitNamespacesArgs(decoder)
+	case events.SocketDup:
+		return ParseSocketDupArgs(decoder)
+	case events.HiddenInodes:
+		return ParseHiddenInodesArgs(decoder)
+	case events.KernelWrite:
+		return ParseKernelWriteArgs(decoder)
+	case events.DirtyPipeSplice:
+		return ParseDirtyPipeSpliceArgs(decoder)
+	case events.ContainerCreate:
+		return ParseContainerCreateArgs(decoder)
+	case events.ContainerRemove:
+		return ParseContainerRemoveArgs(decoder)
+	case events.ExistingContainer:
+		return ParseExistingContainerArgs(decoder)
+	case events.ProcCreate:
+		return ParseProcCreateArgs(decoder)
+	case events.KprobeAttach:
+		return ParseKprobeAttachArgs(decoder)
+	case events.CallUsermodeHelper:
+		return ParseCallUsermodeHelperArgs(decoder)
+	case events.DebugfsCreateFile:
+		return ParseDebugfsCreateFileArgs(decoder)
+	case events.PrintSyscallTable:
+		return ParsePrintSyscallTableArgs(decoder)
+	case events.HiddenKernelModule:
+		return ParseHiddenKernelModuleArgs(decoder)
+	case events.HiddenKernelModuleSeeker:
+		return ParseHiddenKernelModuleSeekerArgs(decoder)
+	case events.HookedSyscalls:
+		return ParseHookedSyscallsArgs(decoder)
+	case events.DebugfsCreateDir:
+		return ParseDebugfsCreateDirArgs(decoder)
+	case events.DeviceAdd:
+		return ParseDeviceAddArgs(decoder)
+	case events.RegisterChrdev:
+		return ParseRegisterChrdevArgs(decoder)
+	case events.SharedObjectLoaded:
+		return ParseSharedObjectLoadedArgs(decoder)
+	case events.SymbolsLoaded:
+		return ParseSymbolsLoadedArgs(decoder)
+	case events.SymbolsCollision:
+		return ParseSymbolsCollisionArgs(decoder)
+	case events.CaptureFileWrite:
+		return ParseCaptureFileWriteArgs(decoder)
+	case events.CaptureFileRead:
+		return ParseCaptureFileReadArgs(decoder)
+	case events.CaptureExec:
+		return ParseCaptureExecArgs(decoder)
+	case events.CaptureModule:
+		return ParseCaptureModuleArgs(decoder)
+	case events.CaptureMem:
+		return ParseCaptureMemArgs(decoder)
+	case events.CaptureBpf:
+		return ParseCaptureBpfArgs(decoder)
+	case events.DoInitModule:
+		return ParseDoInitModuleArgs(decoder)
+	case events.ModuleLoad:
+		return ParseModuleLoadArgs(decoder)
+	case events.ModuleFree:
+		return ParseModuleFreeArgs(decoder)
+	case events.SocketAccept:
+		return ParseSocketAcceptArgs(decoder)
+	case events.LoadElfPhdrs:
+		return ParseLoadElfPhdrsArgs(decoder)
+	case events.PrintNetSeqOps:
+		return ParsePrintNetSeqOpsArgs(decoder)
+	case events.HookedSeqOps:
+		return ParseHookedSeqOpsArgs(decoder)
+	case events.TaskRename:
+		return ParseTaskRenameArgs(decoder)
+	case events.SecurityInodeRename:
+		return ParseSecurityInodeRenameArgs(decoder)
+	case events.DoSigaction:
+		return ParseDoSigactionArgs(decoder)
+	case events.BpfAttach:
+		return ParseBpfAttachArgs(decoder)
+	case events.KallsymsLookupName:
+		return ParseKallsymsLookupNameArgs(decoder)
+	case events.PrintMemDump:
+		return ParsePrintMemDumpArgs(decoder)
+	case events.VfsRead:
+		return ParseVfsReadArgs(decoder)
+	case events.VfsReadv:
+		return ParseVfsReadvArgs(decoder)
+	case events.VfsUtimes:
+		return ParseVfsUtimesArgs(decoder)
+	case events.DoTruncate:
+		return ParseDoTruncateArgs(decoder)
+	case events.FileModification:
+		return ParseFileModificationArgs(decoder)
+	case events.InotifyWatch:
+		return ParseInotifyWatchArgs(decoder)
+	case events.ProcessExecuteFailed:
+		return ParseProcessExecuteFailedArgs(decoder)
+	case events.NetPacketBase:
+		return ParseNetPacketBaseArgs(decoder)
+	case events.NetPacketIPBase:
+		return ParseNetPacketIPBaseArgs(decoder)
+	case events.NetPacketIPv4:
+		return ParseNetPacketIPv4Args(decoder)
+	case events.NetPacketIPv6:
+		return ParseNetPacketIPv6Args(decoder)
+	case events.NetPacketTCPBase:
+		return ParseNetPacketTCPBaseArgs(decoder)
+	case events.NetPacketTCP:
+		return ParseNetPacketTCPArgs(decoder)
+	case events.NetPacketUDPBase:
+		return ParseNetPacketUDPBaseArgs(decoder)
+	case events.NetPacketUDP:
+		return ParseNetPacketUDPArgs(decoder)
+	case events.NetPacketICMPBase:
+		return ParseNetPacketICMPBaseArgs(decoder)
+	case events.NetPacketICMP:
+		return ParseNetPacketICMPArgs(decoder)
+	case events.NetPacketICMPv6Base:
+		return ParseNetPacketICMPv6BaseArgs(decoder)
+	case events.NetPacketICMPv6:
+		return ParseNetPacketICMPv6Args(decoder)
+	case events.NetPacketDNSBase:
+		return ParseNetPacketDNSBaseArgs(decoder)
+	case events.NetPacketDNS:
+		return ParseNetPacketDNSArgs(decoder)
+	case events.NetPacketDNSRequest:
+		return ParseNetPacketDNSRequestArgs(decoder)
+	case events.NetPacketDNSResponse:
+		return ParseNetPacketDNSResponseArgs(decoder)
+	case events.NetPacketHTTPBase:
+		return ParseNetPacketHTTPBaseArgs(decoder)
+	case events.NetPacketHTTP:
+		return ParseNetPacketHTTPArgs(decoder)
+	case events.NetPacketHTTPRequest:
+		return ParseNetPacketHTTPRequestArgs(decoder)
+	case events.NetPacketHTTPResponse:
+		return ParseNetPacketHTTPResponseArgs(decoder)
+	case events.NetPacketCapture:
+		return ParseNetPacketCaptureArgs(decoder)
+	case events.CaptureNetPacket:
+		return ParseCaptureNetPacketArgs(decoder)
+	case events.SockSetState:
+		return ParseSockSetStateArgs(decoder)
+	case events.TrackSyscallStats:
+		return ParseTrackSyscallStatsArgs(decoder)
+	case events.TestEvent:
+		return ParseTestEventArgs(decoder)
+	case events.SignalCgroupMkdir:
+		return ParseSignalCgroupMkdirArgs(decoder)
+	case events.SignalCgroupRmdir:
+		return ParseSignalCgroupRmdirArgs(decoder)
+	}
 
-  return nil, ErrUnknownArgsType
+	return nil, ErrUnknownArgsType
 }

--- a/pkg/ebpftracer/decoder/args_decoder.go
+++ b/pkg/ebpftracer/decoder/args_decoder.go
@@ -3,21086 +3,21134 @@
 package decoder
 
 import (
-	"errors"
+  "errors"
 
-	"github.com/castai/kvisor/pkg/ebpftracer/events"
-	"github.com/castai/kvisor/pkg/ebpftracer/types"
+  "github.com/castai/kvisor/pkg/ebpftracer/events"
+  "github.com/castai/kvisor/pkg/ebpftracer/types"
 )
 
 var (
-	ErrUnknownArgsType error = errors.New("unknown args type")
+  ErrUnknownArgsType error = errors.New("unknown args type")
 )
 
 // eventMaxByteSliceBufferSize is used to determine the max slice size allowed for different
 // event types. For example, most events have a max size of 4096, but for network related events
 // there is no max size (this is represented as -1).
 func eventMaxByteSliceBufferSize(id events.ID) int {
-	// For non network event, we have a max byte slice size of 4096
-	if id < events.NetPacketBase || id > events.MaxNetID {
-		return 4096
-	}
+  // For non network event, we have a max byte slice size of 4096
+  if id < events.NetPacketBase || id > events.MaxNetID {
+    return 4096
+  }
 
-	// Network events do not have a max buffer size.
-	return -1
+  // Network events do not have a max buffer size.
+  return -1
 }
 
 func ParseReadArgs(decoder *Decoder) (types.ReadArgs, error) {
-	var result types.ReadArgs
-	var err error
+  var result types.ReadArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ReadArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ReadArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ReadArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ReadArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.ReadArgs{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.ReadArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		case 2:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.ReadArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.ReadArgs{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.ReadArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    case 2:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.ReadArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseWriteArgs(decoder *Decoder) (types.WriteArgs, error) {
-	var result types.WriteArgs
-	var err error
+  var result types.WriteArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.WriteArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.WriteArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.WriteArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.WriteArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.WriteArgs{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.WriteArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		case 2:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.WriteArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.WriteArgs{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.WriteArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    case 2:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.WriteArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseOpenArgs(decoder *Decoder) (types.OpenArgs, error) {
-	var result types.OpenArgs
-	var err error
+  var result types.OpenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OpenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OpenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OpenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OpenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.OpenArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.OpenArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.OpenArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.OpenArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.OpenArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.OpenArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCloseArgs(decoder *Decoder) (types.CloseArgs, error) {
-	var result types.CloseArgs
-	var err error
+  var result types.CloseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CloseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CloseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CloseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CloseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.CloseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.CloseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseStatArgs(decoder *Decoder) (types.StatArgs, error) {
-	var result types.StatArgs
-	var err error
+  var result types.StatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.StatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.StatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.StatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.StatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.StatArgs{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.StatArgs{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.StatArgs{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.StatArgs{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseFstatArgs(decoder *Decoder) (types.FstatArgs, error) {
-	var result types.FstatArgs
-	var err error
+  var result types.FstatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FstatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FstatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FstatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FstatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FstatArgs{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.FstatArgs{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FstatArgs{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.FstatArgs{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseLstatArgs(decoder *Decoder) (types.LstatArgs, error) {
-	var result types.LstatArgs
-	var err error
+  var result types.LstatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LstatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LstatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LstatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LstatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LstatArgs{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.LstatArgs{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LstatArgs{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.LstatArgs{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParsePollArgs(decoder *Decoder) (types.PollArgs, error) {
-	var result types.PollArgs
-	var err error
+  var result types.PollArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PollArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PollArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PollArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PollArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataFds uint64
-			err = decoder.DecodeUint64(&dataFds)
-			if err != nil {
-				return types.PollArgs{}, err
-			}
-			result.Fds = uintptr(dataFds)
-		case 1:
-			err = decoder.DecodeUint32(&result.Nfds)
-			if err != nil {
-				return types.PollArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Timeout)
-			if err != nil {
-				return types.PollArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataFds uint64
+      err = decoder.DecodeUint64(&dataFds)
+      if err != nil {
+        return types.PollArgs{}, err
+      }
+      result.Fds = uintptr(dataFds)
+    case 1:
+      err = decoder.DecodeUint32(&result.Nfds)
+      if err != nil {
+        return types.PollArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Timeout)
+      if err != nil {
+        return types.PollArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLseekArgs(decoder *Decoder) (types.LseekArgs, error) {
-	var result types.LseekArgs
-	var err error
+  var result types.LseekArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LseekArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LseekArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LseekArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LseekArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.LseekArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.LseekArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Whence)
-			if err != nil {
-				return types.LseekArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.LseekArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.LseekArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Whence)
+      if err != nil {
+        return types.LseekArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMmapArgs(decoder *Decoder) (types.MmapArgs, error) {
-	var result types.MmapArgs
-	var err error
+  var result types.MmapArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MmapArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MmapArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MmapArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MmapArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MmapArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.MmapArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Prot)
-			if err != nil {
-				return types.MmapArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.MmapArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.MmapArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.Off)
-			if err != nil {
-				return types.MmapArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MmapArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.MmapArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Prot)
+      if err != nil {
+        return types.MmapArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.MmapArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.MmapArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.Off)
+      if err != nil {
+        return types.MmapArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMprotectArgs(decoder *Decoder) (types.MprotectArgs, error) {
-	var result types.MprotectArgs
-	var err error
+  var result types.MprotectArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MprotectArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MprotectArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MprotectArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MprotectArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MprotectArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.MprotectArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Prot)
-			if err != nil {
-				return types.MprotectArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MprotectArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.MprotectArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Prot)
+      if err != nil {
+        return types.MprotectArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMunmapArgs(decoder *Decoder) (types.MunmapArgs, error) {
-	var result types.MunmapArgs
-	var err error
+  var result types.MunmapArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MunmapArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MunmapArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MunmapArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MunmapArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MunmapArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.MunmapArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MunmapArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.MunmapArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseBrkArgs(decoder *Decoder) (types.BrkArgs, error) {
-	var result types.BrkArgs
-	var err error
+  var result types.BrkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.BrkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.BrkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.BrkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.BrkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.BrkArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.BrkArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigactionArgs(decoder *Decoder) (types.RtSigactionArgs, error) {
-	var result types.RtSigactionArgs
-	var err error
+  var result types.RtSigactionArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtSigactionArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtSigactionArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtSigactionArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtSigactionArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Signum)
-			if err != nil {
-				return types.RtSigactionArgs{}, err
-			}
-		case 1:
-			var dataAct uint64
-			err = decoder.DecodeUint64(&dataAct)
-			if err != nil {
-				return types.RtSigactionArgs{}, err
-			}
-			result.Act = uintptr(dataAct)
-		case 2:
-			var dataOldact uint64
-			err = decoder.DecodeUint64(&dataOldact)
-			if err != nil {
-				return types.RtSigactionArgs{}, err
-			}
-			result.Oldact = uintptr(dataOldact)
-		case 3:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.RtSigactionArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Signum)
+      if err != nil {
+        return types.RtSigactionArgs{}, err
+      }
+    case 1:
+      var dataAct uint64
+      err = decoder.DecodeUint64(&dataAct)
+      if err != nil {
+        return types.RtSigactionArgs{}, err
+      }
+      result.Act = uintptr(dataAct)
+    case 2:
+      var dataOldact uint64
+      err = decoder.DecodeUint64(&dataOldact)
+      if err != nil {
+        return types.RtSigactionArgs{}, err
+      }
+      result.Oldact = uintptr(dataOldact)
+    case 3:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.RtSigactionArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigprocmaskArgs(decoder *Decoder) (types.RtSigprocmaskArgs, error) {
-	var result types.RtSigprocmaskArgs
-	var err error
+  var result types.RtSigprocmaskArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtSigprocmaskArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtSigprocmaskArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtSigprocmaskArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtSigprocmaskArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.How)
-			if err != nil {
-				return types.RtSigprocmaskArgs{}, err
-			}
-		case 1:
-			var dataSet uint64
-			err = decoder.DecodeUint64(&dataSet)
-			if err != nil {
-				return types.RtSigprocmaskArgs{}, err
-			}
-			result.Set = uintptr(dataSet)
-		case 2:
-			var dataOldset uint64
-			err = decoder.DecodeUint64(&dataOldset)
-			if err != nil {
-				return types.RtSigprocmaskArgs{}, err
-			}
-			result.Oldset = uintptr(dataOldset)
-		case 3:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.RtSigprocmaskArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.How)
+      if err != nil {
+        return types.RtSigprocmaskArgs{}, err
+      }
+    case 1:
+      var dataSet uint64
+      err = decoder.DecodeUint64(&dataSet)
+      if err != nil {
+        return types.RtSigprocmaskArgs{}, err
+      }
+      result.Set = uintptr(dataSet)
+    case 2:
+      var dataOldset uint64
+      err = decoder.DecodeUint64(&dataOldset)
+      if err != nil {
+        return types.RtSigprocmaskArgs{}, err
+      }
+      result.Oldset = uintptr(dataOldset)
+    case 3:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.RtSigprocmaskArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigreturnArgs(decoder *Decoder) (types.RtSigreturnArgs, error) {
-	return types.RtSigreturnArgs{}, nil
+  return types.RtSigreturnArgs{}, nil
 }
 
 func ParseIoctlArgs(decoder *Decoder) (types.IoctlArgs, error) {
-	var result types.IoctlArgs
-	var err error
+  var result types.IoctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.IoctlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Request)
-			if err != nil {
-				return types.IoctlArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Arg)
-			if err != nil {
-				return types.IoctlArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.IoctlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Request)
+      if err != nil {
+        return types.IoctlArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Arg)
+      if err != nil {
+        return types.IoctlArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePread64Args(decoder *Decoder) (types.Pread64Args, error) {
-	var result types.Pread64Args
-	var err error
+  var result types.Pread64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Pread64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Pread64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Pread64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Pread64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Pread64Args{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.Pread64Args{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		case 2:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.Pread64Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.Pread64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Pread64Args{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.Pread64Args{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    case 2:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.Pread64Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.Pread64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePwrite64Args(decoder *Decoder) (types.Pwrite64Args, error) {
-	var result types.Pwrite64Args
-	var err error
+  var result types.Pwrite64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Pwrite64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Pwrite64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Pwrite64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Pwrite64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Pwrite64Args{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.Pwrite64Args{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		case 2:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.Pwrite64Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.Pwrite64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Pwrite64Args{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.Pwrite64Args{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    case 2:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.Pwrite64Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.Pwrite64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseReadvArgs(decoder *Decoder) (types.ReadvArgs, error) {
-	var result types.ReadvArgs
-	var err error
+  var result types.ReadvArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ReadvArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ReadvArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ReadvArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ReadvArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.ReadvArgs{}, err
-			}
-		case 1:
-			var dataIov uint64
-			err = decoder.DecodeUint64(&dataIov)
-			if err != nil {
-				return types.ReadvArgs{}, err
-			}
-			result.Iov = uintptr(dataIov)
-		case 2:
-			err = decoder.DecodeInt32(&result.Iovcnt)
-			if err != nil {
-				return types.ReadvArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.ReadvArgs{}, err
+      }
+    case 1:
+      var dataIov uint64
+      err = decoder.DecodeUint64(&dataIov)
+      if err != nil {
+        return types.ReadvArgs{}, err
+      }
+      result.Iov = uintptr(dataIov)
+    case 2:
+      err = decoder.DecodeInt32(&result.Iovcnt)
+      if err != nil {
+        return types.ReadvArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseWritevArgs(decoder *Decoder) (types.WritevArgs, error) {
-	var result types.WritevArgs
-	var err error
+  var result types.WritevArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.WritevArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.WritevArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.WritevArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.WritevArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.WritevArgs{}, err
-			}
-		case 1:
-			var dataIov uint64
-			err = decoder.DecodeUint64(&dataIov)
-			if err != nil {
-				return types.WritevArgs{}, err
-			}
-			result.Iov = uintptr(dataIov)
-		case 2:
-			err = decoder.DecodeInt32(&result.Iovcnt)
-			if err != nil {
-				return types.WritevArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.WritevArgs{}, err
+      }
+    case 1:
+      var dataIov uint64
+      err = decoder.DecodeUint64(&dataIov)
+      if err != nil {
+        return types.WritevArgs{}, err
+      }
+      result.Iov = uintptr(dataIov)
+    case 2:
+      err = decoder.DecodeInt32(&result.Iovcnt)
+      if err != nil {
+        return types.WritevArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseAccessArgs(decoder *Decoder) (types.AccessArgs, error) {
-	var result types.AccessArgs
-	var err error
+  var result types.AccessArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.AccessArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.AccessArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.AccessArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.AccessArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.AccessArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Mode)
-			if err != nil {
-				return types.AccessArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.AccessArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Mode)
+      if err != nil {
+        return types.AccessArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePipeArgs(decoder *Decoder) (types.PipeArgs, error) {
-	var result types.PipeArgs
-	var err error
+  var result types.PipeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PipeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PipeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PipeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PipeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeIntArray(result.Pipefd[:], 2)
-			if err != nil {
-				return types.PipeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeIntArray(result.Pipefd[:], 2)
+      if err != nil {
+        return types.PipeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSelectArgs(decoder *Decoder) (types.SelectArgs, error) {
-	var result types.SelectArgs
-	var err error
+  var result types.SelectArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SelectArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SelectArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SelectArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SelectArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Nfds)
-			if err != nil {
-				return types.SelectArgs{}, err
-			}
-		case 1:
-			var dataReadfds uint64
-			err = decoder.DecodeUint64(&dataReadfds)
-			if err != nil {
-				return types.SelectArgs{}, err
-			}
-			result.Readfds = uintptr(dataReadfds)
-		case 2:
-			var dataWritefds uint64
-			err = decoder.DecodeUint64(&dataWritefds)
-			if err != nil {
-				return types.SelectArgs{}, err
-			}
-			result.Writefds = uintptr(dataWritefds)
-		case 3:
-			var dataExceptfds uint64
-			err = decoder.DecodeUint64(&dataExceptfds)
-			if err != nil {
-				return types.SelectArgs{}, err
-			}
-			result.Exceptfds = uintptr(dataExceptfds)
-		case 4:
-			var dataTimeout uint64
-			err = decoder.DecodeUint64(&dataTimeout)
-			if err != nil {
-				return types.SelectArgs{}, err
-			}
-			result.Timeout = uintptr(dataTimeout)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Nfds)
+      if err != nil {
+        return types.SelectArgs{}, err
+      }
+    case 1:
+      var dataReadfds uint64
+      err = decoder.DecodeUint64(&dataReadfds)
+      if err != nil {
+        return types.SelectArgs{}, err
+      }
+      result.Readfds = uintptr(dataReadfds)
+    case 2:
+      var dataWritefds uint64
+      err = decoder.DecodeUint64(&dataWritefds)
+      if err != nil {
+        return types.SelectArgs{}, err
+      }
+      result.Writefds = uintptr(dataWritefds)
+    case 3:
+      var dataExceptfds uint64
+      err = decoder.DecodeUint64(&dataExceptfds)
+      if err != nil {
+        return types.SelectArgs{}, err
+      }
+      result.Exceptfds = uintptr(dataExceptfds)
+    case 4:
+      var dataTimeout uint64
+      err = decoder.DecodeUint64(&dataTimeout)
+      if err != nil {
+        return types.SelectArgs{}, err
+      }
+      result.Timeout = uintptr(dataTimeout)
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedYieldArgs(decoder *Decoder) (types.SchedYieldArgs, error) {
-	return types.SchedYieldArgs{}, nil
+  return types.SchedYieldArgs{}, nil
 }
 
 func ParseMremapArgs(decoder *Decoder) (types.MremapArgs, error) {
-	var result types.MremapArgs
-	var err error
+  var result types.MremapArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MremapArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MremapArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MremapArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MremapArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataOldAddress uint64
-			err = decoder.DecodeUint64(&dataOldAddress)
-			if err != nil {
-				return types.MremapArgs{}, err
-			}
-			result.OldAddress = uintptr(dataOldAddress)
-		case 1:
-			err = decoder.DecodeUint64(&result.OldSize)
-			if err != nil {
-				return types.MremapArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.NewSize)
-			if err != nil {
-				return types.MremapArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.MremapArgs{}, err
-			}
-		case 4:
-			var dataNewAddress uint64
-			err = decoder.DecodeUint64(&dataNewAddress)
-			if err != nil {
-				return types.MremapArgs{}, err
-			}
-			result.NewAddress = uintptr(dataNewAddress)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataOldAddress uint64
+      err = decoder.DecodeUint64(&dataOldAddress)
+      if err != nil {
+        return types.MremapArgs{}, err
+      }
+      result.OldAddress = uintptr(dataOldAddress)
+    case 1:
+      err = decoder.DecodeUint64(&result.OldSize)
+      if err != nil {
+        return types.MremapArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.NewSize)
+      if err != nil {
+        return types.MremapArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.MremapArgs{}, err
+      }
+    case 4:
+      var dataNewAddress uint64
+      err = decoder.DecodeUint64(&dataNewAddress)
+      if err != nil {
+        return types.MremapArgs{}, err
+      }
+      result.NewAddress = uintptr(dataNewAddress)
+    }
+  }
+  return result, nil
 }
 
 func ParseMsyncArgs(decoder *Decoder) (types.MsyncArgs, error) {
-	var result types.MsyncArgs
-	var err error
+  var result types.MsyncArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MsyncArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MsyncArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MsyncArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MsyncArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MsyncArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.MsyncArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.MsyncArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MsyncArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.MsyncArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.MsyncArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMincoreArgs(decoder *Decoder) (types.MincoreArgs, error) {
-	var result types.MincoreArgs
-	var err error
+  var result types.MincoreArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MincoreArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MincoreArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MincoreArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MincoreArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MincoreArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.MincoreArgs{}, err
-			}
-		case 2:
-			var dataVec uint64
-			err = decoder.DecodeUint64(&dataVec)
-			if err != nil {
-				return types.MincoreArgs{}, err
-			}
-			result.Vec = uintptr(dataVec)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MincoreArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.MincoreArgs{}, err
+      }
+    case 2:
+      var dataVec uint64
+      err = decoder.DecodeUint64(&dataVec)
+      if err != nil {
+        return types.MincoreArgs{}, err
+      }
+      result.Vec = uintptr(dataVec)
+    }
+  }
+  return result, nil
 }
 
 func ParseMadviseArgs(decoder *Decoder) (types.MadviseArgs, error) {
-	var result types.MadviseArgs
-	var err error
+  var result types.MadviseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MadviseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MadviseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MadviseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MadviseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MadviseArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.MadviseArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Advice)
-			if err != nil {
-				return types.MadviseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MadviseArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.MadviseArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Advice)
+      if err != nil {
+        return types.MadviseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseShmgetArgs(decoder *Decoder) (types.ShmgetArgs, error) {
-	var result types.ShmgetArgs
-	var err error
+  var result types.ShmgetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ShmgetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ShmgetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ShmgetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ShmgetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Key)
-			if err != nil {
-				return types.ShmgetArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.ShmgetArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Shmflg)
-			if err != nil {
-				return types.ShmgetArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Key)
+      if err != nil {
+        return types.ShmgetArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.ShmgetArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Shmflg)
+      if err != nil {
+        return types.ShmgetArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseShmatArgs(decoder *Decoder) (types.ShmatArgs, error) {
-	var result types.ShmatArgs
-	var err error
+  var result types.ShmatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ShmatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ShmatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ShmatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ShmatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Shmid)
-			if err != nil {
-				return types.ShmatArgs{}, err
-			}
-		case 1:
-			var dataShmaddr uint64
-			err = decoder.DecodeUint64(&dataShmaddr)
-			if err != nil {
-				return types.ShmatArgs{}, err
-			}
-			result.Shmaddr = uintptr(dataShmaddr)
-		case 2:
-			err = decoder.DecodeInt32(&result.Shmflg)
-			if err != nil {
-				return types.ShmatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Shmid)
+      if err != nil {
+        return types.ShmatArgs{}, err
+      }
+    case 1:
+      var dataShmaddr uint64
+      err = decoder.DecodeUint64(&dataShmaddr)
+      if err != nil {
+        return types.ShmatArgs{}, err
+      }
+      result.Shmaddr = uintptr(dataShmaddr)
+    case 2:
+      err = decoder.DecodeInt32(&result.Shmflg)
+      if err != nil {
+        return types.ShmatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseShmctlArgs(decoder *Decoder) (types.ShmctlArgs, error) {
-	var result types.ShmctlArgs
-	var err error
+  var result types.ShmctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ShmctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ShmctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ShmctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ShmctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Shmid)
-			if err != nil {
-				return types.ShmctlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.ShmctlArgs{}, err
-			}
-		case 2:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.ShmctlArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Shmid)
+      if err != nil {
+        return types.ShmctlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.ShmctlArgs{}, err
+      }
+    case 2:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.ShmctlArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseDupArgs(decoder *Decoder) (types.DupArgs, error) {
-	var result types.DupArgs
-	var err error
+  var result types.DupArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DupArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DupArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DupArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DupArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Oldfd)
-			if err != nil {
-				return types.DupArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Oldfd)
+      if err != nil {
+        return types.DupArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDup2Args(decoder *Decoder) (types.Dup2Args, error) {
-	var result types.Dup2Args
-	var err error
+  var result types.Dup2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Dup2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Dup2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Dup2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Dup2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Oldfd)
-			if err != nil {
-				return types.Dup2Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Newfd)
-			if err != nil {
-				return types.Dup2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Oldfd)
+      if err != nil {
+        return types.Dup2Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Newfd)
+      if err != nil {
+        return types.Dup2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePauseArgs(decoder *Decoder) (types.PauseArgs, error) {
-	return types.PauseArgs{}, nil
+  return types.PauseArgs{}, nil
 }
 
 func ParseNanosleepArgs(decoder *Decoder) (types.NanosleepArgs, error) {
-	var result types.NanosleepArgs
-	var err error
+  var result types.NanosleepArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NanosleepArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NanosleepArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NanosleepArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NanosleepArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Req, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.NanosleepArgs{}, err
-			}
-		case 1:
-			result.Rem, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.NanosleepArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Req, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.NanosleepArgs{}, err
+      }
+    case 1:
+      result.Rem, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.NanosleepArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetitimerArgs(decoder *Decoder) (types.GetitimerArgs, error) {
-	var result types.GetitimerArgs
-	var err error
+  var result types.GetitimerArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetitimerArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetitimerArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetitimerArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetitimerArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Which)
-			if err != nil {
-				return types.GetitimerArgs{}, err
-			}
-		case 1:
-			var dataCurrValue uint64
-			err = decoder.DecodeUint64(&dataCurrValue)
-			if err != nil {
-				return types.GetitimerArgs{}, err
-			}
-			result.CurrValue = uintptr(dataCurrValue)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Which)
+      if err != nil {
+        return types.GetitimerArgs{}, err
+      }
+    case 1:
+      var dataCurrValue uint64
+      err = decoder.DecodeUint64(&dataCurrValue)
+      if err != nil {
+        return types.GetitimerArgs{}, err
+      }
+      result.CurrValue = uintptr(dataCurrValue)
+    }
+  }
+  return result, nil
 }
 
 func ParseAlarmArgs(decoder *Decoder) (types.AlarmArgs, error) {
-	var result types.AlarmArgs
-	var err error
+  var result types.AlarmArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.AlarmArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.AlarmArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.AlarmArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.AlarmArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Seconds)
-			if err != nil {
-				return types.AlarmArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Seconds)
+      if err != nil {
+        return types.AlarmArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetitimerArgs(decoder *Decoder) (types.SetitimerArgs, error) {
-	var result types.SetitimerArgs
-	var err error
+  var result types.SetitimerArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetitimerArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetitimerArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetitimerArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetitimerArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Which)
-			if err != nil {
-				return types.SetitimerArgs{}, err
-			}
-		case 1:
-			var dataNewValue uint64
-			err = decoder.DecodeUint64(&dataNewValue)
-			if err != nil {
-				return types.SetitimerArgs{}, err
-			}
-			result.NewValue = uintptr(dataNewValue)
-		case 2:
-			var dataOldValue uint64
-			err = decoder.DecodeUint64(&dataOldValue)
-			if err != nil {
-				return types.SetitimerArgs{}, err
-			}
-			result.OldValue = uintptr(dataOldValue)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Which)
+      if err != nil {
+        return types.SetitimerArgs{}, err
+      }
+    case 1:
+      var dataNewValue uint64
+      err = decoder.DecodeUint64(&dataNewValue)
+      if err != nil {
+        return types.SetitimerArgs{}, err
+      }
+      result.NewValue = uintptr(dataNewValue)
+    case 2:
+      var dataOldValue uint64
+      err = decoder.DecodeUint64(&dataOldValue)
+      if err != nil {
+        return types.SetitimerArgs{}, err
+      }
+      result.OldValue = uintptr(dataOldValue)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetpidArgs(decoder *Decoder) (types.GetpidArgs, error) {
-	return types.GetpidArgs{}, nil
+  return types.GetpidArgs{}, nil
 }
 
 func ParseSendfileArgs(decoder *Decoder) (types.SendfileArgs, error) {
-	var result types.SendfileArgs
-	var err error
+  var result types.SendfileArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SendfileArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SendfileArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SendfileArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SendfileArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.OutFd)
-			if err != nil {
-				return types.SendfileArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.InFd)
-			if err != nil {
-				return types.SendfileArgs{}, err
-			}
-		case 2:
-			var dataOffset uint64
-			err = decoder.DecodeUint64(&dataOffset)
-			if err != nil {
-				return types.SendfileArgs{}, err
-			}
-			result.Offset = uintptr(dataOffset)
-		case 3:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.SendfileArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.OutFd)
+      if err != nil {
+        return types.SendfileArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.InFd)
+      if err != nil {
+        return types.SendfileArgs{}, err
+      }
+    case 2:
+      var dataOffset uint64
+      err = decoder.DecodeUint64(&dataOffset)
+      if err != nil {
+        return types.SendfileArgs{}, err
+      }
+      result.Offset = uintptr(dataOffset)
+    case 3:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.SendfileArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSocketArgs(decoder *Decoder) (types.SocketArgs, error) {
-	var result types.SocketArgs
-	var err error
+  var result types.SocketArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SocketArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SocketArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SocketArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SocketArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Domain)
-			if err != nil {
-				return types.SocketArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.SocketArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Protocol)
-			if err != nil {
-				return types.SocketArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Domain)
+      if err != nil {
+        return types.SocketArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.SocketArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Protocol)
+      if err != nil {
+        return types.SocketArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseConnectArgs(decoder *Decoder) (types.ConnectArgs, error) {
-	var result types.ConnectArgs
-	var err error
+  var result types.ConnectArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ConnectArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ConnectArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ConnectArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ConnectArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.ConnectArgs{}, err
-			}
-		case 1:
-			result.Addr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.ConnectArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Addrlen)
-			if err != nil {
-				return types.ConnectArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.ConnectArgs{}, err
+      }
+    case 1:
+      result.Addr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.ConnectArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Addrlen)
+      if err != nil {
+        return types.ConnectArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseAcceptArgs(decoder *Decoder) (types.AcceptArgs, error) {
-	var result types.AcceptArgs
-	var err error
+  var result types.AcceptArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.AcceptArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.AcceptArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.AcceptArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.AcceptArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.AcceptArgs{}, err
-			}
-		case 1:
-			result.Addr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.AcceptArgs{}, err
-			}
-		case 2:
-			var dataAddrlen uint64
-			err = decoder.DecodeUint64(&dataAddrlen)
-			if err != nil {
-				return types.AcceptArgs{}, err
-			}
-			result.Addrlen = uintptr(dataAddrlen)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.AcceptArgs{}, err
+      }
+    case 1:
+      result.Addr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.AcceptArgs{}, err
+      }
+    case 2:
+      var dataAddrlen uint64
+      err = decoder.DecodeUint64(&dataAddrlen)
+      if err != nil {
+        return types.AcceptArgs{}, err
+      }
+      result.Addrlen = uintptr(dataAddrlen)
+    }
+  }
+  return result, nil
 }
 
 func ParseSendtoArgs(decoder *Decoder) (types.SendtoArgs, error) {
-	var result types.SendtoArgs
-	var err error
+  var result types.SendtoArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SendtoArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SendtoArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SendtoArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SendtoArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SendtoArgs{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.SendtoArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		case 2:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.SendtoArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SendtoArgs{}, err
-			}
-		case 4:
-			result.DestAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SendtoArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeInt32(&result.Addrlen)
-			if err != nil {
-				return types.SendtoArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SendtoArgs{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.SendtoArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    case 2:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.SendtoArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SendtoArgs{}, err
+      }
+    case 4:
+      result.DestAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SendtoArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeInt32(&result.Addrlen)
+      if err != nil {
+        return types.SendtoArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRecvfromArgs(decoder *Decoder) (types.RecvfromArgs, error) {
-	var result types.RecvfromArgs
-	var err error
+  var result types.RecvfromArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RecvfromArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RecvfromArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RecvfromArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RecvfromArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.RecvfromArgs{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.RecvfromArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		case 2:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.RecvfromArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.RecvfromArgs{}, err
-			}
-		case 4:
-			result.SrcAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.RecvfromArgs{}, err
-			}
-		case 5:
-			var dataAddrlen uint64
-			err = decoder.DecodeUint64(&dataAddrlen)
-			if err != nil {
-				return types.RecvfromArgs{}, err
-			}
-			result.Addrlen = uintptr(dataAddrlen)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.RecvfromArgs{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.RecvfromArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    case 2:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.RecvfromArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.RecvfromArgs{}, err
+      }
+    case 4:
+      result.SrcAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.RecvfromArgs{}, err
+      }
+    case 5:
+      var dataAddrlen uint64
+      err = decoder.DecodeUint64(&dataAddrlen)
+      if err != nil {
+        return types.RecvfromArgs{}, err
+      }
+      result.Addrlen = uintptr(dataAddrlen)
+    }
+  }
+  return result, nil
 }
 
 func ParseSendmsgArgs(decoder *Decoder) (types.SendmsgArgs, error) {
-	var result types.SendmsgArgs
-	var err error
+  var result types.SendmsgArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SendmsgArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SendmsgArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SendmsgArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SendmsgArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SendmsgArgs{}, err
-			}
-		case 1:
-			var dataMsg uint64
-			err = decoder.DecodeUint64(&dataMsg)
-			if err != nil {
-				return types.SendmsgArgs{}, err
-			}
-			result.Msg = uintptr(dataMsg)
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SendmsgArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SendmsgArgs{}, err
+      }
+    case 1:
+      var dataMsg uint64
+      err = decoder.DecodeUint64(&dataMsg)
+      if err != nil {
+        return types.SendmsgArgs{}, err
+      }
+      result.Msg = uintptr(dataMsg)
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SendmsgArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRecvmsgArgs(decoder *Decoder) (types.RecvmsgArgs, error) {
-	var result types.RecvmsgArgs
-	var err error
+  var result types.RecvmsgArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RecvmsgArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RecvmsgArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RecvmsgArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RecvmsgArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.RecvmsgArgs{}, err
-			}
-		case 1:
-			var dataMsg uint64
-			err = decoder.DecodeUint64(&dataMsg)
-			if err != nil {
-				return types.RecvmsgArgs{}, err
-			}
-			result.Msg = uintptr(dataMsg)
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.RecvmsgArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.RecvmsgArgs{}, err
+      }
+    case 1:
+      var dataMsg uint64
+      err = decoder.DecodeUint64(&dataMsg)
+      if err != nil {
+        return types.RecvmsgArgs{}, err
+      }
+      result.Msg = uintptr(dataMsg)
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.RecvmsgArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseShutdownArgs(decoder *Decoder) (types.ShutdownArgs, error) {
-	var result types.ShutdownArgs
-	var err error
+  var result types.ShutdownArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ShutdownArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ShutdownArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ShutdownArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ShutdownArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.ShutdownArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.How)
-			if err != nil {
-				return types.ShutdownArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.ShutdownArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.How)
+      if err != nil {
+        return types.ShutdownArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseBindArgs(decoder *Decoder) (types.BindArgs, error) {
-	var result types.BindArgs
-	var err error
+  var result types.BindArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.BindArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.BindArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.BindArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.BindArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.BindArgs{}, err
-			}
-		case 1:
-			result.Addr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.BindArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Addrlen)
-			if err != nil {
-				return types.BindArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.BindArgs{}, err
+      }
+    case 1:
+      result.Addr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.BindArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Addrlen)
+      if err != nil {
+        return types.BindArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseListenArgs(decoder *Decoder) (types.ListenArgs, error) {
-	var result types.ListenArgs
-	var err error
+  var result types.ListenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ListenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ListenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ListenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ListenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.ListenArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Backlog)
-			if err != nil {
-				return types.ListenArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.ListenArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Backlog)
+      if err != nil {
+        return types.ListenArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetsocknameArgs(decoder *Decoder) (types.GetsocknameArgs, error) {
-	var result types.GetsocknameArgs
-	var err error
+  var result types.GetsocknameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetsocknameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetsocknameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetsocknameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetsocknameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.GetsocknameArgs{}, err
-			}
-		case 1:
-			result.Addr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.GetsocknameArgs{}, err
-			}
-		case 2:
-			var dataAddrlen uint64
-			err = decoder.DecodeUint64(&dataAddrlen)
-			if err != nil {
-				return types.GetsocknameArgs{}, err
-			}
-			result.Addrlen = uintptr(dataAddrlen)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.GetsocknameArgs{}, err
+      }
+    case 1:
+      result.Addr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.GetsocknameArgs{}, err
+      }
+    case 2:
+      var dataAddrlen uint64
+      err = decoder.DecodeUint64(&dataAddrlen)
+      if err != nil {
+        return types.GetsocknameArgs{}, err
+      }
+      result.Addrlen = uintptr(dataAddrlen)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetpeernameArgs(decoder *Decoder) (types.GetpeernameArgs, error) {
-	var result types.GetpeernameArgs
-	var err error
+  var result types.GetpeernameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetpeernameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetpeernameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetpeernameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetpeernameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.GetpeernameArgs{}, err
-			}
-		case 1:
-			result.Addr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.GetpeernameArgs{}, err
-			}
-		case 2:
-			var dataAddrlen uint64
-			err = decoder.DecodeUint64(&dataAddrlen)
-			if err != nil {
-				return types.GetpeernameArgs{}, err
-			}
-			result.Addrlen = uintptr(dataAddrlen)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.GetpeernameArgs{}, err
+      }
+    case 1:
+      result.Addr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.GetpeernameArgs{}, err
+      }
+    case 2:
+      var dataAddrlen uint64
+      err = decoder.DecodeUint64(&dataAddrlen)
+      if err != nil {
+        return types.GetpeernameArgs{}, err
+      }
+      result.Addrlen = uintptr(dataAddrlen)
+    }
+  }
+  return result, nil
 }
 
 func ParseSocketpairArgs(decoder *Decoder) (types.SocketpairArgs, error) {
-	var result types.SocketpairArgs
-	var err error
+  var result types.SocketpairArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SocketpairArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SocketpairArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SocketpairArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SocketpairArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Domain)
-			if err != nil {
-				return types.SocketpairArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.SocketpairArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Protocol)
-			if err != nil {
-				return types.SocketpairArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeIntArray(result.Sv[:], 2)
-			if err != nil {
-				return types.SocketpairArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Domain)
+      if err != nil {
+        return types.SocketpairArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.SocketpairArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Protocol)
+      if err != nil {
+        return types.SocketpairArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeIntArray(result.Sv[:], 2)
+      if err != nil {
+        return types.SocketpairArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetsockoptArgs(decoder *Decoder) (types.SetsockoptArgs, error) {
-	var result types.SetsockoptArgs
-	var err error
+  var result types.SetsockoptArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetsockoptArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetsockoptArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetsockoptArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetsockoptArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SetsockoptArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Level)
-			if err != nil {
-				return types.SetsockoptArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Optname)
-			if err != nil {
-				return types.SetsockoptArgs{}, err
-			}
-		case 3:
-			var dataOptval uint64
-			err = decoder.DecodeUint64(&dataOptval)
-			if err != nil {
-				return types.SetsockoptArgs{}, err
-			}
-			result.Optval = uintptr(dataOptval)
-		case 4:
-			err = decoder.DecodeInt32(&result.Optlen)
-			if err != nil {
-				return types.SetsockoptArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SetsockoptArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Level)
+      if err != nil {
+        return types.SetsockoptArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Optname)
+      if err != nil {
+        return types.SetsockoptArgs{}, err
+      }
+    case 3:
+      var dataOptval uint64
+      err = decoder.DecodeUint64(&dataOptval)
+      if err != nil {
+        return types.SetsockoptArgs{}, err
+      }
+      result.Optval = uintptr(dataOptval)
+    case 4:
+      err = decoder.DecodeInt32(&result.Optlen)
+      if err != nil {
+        return types.SetsockoptArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetsockoptArgs(decoder *Decoder) (types.GetsockoptArgs, error) {
-	var result types.GetsockoptArgs
-	var err error
+  var result types.GetsockoptArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetsockoptArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetsockoptArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetsockoptArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetsockoptArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.GetsockoptArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Level)
-			if err != nil {
-				return types.GetsockoptArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Optname)
-			if err != nil {
-				return types.GetsockoptArgs{}, err
-			}
-		case 3:
-			var dataOptval uint64
-			err = decoder.DecodeUint64(&dataOptval)
-			if err != nil {
-				return types.GetsockoptArgs{}, err
-			}
-			result.Optval = uintptr(dataOptval)
-		case 4:
-			var dataOptlen uint64
-			err = decoder.DecodeUint64(&dataOptlen)
-			if err != nil {
-				return types.GetsockoptArgs{}, err
-			}
-			result.Optlen = uintptr(dataOptlen)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.GetsockoptArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Level)
+      if err != nil {
+        return types.GetsockoptArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Optname)
+      if err != nil {
+        return types.GetsockoptArgs{}, err
+      }
+    case 3:
+      var dataOptval uint64
+      err = decoder.DecodeUint64(&dataOptval)
+      if err != nil {
+        return types.GetsockoptArgs{}, err
+      }
+      result.Optval = uintptr(dataOptval)
+    case 4:
+      var dataOptlen uint64
+      err = decoder.DecodeUint64(&dataOptlen)
+      if err != nil {
+        return types.GetsockoptArgs{}, err
+      }
+      result.Optlen = uintptr(dataOptlen)
+    }
+  }
+  return result, nil
 }
 
 func ParseCloneArgs(decoder *Decoder) (types.CloneArgs, error) {
-	var result types.CloneArgs
-	var err error
+  var result types.CloneArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CloneArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CloneArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CloneArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CloneArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.CloneArgs{}, err
-			}
-		case 1:
-			var dataStack uint64
-			err = decoder.DecodeUint64(&dataStack)
-			if err != nil {
-				return types.CloneArgs{}, err
-			}
-			result.Stack = uintptr(dataStack)
-		case 2:
-			var dataParentTid uint64
-			err = decoder.DecodeUint64(&dataParentTid)
-			if err != nil {
-				return types.CloneArgs{}, err
-			}
-			result.ParentTid = uintptr(dataParentTid)
-		case 3:
-			var dataChildTid uint64
-			err = decoder.DecodeUint64(&dataChildTid)
-			if err != nil {
-				return types.CloneArgs{}, err
-			}
-			result.ChildTid = uintptr(dataChildTid)
-		case 4:
-			err = decoder.DecodeUint64(&result.Tls)
-			if err != nil {
-				return types.CloneArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.CloneArgs{}, err
+      }
+    case 1:
+      var dataStack uint64
+      err = decoder.DecodeUint64(&dataStack)
+      if err != nil {
+        return types.CloneArgs{}, err
+      }
+      result.Stack = uintptr(dataStack)
+    case 2:
+      var dataParentTid uint64
+      err = decoder.DecodeUint64(&dataParentTid)
+      if err != nil {
+        return types.CloneArgs{}, err
+      }
+      result.ParentTid = uintptr(dataParentTid)
+    case 3:
+      var dataChildTid uint64
+      err = decoder.DecodeUint64(&dataChildTid)
+      if err != nil {
+        return types.CloneArgs{}, err
+      }
+      result.ChildTid = uintptr(dataChildTid)
+    case 4:
+      err = decoder.DecodeUint64(&result.Tls)
+      if err != nil {
+        return types.CloneArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseForkArgs(decoder *Decoder) (types.ForkArgs, error) {
-	return types.ForkArgs{}, nil
+  return types.ForkArgs{}, nil
 }
 
 func ParseVforkArgs(decoder *Decoder) (types.VforkArgs, error) {
-	return types.VforkArgs{}, nil
+  return types.VforkArgs{}, nil
 }
 
 func ParseExecveArgs(decoder *Decoder) (types.ExecveArgs, error) {
-	var result types.ExecveArgs
-	var err error
+  var result types.ExecveArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ExecveArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ExecveArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ExecveArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ExecveArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExecveArgs{}, err
-			}
-		case 1:
-			result.Argv, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.ExecveArgs{}, err
-			}
-		case 2:
-			result.Envp, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.ExecveArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExecveArgs{}, err
+      }
+    case 1:
+      result.Argv, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.ExecveArgs{}, err
+      }
+    case 2:
+      result.Envp, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.ExecveArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseExitArgs(decoder *Decoder) (types.ExitArgs, error) {
-	var result types.ExitArgs
-	var err error
+  var result types.ExitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ExitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ExitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ExitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ExitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Status)
-			if err != nil {
-				return types.ExitArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Status)
+      if err != nil {
+        return types.ExitArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseWait4Args(decoder *Decoder) (types.Wait4Args, error) {
-	var result types.Wait4Args
-	var err error
+  var result types.Wait4Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Wait4Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Wait4Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Wait4Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Wait4Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.Wait4Args{}, err
-			}
-		case 1:
-			var dataWstatus uint64
-			err = decoder.DecodeUint64(&dataWstatus)
-			if err != nil {
-				return types.Wait4Args{}, err
-			}
-			result.Wstatus = uintptr(dataWstatus)
-		case 2:
-			err = decoder.DecodeInt32(&result.Options)
-			if err != nil {
-				return types.Wait4Args{}, err
-			}
-		case 3:
-			var dataRusage uint64
-			err = decoder.DecodeUint64(&dataRusage)
-			if err != nil {
-				return types.Wait4Args{}, err
-			}
-			result.Rusage = uintptr(dataRusage)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.Wait4Args{}, err
+      }
+    case 1:
+      var dataWstatus uint64
+      err = decoder.DecodeUint64(&dataWstatus)
+      if err != nil {
+        return types.Wait4Args{}, err
+      }
+      result.Wstatus = uintptr(dataWstatus)
+    case 2:
+      err = decoder.DecodeInt32(&result.Options)
+      if err != nil {
+        return types.Wait4Args{}, err
+      }
+    case 3:
+      var dataRusage uint64
+      err = decoder.DecodeUint64(&dataRusage)
+      if err != nil {
+        return types.Wait4Args{}, err
+      }
+      result.Rusage = uintptr(dataRusage)
+    }
+  }
+  return result, nil
 }
 
 func ParseKillArgs(decoder *Decoder) (types.KillArgs, error) {
-	var result types.KillArgs
-	var err error
+  var result types.KillArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KillArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KillArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KillArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KillArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.KillArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.KillArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.KillArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.KillArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUnameArgs(decoder *Decoder) (types.UnameArgs, error) {
-	var result types.UnameArgs
-	var err error
+  var result types.UnameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UnameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UnameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UnameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UnameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.UnameArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.UnameArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseSemgetArgs(decoder *Decoder) (types.SemgetArgs, error) {
-	var result types.SemgetArgs
-	var err error
+  var result types.SemgetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SemgetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SemgetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SemgetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SemgetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Key)
-			if err != nil {
-				return types.SemgetArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Nsems)
-			if err != nil {
-				return types.SemgetArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Semflg)
-			if err != nil {
-				return types.SemgetArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Key)
+      if err != nil {
+        return types.SemgetArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Nsems)
+      if err != nil {
+        return types.SemgetArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Semflg)
+      if err != nil {
+        return types.SemgetArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSemopArgs(decoder *Decoder) (types.SemopArgs, error) {
-	var result types.SemopArgs
-	var err error
+  var result types.SemopArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SemopArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SemopArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SemopArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SemopArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Semid)
-			if err != nil {
-				return types.SemopArgs{}, err
-			}
-		case 1:
-			var dataSops uint64
-			err = decoder.DecodeUint64(&dataSops)
-			if err != nil {
-				return types.SemopArgs{}, err
-			}
-			result.Sops = uintptr(dataSops)
-		case 2:
-			err = decoder.DecodeUint64(&result.Nsops)
-			if err != nil {
-				return types.SemopArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Semid)
+      if err != nil {
+        return types.SemopArgs{}, err
+      }
+    case 1:
+      var dataSops uint64
+      err = decoder.DecodeUint64(&dataSops)
+      if err != nil {
+        return types.SemopArgs{}, err
+      }
+      result.Sops = uintptr(dataSops)
+    case 2:
+      err = decoder.DecodeUint64(&result.Nsops)
+      if err != nil {
+        return types.SemopArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSemctlArgs(decoder *Decoder) (types.SemctlArgs, error) {
-	var result types.SemctlArgs
-	var err error
+  var result types.SemctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SemctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SemctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SemctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SemctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Semid)
-			if err != nil {
-				return types.SemctlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Semnum)
-			if err != nil {
-				return types.SemctlArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.SemctlArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Arg)
-			if err != nil {
-				return types.SemctlArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Semid)
+      if err != nil {
+        return types.SemctlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Semnum)
+      if err != nil {
+        return types.SemctlArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.SemctlArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Arg)
+      if err != nil {
+        return types.SemctlArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseShmdtArgs(decoder *Decoder) (types.ShmdtArgs, error) {
-	var result types.ShmdtArgs
-	var err error
+  var result types.ShmdtArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ShmdtArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ShmdtArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ShmdtArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ShmdtArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataShmaddr uint64
-			err = decoder.DecodeUint64(&dataShmaddr)
-			if err != nil {
-				return types.ShmdtArgs{}, err
-			}
-			result.Shmaddr = uintptr(dataShmaddr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataShmaddr uint64
+      err = decoder.DecodeUint64(&dataShmaddr)
+      if err != nil {
+        return types.ShmdtArgs{}, err
+      }
+      result.Shmaddr = uintptr(dataShmaddr)
+    }
+  }
+  return result, nil
 }
 
 func ParseMsggetArgs(decoder *Decoder) (types.MsggetArgs, error) {
-	var result types.MsggetArgs
-	var err error
+  var result types.MsggetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MsggetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MsggetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MsggetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MsggetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Key)
-			if err != nil {
-				return types.MsggetArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Msgflg)
-			if err != nil {
-				return types.MsggetArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Key)
+      if err != nil {
+        return types.MsggetArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Msgflg)
+      if err != nil {
+        return types.MsggetArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMsgsndArgs(decoder *Decoder) (types.MsgsndArgs, error) {
-	var result types.MsgsndArgs
-	var err error
+  var result types.MsgsndArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MsgsndArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MsgsndArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MsgsndArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MsgsndArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Msqid)
-			if err != nil {
-				return types.MsgsndArgs{}, err
-			}
-		case 1:
-			var dataMsgp uint64
-			err = decoder.DecodeUint64(&dataMsgp)
-			if err != nil {
-				return types.MsgsndArgs{}, err
-			}
-			result.Msgp = uintptr(dataMsgp)
-		case 2:
-			err = decoder.DecodeUint64(&result.Msgsz)
-			if err != nil {
-				return types.MsgsndArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Msgflg)
-			if err != nil {
-				return types.MsgsndArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Msqid)
+      if err != nil {
+        return types.MsgsndArgs{}, err
+      }
+    case 1:
+      var dataMsgp uint64
+      err = decoder.DecodeUint64(&dataMsgp)
+      if err != nil {
+        return types.MsgsndArgs{}, err
+      }
+      result.Msgp = uintptr(dataMsgp)
+    case 2:
+      err = decoder.DecodeUint64(&result.Msgsz)
+      if err != nil {
+        return types.MsgsndArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Msgflg)
+      if err != nil {
+        return types.MsgsndArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMsgrcvArgs(decoder *Decoder) (types.MsgrcvArgs, error) {
-	var result types.MsgrcvArgs
-	var err error
+  var result types.MsgrcvArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MsgrcvArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MsgrcvArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MsgrcvArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MsgrcvArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Msqid)
-			if err != nil {
-				return types.MsgrcvArgs{}, err
-			}
-		case 1:
-			var dataMsgp uint64
-			err = decoder.DecodeUint64(&dataMsgp)
-			if err != nil {
-				return types.MsgrcvArgs{}, err
-			}
-			result.Msgp = uintptr(dataMsgp)
-		case 2:
-			err = decoder.DecodeUint64(&result.Msgsz)
-			if err != nil {
-				return types.MsgrcvArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt64(&result.Msgtyp)
-			if err != nil {
-				return types.MsgrcvArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Msgflg)
-			if err != nil {
-				return types.MsgrcvArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Msqid)
+      if err != nil {
+        return types.MsgrcvArgs{}, err
+      }
+    case 1:
+      var dataMsgp uint64
+      err = decoder.DecodeUint64(&dataMsgp)
+      if err != nil {
+        return types.MsgrcvArgs{}, err
+      }
+      result.Msgp = uintptr(dataMsgp)
+    case 2:
+      err = decoder.DecodeUint64(&result.Msgsz)
+      if err != nil {
+        return types.MsgrcvArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt64(&result.Msgtyp)
+      if err != nil {
+        return types.MsgrcvArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Msgflg)
+      if err != nil {
+        return types.MsgrcvArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMsgctlArgs(decoder *Decoder) (types.MsgctlArgs, error) {
-	var result types.MsgctlArgs
-	var err error
+  var result types.MsgctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MsgctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MsgctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MsgctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MsgctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Msqid)
-			if err != nil {
-				return types.MsgctlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.MsgctlArgs{}, err
-			}
-		case 2:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.MsgctlArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Msqid)
+      if err != nil {
+        return types.MsgctlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.MsgctlArgs{}, err
+      }
+    case 2:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.MsgctlArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseFcntlArgs(decoder *Decoder) (types.FcntlArgs, error) {
-	var result types.FcntlArgs
-	var err error
+  var result types.FcntlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FcntlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FcntlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FcntlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FcntlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FcntlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.FcntlArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Arg)
-			if err != nil {
-				return types.FcntlArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FcntlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.FcntlArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Arg)
+      if err != nil {
+        return types.FcntlArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFlockArgs(decoder *Decoder) (types.FlockArgs, error) {
-	var result types.FlockArgs
-	var err error
+  var result types.FlockArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FlockArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FlockArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FlockArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FlockArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FlockArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Operation)
-			if err != nil {
-				return types.FlockArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FlockArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Operation)
+      if err != nil {
+        return types.FlockArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFsyncArgs(decoder *Decoder) (types.FsyncArgs, error) {
-	var result types.FsyncArgs
-	var err error
+  var result types.FsyncArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FsyncArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FsyncArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FsyncArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FsyncArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FsyncArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FsyncArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFdatasyncArgs(decoder *Decoder) (types.FdatasyncArgs, error) {
-	var result types.FdatasyncArgs
-	var err error
+  var result types.FdatasyncArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FdatasyncArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FdatasyncArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FdatasyncArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FdatasyncArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FdatasyncArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FdatasyncArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTruncateArgs(decoder *Decoder) (types.TruncateArgs, error) {
-	var result types.TruncateArgs
-	var err error
+  var result types.TruncateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TruncateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TruncateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TruncateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TruncateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.TruncateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.TruncateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.TruncateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.TruncateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFtruncateArgs(decoder *Decoder) (types.FtruncateArgs, error) {
-	var result types.FtruncateArgs
-	var err error
+  var result types.FtruncateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FtruncateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FtruncateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FtruncateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FtruncateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FtruncateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.FtruncateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FtruncateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.FtruncateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetdentsArgs(decoder *Decoder) (types.GetdentsArgs, error) {
-	var result types.GetdentsArgs
-	var err error
+  var result types.GetdentsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetdentsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetdentsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetdentsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetdentsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.GetdentsArgs{}, err
-			}
-		case 1:
-			var dataDirp uint64
-			err = decoder.DecodeUint64(&dataDirp)
-			if err != nil {
-				return types.GetdentsArgs{}, err
-			}
-			result.Dirp = uintptr(dataDirp)
-		case 2:
-			err = decoder.DecodeUint32(&result.Count)
-			if err != nil {
-				return types.GetdentsArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.GetdentsArgs{}, err
+      }
+    case 1:
+      var dataDirp uint64
+      err = decoder.DecodeUint64(&dataDirp)
+      if err != nil {
+        return types.GetdentsArgs{}, err
+      }
+      result.Dirp = uintptr(dataDirp)
+    case 2:
+      err = decoder.DecodeUint32(&result.Count)
+      if err != nil {
+        return types.GetdentsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetcwdArgs(decoder *Decoder) (types.GetcwdArgs, error) {
-	var result types.GetcwdArgs
-	var err error
+  var result types.GetcwdArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetcwdArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetcwdArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetcwdArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetcwdArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Buf, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.GetcwdArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.GetcwdArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Buf, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.GetcwdArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.GetcwdArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseChdirArgs(decoder *Decoder) (types.ChdirArgs, error) {
-	var result types.ChdirArgs
-	var err error
+  var result types.ChdirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ChdirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ChdirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ChdirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ChdirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ChdirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ChdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFchdirArgs(decoder *Decoder) (types.FchdirArgs, error) {
-	var result types.FchdirArgs
-	var err error
+  var result types.FchdirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FchdirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FchdirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FchdirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FchdirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FchdirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FchdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRenameArgs(decoder *Decoder) (types.RenameArgs, error) {
-	var result types.RenameArgs
-	var err error
+  var result types.RenameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RenameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RenameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RenameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RenameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Oldpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RenameArgs{}, err
-			}
-		case 1:
-			result.Newpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RenameArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Oldpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RenameArgs{}, err
+      }
+    case 1:
+      result.Newpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RenameArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMkdirArgs(decoder *Decoder) (types.MkdirArgs, error) {
-	var result types.MkdirArgs
-	var err error
+  var result types.MkdirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MkdirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MkdirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MkdirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MkdirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MkdirArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.MkdirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MkdirArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.MkdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRmdirArgs(decoder *Decoder) (types.RmdirArgs, error) {
-	var result types.RmdirArgs
-	var err error
+  var result types.RmdirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RmdirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RmdirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RmdirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RmdirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RmdirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RmdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCreatArgs(decoder *Decoder) (types.CreatArgs, error) {
-	var result types.CreatArgs
-	var err error
+  var result types.CreatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CreatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CreatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CreatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CreatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.CreatArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.CreatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.CreatArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.CreatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLinkArgs(decoder *Decoder) (types.LinkArgs, error) {
-	var result types.LinkArgs
-	var err error
+  var result types.LinkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LinkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LinkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LinkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LinkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Oldpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LinkArgs{}, err
-			}
-		case 1:
-			result.Newpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LinkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Oldpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LinkArgs{}, err
+      }
+    case 1:
+      result.Newpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LinkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUnlinkArgs(decoder *Decoder) (types.UnlinkArgs, error) {
-	var result types.UnlinkArgs
-	var err error
+  var result types.UnlinkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UnlinkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UnlinkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UnlinkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UnlinkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UnlinkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UnlinkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSymlinkArgs(decoder *Decoder) (types.SymlinkArgs, error) {
-	var result types.SymlinkArgs
-	var err error
+  var result types.SymlinkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SymlinkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SymlinkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SymlinkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SymlinkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Target, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SymlinkArgs{}, err
-			}
-		case 1:
-			result.Linkpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SymlinkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Target, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SymlinkArgs{}, err
+      }
+    case 1:
+      result.Linkpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SymlinkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseReadlinkArgs(decoder *Decoder) (types.ReadlinkArgs, error) {
-	var result types.ReadlinkArgs
-	var err error
+  var result types.ReadlinkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ReadlinkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ReadlinkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ReadlinkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ReadlinkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ReadlinkArgs{}, err
-			}
-		case 1:
-			result.Buf, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ReadlinkArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Bufsiz)
-			if err != nil {
-				return types.ReadlinkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ReadlinkArgs{}, err
+      }
+    case 1:
+      result.Buf, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ReadlinkArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Bufsiz)
+      if err != nil {
+        return types.ReadlinkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseChmodArgs(decoder *Decoder) (types.ChmodArgs, error) {
-	var result types.ChmodArgs
-	var err error
+  var result types.ChmodArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ChmodArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ChmodArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ChmodArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ChmodArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ChmodArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.ChmodArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ChmodArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.ChmodArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFchmodArgs(decoder *Decoder) (types.FchmodArgs, error) {
-	var result types.FchmodArgs
-	var err error
+  var result types.FchmodArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FchmodArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FchmodArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FchmodArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FchmodArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FchmodArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.FchmodArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FchmodArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.FchmodArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseChownArgs(decoder *Decoder) (types.ChownArgs, error) {
-	var result types.ChownArgs
-	var err error
+  var result types.ChownArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ChownArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ChownArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ChownArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ChownArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ChownArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Owner)
-			if err != nil {
-				return types.ChownArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Group)
-			if err != nil {
-				return types.ChownArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ChownArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Owner)
+      if err != nil {
+        return types.ChownArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Group)
+      if err != nil {
+        return types.ChownArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFchownArgs(decoder *Decoder) (types.FchownArgs, error) {
-	var result types.FchownArgs
-	var err error
+  var result types.FchownArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FchownArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FchownArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FchownArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FchownArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FchownArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Owner)
-			if err != nil {
-				return types.FchownArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Group)
-			if err != nil {
-				return types.FchownArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FchownArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Owner)
+      if err != nil {
+        return types.FchownArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Group)
+      if err != nil {
+        return types.FchownArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLchownArgs(decoder *Decoder) (types.LchownArgs, error) {
-	var result types.LchownArgs
-	var err error
+  var result types.LchownArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LchownArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LchownArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LchownArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LchownArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LchownArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Owner)
-			if err != nil {
-				return types.LchownArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Group)
-			if err != nil {
-				return types.LchownArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LchownArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Owner)
+      if err != nil {
+        return types.LchownArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Group)
+      if err != nil {
+        return types.LchownArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUmaskArgs(decoder *Decoder) (types.UmaskArgs, error) {
-	var result types.UmaskArgs
-	var err error
+  var result types.UmaskArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UmaskArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UmaskArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UmaskArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UmaskArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Mask)
-			if err != nil {
-				return types.UmaskArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Mask)
+      if err != nil {
+        return types.UmaskArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGettimeofdayArgs(decoder *Decoder) (types.GettimeofdayArgs, error) {
-	var result types.GettimeofdayArgs
-	var err error
+  var result types.GettimeofdayArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GettimeofdayArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GettimeofdayArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GettimeofdayArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GettimeofdayArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataTv uint64
-			err = decoder.DecodeUint64(&dataTv)
-			if err != nil {
-				return types.GettimeofdayArgs{}, err
-			}
-			result.Tv = uintptr(dataTv)
-		case 1:
-			var dataTz uint64
-			err = decoder.DecodeUint64(&dataTz)
-			if err != nil {
-				return types.GettimeofdayArgs{}, err
-			}
-			result.Tz = uintptr(dataTz)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataTv uint64
+      err = decoder.DecodeUint64(&dataTv)
+      if err != nil {
+        return types.GettimeofdayArgs{}, err
+      }
+      result.Tv = uintptr(dataTv)
+    case 1:
+      var dataTz uint64
+      err = decoder.DecodeUint64(&dataTz)
+      if err != nil {
+        return types.GettimeofdayArgs{}, err
+      }
+      result.Tz = uintptr(dataTz)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetrlimitArgs(decoder *Decoder) (types.GetrlimitArgs, error) {
-	var result types.GetrlimitArgs
-	var err error
+  var result types.GetrlimitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetrlimitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetrlimitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetrlimitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetrlimitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Resource)
-			if err != nil {
-				return types.GetrlimitArgs{}, err
-			}
-		case 1:
-			var dataRlim uint64
-			err = decoder.DecodeUint64(&dataRlim)
-			if err != nil {
-				return types.GetrlimitArgs{}, err
-			}
-			result.Rlim = uintptr(dataRlim)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Resource)
+      if err != nil {
+        return types.GetrlimitArgs{}, err
+      }
+    case 1:
+      var dataRlim uint64
+      err = decoder.DecodeUint64(&dataRlim)
+      if err != nil {
+        return types.GetrlimitArgs{}, err
+      }
+      result.Rlim = uintptr(dataRlim)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetrusageArgs(decoder *Decoder) (types.GetrusageArgs, error) {
-	var result types.GetrusageArgs
-	var err error
+  var result types.GetrusageArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetrusageArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetrusageArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetrusageArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetrusageArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Who)
-			if err != nil {
-				return types.GetrusageArgs{}, err
-			}
-		case 1:
-			var dataUsage uint64
-			err = decoder.DecodeUint64(&dataUsage)
-			if err != nil {
-				return types.GetrusageArgs{}, err
-			}
-			result.Usage = uintptr(dataUsage)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Who)
+      if err != nil {
+        return types.GetrusageArgs{}, err
+      }
+    case 1:
+      var dataUsage uint64
+      err = decoder.DecodeUint64(&dataUsage)
+      if err != nil {
+        return types.GetrusageArgs{}, err
+      }
+      result.Usage = uintptr(dataUsage)
+    }
+  }
+  return result, nil
 }
 
 func ParseSysinfoArgs(decoder *Decoder) (types.SysinfoArgs, error) {
-	var result types.SysinfoArgs
-	var err error
+  var result types.SysinfoArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SysinfoArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SysinfoArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SysinfoArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SysinfoArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataInfo uint64
-			err = decoder.DecodeUint64(&dataInfo)
-			if err != nil {
-				return types.SysinfoArgs{}, err
-			}
-			result.Info = uintptr(dataInfo)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataInfo uint64
+      err = decoder.DecodeUint64(&dataInfo)
+      if err != nil {
+        return types.SysinfoArgs{}, err
+      }
+      result.Info = uintptr(dataInfo)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimesArgs(decoder *Decoder) (types.TimesArgs, error) {
-	var result types.TimesArgs
-	var err error
+  var result types.TimesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.TimesArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.TimesArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParsePtraceArgs(decoder *Decoder) (types.PtraceArgs, error) {
-	var result types.PtraceArgs
-	var err error
+  var result types.PtraceArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PtraceArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PtraceArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PtraceArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PtraceArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt64(&result.Request)
-			if err != nil {
-				return types.PtraceArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.PtraceArgs{}, err
-			}
-		case 2:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.PtraceArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 3:
-			var dataData uint64
-			err = decoder.DecodeUint64(&dataData)
-			if err != nil {
-				return types.PtraceArgs{}, err
-			}
-			result.Data = uintptr(dataData)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt64(&result.Request)
+      if err != nil {
+        return types.PtraceArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.PtraceArgs{}, err
+      }
+    case 2:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.PtraceArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 3:
+      var dataData uint64
+      err = decoder.DecodeUint64(&dataData)
+      if err != nil {
+        return types.PtraceArgs{}, err
+      }
+      result.Data = uintptr(dataData)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetuidArgs(decoder *Decoder) (types.GetuidArgs, error) {
-	return types.GetuidArgs{}, nil
+  return types.GetuidArgs{}, nil
 }
 
 func ParseSyslogArgs(decoder *Decoder) (types.SyslogArgs, error) {
-	var result types.SyslogArgs
-	var err error
+  var result types.SyslogArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SyslogArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SyslogArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SyslogArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SyslogArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.SyslogArgs{}, err
-			}
-		case 1:
-			result.Bufp, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SyslogArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Len)
-			if err != nil {
-				return types.SyslogArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.SyslogArgs{}, err
+      }
+    case 1:
+      result.Bufp, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SyslogArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Len)
+      if err != nil {
+        return types.SyslogArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetgidArgs(decoder *Decoder) (types.GetgidArgs, error) {
-	return types.GetgidArgs{}, nil
+  return types.GetgidArgs{}, nil
 }
 
 func ParseSetuidArgs(decoder *Decoder) (types.SetuidArgs, error) {
-	var result types.SetuidArgs
-	var err error
+  var result types.SetuidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetuidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetuidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetuidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetuidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Uid)
-			if err != nil {
-				return types.SetuidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Uid)
+      if err != nil {
+        return types.SetuidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetgidArgs(decoder *Decoder) (types.SetgidArgs, error) {
-	var result types.SetgidArgs
-	var err error
+  var result types.SetgidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetgidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetgidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetgidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetgidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Gid)
-			if err != nil {
-				return types.SetgidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Gid)
+      if err != nil {
+        return types.SetgidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGeteuidArgs(decoder *Decoder) (types.GeteuidArgs, error) {
-	return types.GeteuidArgs{}, nil
+  return types.GeteuidArgs{}, nil
 }
 
 func ParseGetegidArgs(decoder *Decoder) (types.GetegidArgs, error) {
-	return types.GetegidArgs{}, nil
+  return types.GetegidArgs{}, nil
 }
 
 func ParseSetpgidArgs(decoder *Decoder) (types.SetpgidArgs, error) {
-	var result types.SetpgidArgs
-	var err error
+  var result types.SetpgidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetpgidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetpgidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetpgidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetpgidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SetpgidArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Pgid)
-			if err != nil {
-				return types.SetpgidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SetpgidArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Pgid)
+      if err != nil {
+        return types.SetpgidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetppidArgs(decoder *Decoder) (types.GetppidArgs, error) {
-	return types.GetppidArgs{}, nil
+  return types.GetppidArgs{}, nil
 }
 
 func ParseGetpgrpArgs(decoder *Decoder) (types.GetpgrpArgs, error) {
-	return types.GetpgrpArgs{}, nil
+  return types.GetpgrpArgs{}, nil
 }
 
 func ParseSetsidArgs(decoder *Decoder) (types.SetsidArgs, error) {
-	return types.SetsidArgs{}, nil
+  return types.SetsidArgs{}, nil
 }
 
 func ParseSetreuidArgs(decoder *Decoder) (types.SetreuidArgs, error) {
-	var result types.SetreuidArgs
-	var err error
+  var result types.SetreuidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetreuidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetreuidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetreuidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetreuidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Ruid)
-			if err != nil {
-				return types.SetreuidArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Euid)
-			if err != nil {
-				return types.SetreuidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Ruid)
+      if err != nil {
+        return types.SetreuidArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Euid)
+      if err != nil {
+        return types.SetreuidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetregidArgs(decoder *Decoder) (types.SetregidArgs, error) {
-	var result types.SetregidArgs
-	var err error
+  var result types.SetregidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetregidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetregidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetregidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetregidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Rgid)
-			if err != nil {
-				return types.SetregidArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Egid)
-			if err != nil {
-				return types.SetregidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Rgid)
+      if err != nil {
+        return types.SetregidArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Egid)
+      if err != nil {
+        return types.SetregidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetgroupsArgs(decoder *Decoder) (types.GetgroupsArgs, error) {
-	var result types.GetgroupsArgs
-	var err error
+  var result types.GetgroupsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetgroupsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetgroupsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetgroupsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetgroupsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Size)
-			if err != nil {
-				return types.GetgroupsArgs{}, err
-			}
-		case 1:
-			var dataList uint64
-			err = decoder.DecodeUint64(&dataList)
-			if err != nil {
-				return types.GetgroupsArgs{}, err
-			}
-			result.List = uintptr(dataList)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Size)
+      if err != nil {
+        return types.GetgroupsArgs{}, err
+      }
+    case 1:
+      var dataList uint64
+      err = decoder.DecodeUint64(&dataList)
+      if err != nil {
+        return types.GetgroupsArgs{}, err
+      }
+      result.List = uintptr(dataList)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetgroupsArgs(decoder *Decoder) (types.SetgroupsArgs, error) {
-	var result types.SetgroupsArgs
-	var err error
+  var result types.SetgroupsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetgroupsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetgroupsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetgroupsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetgroupsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Size)
-			if err != nil {
-				return types.SetgroupsArgs{}, err
-			}
-		case 1:
-			var dataList uint64
-			err = decoder.DecodeUint64(&dataList)
-			if err != nil {
-				return types.SetgroupsArgs{}, err
-			}
-			result.List = uintptr(dataList)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Size)
+      if err != nil {
+        return types.SetgroupsArgs{}, err
+      }
+    case 1:
+      var dataList uint64
+      err = decoder.DecodeUint64(&dataList)
+      if err != nil {
+        return types.SetgroupsArgs{}, err
+      }
+      result.List = uintptr(dataList)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetresuidArgs(decoder *Decoder) (types.SetresuidArgs, error) {
-	var result types.SetresuidArgs
-	var err error
+  var result types.SetresuidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetresuidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetresuidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetresuidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetresuidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Ruid)
-			if err != nil {
-				return types.SetresuidArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Euid)
-			if err != nil {
-				return types.SetresuidArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Suid)
-			if err != nil {
-				return types.SetresuidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Ruid)
+      if err != nil {
+        return types.SetresuidArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Euid)
+      if err != nil {
+        return types.SetresuidArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Suid)
+      if err != nil {
+        return types.SetresuidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetresuidArgs(decoder *Decoder) (types.GetresuidArgs, error) {
-	var result types.GetresuidArgs
-	var err error
+  var result types.GetresuidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetresuidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetresuidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetresuidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetresuidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRuid uint64
-			err = decoder.DecodeUint64(&dataRuid)
-			if err != nil {
-				return types.GetresuidArgs{}, err
-			}
-			result.Ruid = uintptr(dataRuid)
-		case 1:
-			var dataEuid uint64
-			err = decoder.DecodeUint64(&dataEuid)
-			if err != nil {
-				return types.GetresuidArgs{}, err
-			}
-			result.Euid = uintptr(dataEuid)
-		case 2:
-			var dataSuid uint64
-			err = decoder.DecodeUint64(&dataSuid)
-			if err != nil {
-				return types.GetresuidArgs{}, err
-			}
-			result.Suid = uintptr(dataSuid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRuid uint64
+      err = decoder.DecodeUint64(&dataRuid)
+      if err != nil {
+        return types.GetresuidArgs{}, err
+      }
+      result.Ruid = uintptr(dataRuid)
+    case 1:
+      var dataEuid uint64
+      err = decoder.DecodeUint64(&dataEuid)
+      if err != nil {
+        return types.GetresuidArgs{}, err
+      }
+      result.Euid = uintptr(dataEuid)
+    case 2:
+      var dataSuid uint64
+      err = decoder.DecodeUint64(&dataSuid)
+      if err != nil {
+        return types.GetresuidArgs{}, err
+      }
+      result.Suid = uintptr(dataSuid)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetresgidArgs(decoder *Decoder) (types.SetresgidArgs, error) {
-	var result types.SetresgidArgs
-	var err error
+  var result types.SetresgidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetresgidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetresgidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetresgidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetresgidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Rgid)
-			if err != nil {
-				return types.SetresgidArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Egid)
-			if err != nil {
-				return types.SetresgidArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Sgid)
-			if err != nil {
-				return types.SetresgidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Rgid)
+      if err != nil {
+        return types.SetresgidArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Egid)
+      if err != nil {
+        return types.SetresgidArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Sgid)
+      if err != nil {
+        return types.SetresgidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetresgidArgs(decoder *Decoder) (types.GetresgidArgs, error) {
-	var result types.GetresgidArgs
-	var err error
+  var result types.GetresgidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetresgidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetresgidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetresgidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetresgidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRgid uint64
-			err = decoder.DecodeUint64(&dataRgid)
-			if err != nil {
-				return types.GetresgidArgs{}, err
-			}
-			result.Rgid = uintptr(dataRgid)
-		case 1:
-			var dataEgid uint64
-			err = decoder.DecodeUint64(&dataEgid)
-			if err != nil {
-				return types.GetresgidArgs{}, err
-			}
-			result.Egid = uintptr(dataEgid)
-		case 2:
-			var dataSgid uint64
-			err = decoder.DecodeUint64(&dataSgid)
-			if err != nil {
-				return types.GetresgidArgs{}, err
-			}
-			result.Sgid = uintptr(dataSgid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRgid uint64
+      err = decoder.DecodeUint64(&dataRgid)
+      if err != nil {
+        return types.GetresgidArgs{}, err
+      }
+      result.Rgid = uintptr(dataRgid)
+    case 1:
+      var dataEgid uint64
+      err = decoder.DecodeUint64(&dataEgid)
+      if err != nil {
+        return types.GetresgidArgs{}, err
+      }
+      result.Egid = uintptr(dataEgid)
+    case 2:
+      var dataSgid uint64
+      err = decoder.DecodeUint64(&dataSgid)
+      if err != nil {
+        return types.GetresgidArgs{}, err
+      }
+      result.Sgid = uintptr(dataSgid)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetpgidArgs(decoder *Decoder) (types.GetpgidArgs, error) {
-	var result types.GetpgidArgs
-	var err error
+  var result types.GetpgidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetpgidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetpgidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetpgidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetpgidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.GetpgidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.GetpgidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetfsuidArgs(decoder *Decoder) (types.SetfsuidArgs, error) {
-	var result types.SetfsuidArgs
-	var err error
+  var result types.SetfsuidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetfsuidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetfsuidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetfsuidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetfsuidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fsuid)
-			if err != nil {
-				return types.SetfsuidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fsuid)
+      if err != nil {
+        return types.SetfsuidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetfsgidArgs(decoder *Decoder) (types.SetfsgidArgs, error) {
-	var result types.SetfsgidArgs
-	var err error
+  var result types.SetfsgidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetfsgidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetfsgidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetfsgidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetfsgidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fsgid)
-			if err != nil {
-				return types.SetfsgidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fsgid)
+      if err != nil {
+        return types.SetfsgidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetsidArgs(decoder *Decoder) (types.GetsidArgs, error) {
-	var result types.GetsidArgs
-	var err error
+  var result types.GetsidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetsidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetsidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetsidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetsidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.GetsidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.GetsidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCapgetArgs(decoder *Decoder) (types.CapgetArgs, error) {
-	var result types.CapgetArgs
-	var err error
+  var result types.CapgetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CapgetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CapgetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CapgetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CapgetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataHdrp uint64
-			err = decoder.DecodeUint64(&dataHdrp)
-			if err != nil {
-				return types.CapgetArgs{}, err
-			}
-			result.Hdrp = uintptr(dataHdrp)
-		case 1:
-			var dataDatap uint64
-			err = decoder.DecodeUint64(&dataDatap)
-			if err != nil {
-				return types.CapgetArgs{}, err
-			}
-			result.Datap = uintptr(dataDatap)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataHdrp uint64
+      err = decoder.DecodeUint64(&dataHdrp)
+      if err != nil {
+        return types.CapgetArgs{}, err
+      }
+      result.Hdrp = uintptr(dataHdrp)
+    case 1:
+      var dataDatap uint64
+      err = decoder.DecodeUint64(&dataDatap)
+      if err != nil {
+        return types.CapgetArgs{}, err
+      }
+      result.Datap = uintptr(dataDatap)
+    }
+  }
+  return result, nil
 }
 
 func ParseCapsetArgs(decoder *Decoder) (types.CapsetArgs, error) {
-	var result types.CapsetArgs
-	var err error
+  var result types.CapsetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CapsetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CapsetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CapsetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CapsetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataHdrp uint64
-			err = decoder.DecodeUint64(&dataHdrp)
-			if err != nil {
-				return types.CapsetArgs{}, err
-			}
-			result.Hdrp = uintptr(dataHdrp)
-		case 1:
-			var dataDatap uint64
-			err = decoder.DecodeUint64(&dataDatap)
-			if err != nil {
-				return types.CapsetArgs{}, err
-			}
-			result.Datap = uintptr(dataDatap)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataHdrp uint64
+      err = decoder.DecodeUint64(&dataHdrp)
+      if err != nil {
+        return types.CapsetArgs{}, err
+      }
+      result.Hdrp = uintptr(dataHdrp)
+    case 1:
+      var dataDatap uint64
+      err = decoder.DecodeUint64(&dataDatap)
+      if err != nil {
+        return types.CapsetArgs{}, err
+      }
+      result.Datap = uintptr(dataDatap)
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigpendingArgs(decoder *Decoder) (types.RtSigpendingArgs, error) {
-	var result types.RtSigpendingArgs
-	var err error
+  var result types.RtSigpendingArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtSigpendingArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtSigpendingArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtSigpendingArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtSigpendingArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataSet uint64
-			err = decoder.DecodeUint64(&dataSet)
-			if err != nil {
-				return types.RtSigpendingArgs{}, err
-			}
-			result.Set = uintptr(dataSet)
-		case 1:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.RtSigpendingArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataSet uint64
+      err = decoder.DecodeUint64(&dataSet)
+      if err != nil {
+        return types.RtSigpendingArgs{}, err
+      }
+      result.Set = uintptr(dataSet)
+    case 1:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.RtSigpendingArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigtimedwaitArgs(decoder *Decoder) (types.RtSigtimedwaitArgs, error) {
-	var result types.RtSigtimedwaitArgs
-	var err error
+  var result types.RtSigtimedwaitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtSigtimedwaitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtSigtimedwaitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtSigtimedwaitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtSigtimedwaitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataSet uint64
-			err = decoder.DecodeUint64(&dataSet)
-			if err != nil {
-				return types.RtSigtimedwaitArgs{}, err
-			}
-			result.Set = uintptr(dataSet)
-		case 1:
-			var dataInfo uint64
-			err = decoder.DecodeUint64(&dataInfo)
-			if err != nil {
-				return types.RtSigtimedwaitArgs{}, err
-			}
-			result.Info = uintptr(dataInfo)
-		case 2:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.RtSigtimedwaitArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.RtSigtimedwaitArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataSet uint64
+      err = decoder.DecodeUint64(&dataSet)
+      if err != nil {
+        return types.RtSigtimedwaitArgs{}, err
+      }
+      result.Set = uintptr(dataSet)
+    case 1:
+      var dataInfo uint64
+      err = decoder.DecodeUint64(&dataInfo)
+      if err != nil {
+        return types.RtSigtimedwaitArgs{}, err
+      }
+      result.Info = uintptr(dataInfo)
+    case 2:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.RtSigtimedwaitArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.RtSigtimedwaitArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigqueueinfoArgs(decoder *Decoder) (types.RtSigqueueinfoArgs, error) {
-	var result types.RtSigqueueinfoArgs
-	var err error
+  var result types.RtSigqueueinfoArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtSigqueueinfoArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtSigqueueinfoArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtSigqueueinfoArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtSigqueueinfoArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Tgid)
-			if err != nil {
-				return types.RtSigqueueinfoArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.RtSigqueueinfoArgs{}, err
-			}
-		case 2:
-			var dataInfo uint64
-			err = decoder.DecodeUint64(&dataInfo)
-			if err != nil {
-				return types.RtSigqueueinfoArgs{}, err
-			}
-			result.Info = uintptr(dataInfo)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Tgid)
+      if err != nil {
+        return types.RtSigqueueinfoArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.RtSigqueueinfoArgs{}, err
+      }
+    case 2:
+      var dataInfo uint64
+      err = decoder.DecodeUint64(&dataInfo)
+      if err != nil {
+        return types.RtSigqueueinfoArgs{}, err
+      }
+      result.Info = uintptr(dataInfo)
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigsuspendArgs(decoder *Decoder) (types.RtSigsuspendArgs, error) {
-	var result types.RtSigsuspendArgs
-	var err error
+  var result types.RtSigsuspendArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtSigsuspendArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtSigsuspendArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtSigsuspendArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtSigsuspendArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataMask uint64
-			err = decoder.DecodeUint64(&dataMask)
-			if err != nil {
-				return types.RtSigsuspendArgs{}, err
-			}
-			result.Mask = uintptr(dataMask)
-		case 1:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.RtSigsuspendArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataMask uint64
+      err = decoder.DecodeUint64(&dataMask)
+      if err != nil {
+        return types.RtSigsuspendArgs{}, err
+      }
+      result.Mask = uintptr(dataMask)
+    case 1:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.RtSigsuspendArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSigaltstackArgs(decoder *Decoder) (types.SigaltstackArgs, error) {
-	var result types.SigaltstackArgs
-	var err error
+  var result types.SigaltstackArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SigaltstackArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SigaltstackArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SigaltstackArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SigaltstackArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataSs uint64
-			err = decoder.DecodeUint64(&dataSs)
-			if err != nil {
-				return types.SigaltstackArgs{}, err
-			}
-			result.Ss = uintptr(dataSs)
-		case 1:
-			var dataOldSs uint64
-			err = decoder.DecodeUint64(&dataOldSs)
-			if err != nil {
-				return types.SigaltstackArgs{}, err
-			}
-			result.OldSs = uintptr(dataOldSs)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataSs uint64
+      err = decoder.DecodeUint64(&dataSs)
+      if err != nil {
+        return types.SigaltstackArgs{}, err
+      }
+      result.Ss = uintptr(dataSs)
+    case 1:
+      var dataOldSs uint64
+      err = decoder.DecodeUint64(&dataOldSs)
+      if err != nil {
+        return types.SigaltstackArgs{}, err
+      }
+      result.OldSs = uintptr(dataOldSs)
+    }
+  }
+  return result, nil
 }
 
 func ParseUtimeArgs(decoder *Decoder) (types.UtimeArgs, error) {
-	var result types.UtimeArgs
-	var err error
+  var result types.UtimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UtimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UtimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UtimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UtimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Filename, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UtimeArgs{}, err
-			}
-		case 1:
-			var dataTimes uint64
-			err = decoder.DecodeUint64(&dataTimes)
-			if err != nil {
-				return types.UtimeArgs{}, err
-			}
-			result.Times = uintptr(dataTimes)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Filename, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UtimeArgs{}, err
+      }
+    case 1:
+      var dataTimes uint64
+      err = decoder.DecodeUint64(&dataTimes)
+      if err != nil {
+        return types.UtimeArgs{}, err
+      }
+      result.Times = uintptr(dataTimes)
+    }
+  }
+  return result, nil
 }
 
 func ParseMknodArgs(decoder *Decoder) (types.MknodArgs, error) {
-	var result types.MknodArgs
-	var err error
+  var result types.MknodArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MknodArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MknodArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MknodArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MknodArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MknodArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.MknodArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.MknodArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MknodArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.MknodArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.MknodArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUselibArgs(decoder *Decoder) (types.UselibArgs, error) {
-	var result types.UselibArgs
-	var err error
+  var result types.UselibArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UselibArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UselibArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UselibArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UselibArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Library, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UselibArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Library, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UselibArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePersonalityArgs(decoder *Decoder) (types.PersonalityArgs, error) {
-	var result types.PersonalityArgs
-	var err error
+  var result types.PersonalityArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PersonalityArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PersonalityArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PersonalityArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PersonalityArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Persona)
-			if err != nil {
-				return types.PersonalityArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Persona)
+      if err != nil {
+        return types.PersonalityArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUstatArgs(decoder *Decoder) (types.UstatArgs, error) {
-	var result types.UstatArgs
-	var err error
+  var result types.UstatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UstatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UstatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UstatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UstatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.UstatArgs{}, err
-			}
-		case 1:
-			var dataUbuf uint64
-			err = decoder.DecodeUint64(&dataUbuf)
-			if err != nil {
-				return types.UstatArgs{}, err
-			}
-			result.Ubuf = uintptr(dataUbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.UstatArgs{}, err
+      }
+    case 1:
+      var dataUbuf uint64
+      err = decoder.DecodeUint64(&dataUbuf)
+      if err != nil {
+        return types.UstatArgs{}, err
+      }
+      result.Ubuf = uintptr(dataUbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseStatfsArgs(decoder *Decoder) (types.StatfsArgs, error) {
-	var result types.StatfsArgs
-	var err error
+  var result types.StatfsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.StatfsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.StatfsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.StatfsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.StatfsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.StatfsArgs{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.StatfsArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.StatfsArgs{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.StatfsArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseFstatfsArgs(decoder *Decoder) (types.FstatfsArgs, error) {
-	var result types.FstatfsArgs
-	var err error
+  var result types.FstatfsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FstatfsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FstatfsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FstatfsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FstatfsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FstatfsArgs{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.FstatfsArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FstatfsArgs{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.FstatfsArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseSysfsArgs(decoder *Decoder) (types.SysfsArgs, error) {
-	var result types.SysfsArgs
-	var err error
+  var result types.SysfsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SysfsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SysfsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SysfsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SysfsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Option)
-			if err != nil {
-				return types.SysfsArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Option)
+      if err != nil {
+        return types.SysfsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetpriorityArgs(decoder *Decoder) (types.GetpriorityArgs, error) {
-	var result types.GetpriorityArgs
-	var err error
+  var result types.GetpriorityArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetpriorityArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetpriorityArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetpriorityArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetpriorityArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Which)
-			if err != nil {
-				return types.GetpriorityArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Who)
-			if err != nil {
-				return types.GetpriorityArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Which)
+      if err != nil {
+        return types.GetpriorityArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Who)
+      if err != nil {
+        return types.GetpriorityArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetpriorityArgs(decoder *Decoder) (types.SetpriorityArgs, error) {
-	var result types.SetpriorityArgs
-	var err error
+  var result types.SetpriorityArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetpriorityArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetpriorityArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetpriorityArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetpriorityArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Which)
-			if err != nil {
-				return types.SetpriorityArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Who)
-			if err != nil {
-				return types.SetpriorityArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Prio)
-			if err != nil {
-				return types.SetpriorityArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Which)
+      if err != nil {
+        return types.SetpriorityArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Who)
+      if err != nil {
+        return types.SetpriorityArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Prio)
+      if err != nil {
+        return types.SetpriorityArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedSetparamArgs(decoder *Decoder) (types.SchedSetparamArgs, error) {
-	var result types.SchedSetparamArgs
-	var err error
+  var result types.SchedSetparamArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedSetparamArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedSetparamArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedSetparamArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedSetparamArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedSetparamArgs{}, err
-			}
-		case 1:
-			var dataParam uint64
-			err = decoder.DecodeUint64(&dataParam)
-			if err != nil {
-				return types.SchedSetparamArgs{}, err
-			}
-			result.Param = uintptr(dataParam)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedSetparamArgs{}, err
+      }
+    case 1:
+      var dataParam uint64
+      err = decoder.DecodeUint64(&dataParam)
+      if err != nil {
+        return types.SchedSetparamArgs{}, err
+      }
+      result.Param = uintptr(dataParam)
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedGetparamArgs(decoder *Decoder) (types.SchedGetparamArgs, error) {
-	var result types.SchedGetparamArgs
-	var err error
+  var result types.SchedGetparamArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedGetparamArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedGetparamArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedGetparamArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedGetparamArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedGetparamArgs{}, err
-			}
-		case 1:
-			var dataParam uint64
-			err = decoder.DecodeUint64(&dataParam)
-			if err != nil {
-				return types.SchedGetparamArgs{}, err
-			}
-			result.Param = uintptr(dataParam)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedGetparamArgs{}, err
+      }
+    case 1:
+      var dataParam uint64
+      err = decoder.DecodeUint64(&dataParam)
+      if err != nil {
+        return types.SchedGetparamArgs{}, err
+      }
+      result.Param = uintptr(dataParam)
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedSetschedulerArgs(decoder *Decoder) (types.SchedSetschedulerArgs, error) {
-	var result types.SchedSetschedulerArgs
-	var err error
+  var result types.SchedSetschedulerArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedSetschedulerArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedSetschedulerArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedSetschedulerArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedSetschedulerArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedSetschedulerArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Policy)
-			if err != nil {
-				return types.SchedSetschedulerArgs{}, err
-			}
-		case 2:
-			var dataParam uint64
-			err = decoder.DecodeUint64(&dataParam)
-			if err != nil {
-				return types.SchedSetschedulerArgs{}, err
-			}
-			result.Param = uintptr(dataParam)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedSetschedulerArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Policy)
+      if err != nil {
+        return types.SchedSetschedulerArgs{}, err
+      }
+    case 2:
+      var dataParam uint64
+      err = decoder.DecodeUint64(&dataParam)
+      if err != nil {
+        return types.SchedSetschedulerArgs{}, err
+      }
+      result.Param = uintptr(dataParam)
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedGetschedulerArgs(decoder *Decoder) (types.SchedGetschedulerArgs, error) {
-	var result types.SchedGetschedulerArgs
-	var err error
+  var result types.SchedGetschedulerArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedGetschedulerArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedGetschedulerArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedGetschedulerArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedGetschedulerArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedGetschedulerArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedGetschedulerArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedGetPriorityMaxArgs(decoder *Decoder) (types.SchedGetPriorityMaxArgs, error) {
-	var result types.SchedGetPriorityMaxArgs
-	var err error
+  var result types.SchedGetPriorityMaxArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedGetPriorityMaxArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedGetPriorityMaxArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedGetPriorityMaxArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedGetPriorityMaxArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Policy)
-			if err != nil {
-				return types.SchedGetPriorityMaxArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Policy)
+      if err != nil {
+        return types.SchedGetPriorityMaxArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedGetPriorityMinArgs(decoder *Decoder) (types.SchedGetPriorityMinArgs, error) {
-	var result types.SchedGetPriorityMinArgs
-	var err error
+  var result types.SchedGetPriorityMinArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedGetPriorityMinArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedGetPriorityMinArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedGetPriorityMinArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedGetPriorityMinArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Policy)
-			if err != nil {
-				return types.SchedGetPriorityMinArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Policy)
+      if err != nil {
+        return types.SchedGetPriorityMinArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedRrGetIntervalArgs(decoder *Decoder) (types.SchedRrGetIntervalArgs, error) {
-	var result types.SchedRrGetIntervalArgs
-	var err error
+  var result types.SchedRrGetIntervalArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedRrGetIntervalArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedRrGetIntervalArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedRrGetIntervalArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedRrGetIntervalArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedRrGetIntervalArgs{}, err
-			}
-		case 1:
-			result.Tp, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.SchedRrGetIntervalArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedRrGetIntervalArgs{}, err
+      }
+    case 1:
+      result.Tp, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.SchedRrGetIntervalArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMlockArgs(decoder *Decoder) (types.MlockArgs, error) {
-	var result types.MlockArgs
-	var err error
+  var result types.MlockArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MlockArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MlockArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MlockArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MlockArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MlockArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.MlockArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MlockArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.MlockArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMunlockArgs(decoder *Decoder) (types.MunlockArgs, error) {
-	var result types.MunlockArgs
-	var err error
+  var result types.MunlockArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MunlockArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MunlockArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MunlockArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MunlockArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MunlockArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.MunlockArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MunlockArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.MunlockArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMlockallArgs(decoder *Decoder) (types.MlockallArgs, error) {
-	var result types.MlockallArgs
-	var err error
+  var result types.MlockallArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MlockallArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MlockallArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MlockallArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MlockallArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.MlockallArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.MlockallArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMunlockallArgs(decoder *Decoder) (types.MunlockallArgs, error) {
-	return types.MunlockallArgs{}, nil
+  return types.MunlockallArgs{}, nil
 }
 
 func ParseVhangupArgs(decoder *Decoder) (types.VhangupArgs, error) {
-	return types.VhangupArgs{}, nil
+  return types.VhangupArgs{}, nil
 }
 
 func ParseModifyLdtArgs(decoder *Decoder) (types.ModifyLdtArgs, error) {
-	var result types.ModifyLdtArgs
-	var err error
+  var result types.ModifyLdtArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ModifyLdtArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ModifyLdtArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ModifyLdtArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ModifyLdtArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Func)
-			if err != nil {
-				return types.ModifyLdtArgs{}, err
-			}
-		case 1:
-			var dataPtr uint64
-			err = decoder.DecodeUint64(&dataPtr)
-			if err != nil {
-				return types.ModifyLdtArgs{}, err
-			}
-			result.Ptr = uintptr(dataPtr)
-		case 2:
-			err = decoder.DecodeUint64(&result.Bytecount)
-			if err != nil {
-				return types.ModifyLdtArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Func)
+      if err != nil {
+        return types.ModifyLdtArgs{}, err
+      }
+    case 1:
+      var dataPtr uint64
+      err = decoder.DecodeUint64(&dataPtr)
+      if err != nil {
+        return types.ModifyLdtArgs{}, err
+      }
+      result.Ptr = uintptr(dataPtr)
+    case 2:
+      err = decoder.DecodeUint64(&result.Bytecount)
+      if err != nil {
+        return types.ModifyLdtArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePivotRootArgs(decoder *Decoder) (types.PivotRootArgs, error) {
-	var result types.PivotRootArgs
-	var err error
+  var result types.PivotRootArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PivotRootArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PivotRootArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PivotRootArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PivotRootArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.NewRoot, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.PivotRootArgs{}, err
-			}
-		case 1:
-			result.PutOld, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.PivotRootArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.NewRoot, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.PivotRootArgs{}, err
+      }
+    case 1:
+      result.PutOld, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.PivotRootArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSysctlArgs(decoder *Decoder) (types.SysctlArgs, error) {
-	var result types.SysctlArgs
-	var err error
+  var result types.SysctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SysctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SysctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SysctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SysctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataArgs uint64
-			err = decoder.DecodeUint64(&dataArgs)
-			if err != nil {
-				return types.SysctlArgs{}, err
-			}
-			result.Args = uintptr(dataArgs)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataArgs uint64
+      err = decoder.DecodeUint64(&dataArgs)
+      if err != nil {
+        return types.SysctlArgs{}, err
+      }
+      result.Args = uintptr(dataArgs)
+    }
+  }
+  return result, nil
 }
 
 func ParsePrctlArgs(decoder *Decoder) (types.PrctlArgs, error) {
-	var result types.PrctlArgs
-	var err error
+  var result types.PrctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PrctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PrctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PrctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PrctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Option)
-			if err != nil {
-				return types.PrctlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Arg2)
-			if err != nil {
-				return types.PrctlArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Arg3)
-			if err != nil {
-				return types.PrctlArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Arg4)
-			if err != nil {
-				return types.PrctlArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Arg5)
-			if err != nil {
-				return types.PrctlArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Option)
+      if err != nil {
+        return types.PrctlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Arg2)
+      if err != nil {
+        return types.PrctlArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Arg3)
+      if err != nil {
+        return types.PrctlArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Arg4)
+      if err != nil {
+        return types.PrctlArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Arg5)
+      if err != nil {
+        return types.PrctlArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseArchPrctlArgs(decoder *Decoder) (types.ArchPrctlArgs, error) {
-	var result types.ArchPrctlArgs
-	var err error
+  var result types.ArchPrctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ArchPrctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ArchPrctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ArchPrctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ArchPrctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Option)
-			if err != nil {
-				return types.ArchPrctlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Addr)
-			if err != nil {
-				return types.ArchPrctlArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Option)
+      if err != nil {
+        return types.ArchPrctlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Addr)
+      if err != nil {
+        return types.ArchPrctlArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseAdjtimexArgs(decoder *Decoder) (types.AdjtimexArgs, error) {
-	var result types.AdjtimexArgs
-	var err error
+  var result types.AdjtimexArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.AdjtimexArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.AdjtimexArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.AdjtimexArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.AdjtimexArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.AdjtimexArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.AdjtimexArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetrlimitArgs(decoder *Decoder) (types.SetrlimitArgs, error) {
-	var result types.SetrlimitArgs
-	var err error
+  var result types.SetrlimitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetrlimitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetrlimitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetrlimitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetrlimitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Resource)
-			if err != nil {
-				return types.SetrlimitArgs{}, err
-			}
-		case 1:
-			var dataRlim uint64
-			err = decoder.DecodeUint64(&dataRlim)
-			if err != nil {
-				return types.SetrlimitArgs{}, err
-			}
-			result.Rlim = uintptr(dataRlim)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Resource)
+      if err != nil {
+        return types.SetrlimitArgs{}, err
+      }
+    case 1:
+      var dataRlim uint64
+      err = decoder.DecodeUint64(&dataRlim)
+      if err != nil {
+        return types.SetrlimitArgs{}, err
+      }
+      result.Rlim = uintptr(dataRlim)
+    }
+  }
+  return result, nil
 }
 
 func ParseChrootArgs(decoder *Decoder) (types.ChrootArgs, error) {
-	var result types.ChrootArgs
-	var err error
+  var result types.ChrootArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ChrootArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ChrootArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ChrootArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ChrootArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ChrootArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ChrootArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSyncArgs(decoder *Decoder) (types.SyncArgs, error) {
-	return types.SyncArgs{}, nil
+  return types.SyncArgs{}, nil
 }
 
 func ParseAcctArgs(decoder *Decoder) (types.AcctArgs, error) {
-	var result types.AcctArgs
-	var err error
+  var result types.AcctArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.AcctArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.AcctArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.AcctArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.AcctArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Filename, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.AcctArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Filename, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.AcctArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSettimeofdayArgs(decoder *Decoder) (types.SettimeofdayArgs, error) {
-	var result types.SettimeofdayArgs
-	var err error
+  var result types.SettimeofdayArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SettimeofdayArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SettimeofdayArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SettimeofdayArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SettimeofdayArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataTv uint64
-			err = decoder.DecodeUint64(&dataTv)
-			if err != nil {
-				return types.SettimeofdayArgs{}, err
-			}
-			result.Tv = uintptr(dataTv)
-		case 1:
-			var dataTz uint64
-			err = decoder.DecodeUint64(&dataTz)
-			if err != nil {
-				return types.SettimeofdayArgs{}, err
-			}
-			result.Tz = uintptr(dataTz)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataTv uint64
+      err = decoder.DecodeUint64(&dataTv)
+      if err != nil {
+        return types.SettimeofdayArgs{}, err
+      }
+      result.Tv = uintptr(dataTv)
+    case 1:
+      var dataTz uint64
+      err = decoder.DecodeUint64(&dataTz)
+      if err != nil {
+        return types.SettimeofdayArgs{}, err
+      }
+      result.Tz = uintptr(dataTz)
+    }
+  }
+  return result, nil
 }
 
 func ParseMountArgs(decoder *Decoder) (types.MountArgs, error) {
-	var result types.MountArgs
-	var err error
+  var result types.MountArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MountArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MountArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MountArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MountArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Source, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MountArgs{}, err
-			}
-		case 1:
-			result.Target, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MountArgs{}, err
-			}
-		case 2:
-			result.Filesystemtype, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MountArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Mountflags)
-			if err != nil {
-				return types.MountArgs{}, err
-			}
-		case 4:
-			var dataData uint64
-			err = decoder.DecodeUint64(&dataData)
-			if err != nil {
-				return types.MountArgs{}, err
-			}
-			result.Data = uintptr(dataData)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Source, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MountArgs{}, err
+      }
+    case 1:
+      result.Target, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MountArgs{}, err
+      }
+    case 2:
+      result.Filesystemtype, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MountArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Mountflags)
+      if err != nil {
+        return types.MountArgs{}, err
+      }
+    case 4:
+      var dataData uint64
+      err = decoder.DecodeUint64(&dataData)
+      if err != nil {
+        return types.MountArgs{}, err
+      }
+      result.Data = uintptr(dataData)
+    }
+  }
+  return result, nil
 }
 
 func ParseUmount2Args(decoder *Decoder) (types.Umount2Args, error) {
-	var result types.Umount2Args
-	var err error
+  var result types.Umount2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Umount2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Umount2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Umount2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Umount2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Target, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Umount2Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Umount2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Target, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Umount2Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Umount2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSwaponArgs(decoder *Decoder) (types.SwaponArgs, error) {
-	var result types.SwaponArgs
-	var err error
+  var result types.SwaponArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SwaponArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SwaponArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SwaponArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SwaponArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SwaponArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Swapflags)
-			if err != nil {
-				return types.SwaponArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SwaponArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Swapflags)
+      if err != nil {
+        return types.SwaponArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSwapoffArgs(decoder *Decoder) (types.SwapoffArgs, error) {
-	var result types.SwapoffArgs
-	var err error
+  var result types.SwapoffArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SwapoffArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SwapoffArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SwapoffArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SwapoffArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SwapoffArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SwapoffArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRebootArgs(decoder *Decoder) (types.RebootArgs, error) {
-	var result types.RebootArgs
-	var err error
+  var result types.RebootArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RebootArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RebootArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RebootArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RebootArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Magic)
-			if err != nil {
-				return types.RebootArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Magic2)
-			if err != nil {
-				return types.RebootArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.RebootArgs{}, err
-			}
-		case 3:
-			var dataArg uint64
-			err = decoder.DecodeUint64(&dataArg)
-			if err != nil {
-				return types.RebootArgs{}, err
-			}
-			result.Arg = uintptr(dataArg)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Magic)
+      if err != nil {
+        return types.RebootArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Magic2)
+      if err != nil {
+        return types.RebootArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.RebootArgs{}, err
+      }
+    case 3:
+      var dataArg uint64
+      err = decoder.DecodeUint64(&dataArg)
+      if err != nil {
+        return types.RebootArgs{}, err
+      }
+      result.Arg = uintptr(dataArg)
+    }
+  }
+  return result, nil
 }
 
 func ParseSethostnameArgs(decoder *Decoder) (types.SethostnameArgs, error) {
-	var result types.SethostnameArgs
-	var err error
+  var result types.SethostnameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SethostnameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SethostnameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SethostnameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SethostnameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SethostnameArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.SethostnameArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SethostnameArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.SethostnameArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetdomainnameArgs(decoder *Decoder) (types.SetdomainnameArgs, error) {
-	var result types.SetdomainnameArgs
-	var err error
+  var result types.SetdomainnameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetdomainnameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetdomainnameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetdomainnameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetdomainnameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SetdomainnameArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.SetdomainnameArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SetdomainnameArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.SetdomainnameArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseIoplArgs(decoder *Decoder) (types.IoplArgs, error) {
-	var result types.IoplArgs
-	var err error
+  var result types.IoplArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoplArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoplArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoplArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoplArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Level)
-			if err != nil {
-				return types.IoplArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Level)
+      if err != nil {
+        return types.IoplArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseIopermArgs(decoder *Decoder) (types.IopermArgs, error) {
-	var result types.IopermArgs
-	var err error
+  var result types.IopermArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IopermArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IopermArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IopermArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IopermArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.From)
-			if err != nil {
-				return types.IopermArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Num)
-			if err != nil {
-				return types.IopermArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.TurnOn)
-			if err != nil {
-				return types.IopermArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.From)
+      if err != nil {
+        return types.IopermArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Num)
+      if err != nil {
+        return types.IopermArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.TurnOn)
+      if err != nil {
+        return types.IopermArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCreateModuleArgs(decoder *Decoder) (types.CreateModuleArgs, error) {
-	return types.CreateModuleArgs{}, nil
+  return types.CreateModuleArgs{}, nil
 }
 
 func ParseInitModuleArgs(decoder *Decoder) (types.InitModuleArgs, error) {
-	var result types.InitModuleArgs
-	var err error
+  var result types.InitModuleArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.InitModuleArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.InitModuleArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.InitModuleArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.InitModuleArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataModuleImage uint64
-			err = decoder.DecodeUint64(&dataModuleImage)
-			if err != nil {
-				return types.InitModuleArgs{}, err
-			}
-			result.ModuleImage = uintptr(dataModuleImage)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.InitModuleArgs{}, err
-			}
-		case 2:
-			result.ParamValues, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.InitModuleArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataModuleImage uint64
+      err = decoder.DecodeUint64(&dataModuleImage)
+      if err != nil {
+        return types.InitModuleArgs{}, err
+      }
+      result.ModuleImage = uintptr(dataModuleImage)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.InitModuleArgs{}, err
+      }
+    case 2:
+      result.ParamValues, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.InitModuleArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDeleteModuleArgs(decoder *Decoder) (types.DeleteModuleArgs, error) {
-	var result types.DeleteModuleArgs
-	var err error
+  var result types.DeleteModuleArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DeleteModuleArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DeleteModuleArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DeleteModuleArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DeleteModuleArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DeleteModuleArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.DeleteModuleArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DeleteModuleArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.DeleteModuleArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetKernelSymsArgs(decoder *Decoder) (types.GetKernelSymsArgs, error) {
-	return types.GetKernelSymsArgs{}, nil
+  return types.GetKernelSymsArgs{}, nil
 }
 
 func ParseQueryModuleArgs(decoder *Decoder) (types.QueryModuleArgs, error) {
-	return types.QueryModuleArgs{}, nil
+  return types.QueryModuleArgs{}, nil
 }
 
 func ParseQuotactlArgs(decoder *Decoder) (types.QuotactlArgs, error) {
-	var result types.QuotactlArgs
-	var err error
+  var result types.QuotactlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.QuotactlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.QuotactlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.QuotactlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.QuotactlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.QuotactlArgs{}, err
-			}
-		case 1:
-			result.Special, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.QuotactlArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Id)
-			if err != nil {
-				return types.QuotactlArgs{}, err
-			}
-		case 3:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.QuotactlArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.QuotactlArgs{}, err
+      }
+    case 1:
+      result.Special, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.QuotactlArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Id)
+      if err != nil {
+        return types.QuotactlArgs{}, err
+      }
+    case 3:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.QuotactlArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    }
+  }
+  return result, nil
 }
 
 func ParseNfsservctlArgs(decoder *Decoder) (types.NfsservctlArgs, error) {
-	return types.NfsservctlArgs{}, nil
+  return types.NfsservctlArgs{}, nil
 }
 
 func ParseGetpmsgArgs(decoder *Decoder) (types.GetpmsgArgs, error) {
-	return types.GetpmsgArgs{}, nil
+  return types.GetpmsgArgs{}, nil
 }
 
 func ParsePutpmsgArgs(decoder *Decoder) (types.PutpmsgArgs, error) {
-	return types.PutpmsgArgs{}, nil
+  return types.PutpmsgArgs{}, nil
 }
 
 func ParseAfsArgs(decoder *Decoder) (types.AfsArgs, error) {
-	return types.AfsArgs{}, nil
+  return types.AfsArgs{}, nil
 }
 
 func ParseTuxcallArgs(decoder *Decoder) (types.TuxcallArgs, error) {
-	return types.TuxcallArgs{}, nil
+  return types.TuxcallArgs{}, nil
 }
 
 func ParseSecurityArgs(decoder *Decoder) (types.SecurityArgs, error) {
-	return types.SecurityArgs{}, nil
+  return types.SecurityArgs{}, nil
 }
 
 func ParseGettidArgs(decoder *Decoder) (types.GettidArgs, error) {
-	return types.GettidArgs{}, nil
+  return types.GettidArgs{}, nil
 }
 
 func ParseReadaheadArgs(decoder *Decoder) (types.ReadaheadArgs, error) {
-	var result types.ReadaheadArgs
-	var err error
+  var result types.ReadaheadArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ReadaheadArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ReadaheadArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ReadaheadArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ReadaheadArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.ReadaheadArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.ReadaheadArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.ReadaheadArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.ReadaheadArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.ReadaheadArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.ReadaheadArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetxattrArgs(decoder *Decoder) (types.SetxattrArgs, error) {
-	var result types.SetxattrArgs
-	var err error
+  var result types.SetxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SetxattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SetxattrArgs{}, err
-			}
-		case 2:
-			var dataValue uint64
-			err = decoder.DecodeUint64(&dataValue)
-			if err != nil {
-				return types.SetxattrArgs{}, err
-			}
-			result.Value = uintptr(dataValue)
-		case 3:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.SetxattrArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SetxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SetxattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SetxattrArgs{}, err
+      }
+    case 2:
+      var dataValue uint64
+      err = decoder.DecodeUint64(&dataValue)
+      if err != nil {
+        return types.SetxattrArgs{}, err
+      }
+      result.Value = uintptr(dataValue)
+    case 3:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.SetxattrArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SetxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLsetxattrArgs(decoder *Decoder) (types.LsetxattrArgs, error) {
-	var result types.LsetxattrArgs
-	var err error
+  var result types.LsetxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LsetxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LsetxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LsetxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LsetxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LsetxattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LsetxattrArgs{}, err
-			}
-		case 2:
-			var dataValue uint64
-			err = decoder.DecodeUint64(&dataValue)
-			if err != nil {
-				return types.LsetxattrArgs{}, err
-			}
-			result.Value = uintptr(dataValue)
-		case 3:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.LsetxattrArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.LsetxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LsetxattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LsetxattrArgs{}, err
+      }
+    case 2:
+      var dataValue uint64
+      err = decoder.DecodeUint64(&dataValue)
+      if err != nil {
+        return types.LsetxattrArgs{}, err
+      }
+      result.Value = uintptr(dataValue)
+    case 3:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.LsetxattrArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.LsetxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFsetxattrArgs(decoder *Decoder) (types.FsetxattrArgs, error) {
-	var result types.FsetxattrArgs
-	var err error
+  var result types.FsetxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FsetxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FsetxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FsetxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FsetxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FsetxattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FsetxattrArgs{}, err
-			}
-		case 2:
-			var dataValue uint64
-			err = decoder.DecodeUint64(&dataValue)
-			if err != nil {
-				return types.FsetxattrArgs{}, err
-			}
-			result.Value = uintptr(dataValue)
-		case 3:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.FsetxattrArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.FsetxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FsetxattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FsetxattrArgs{}, err
+      }
+    case 2:
+      var dataValue uint64
+      err = decoder.DecodeUint64(&dataValue)
+      if err != nil {
+        return types.FsetxattrArgs{}, err
+      }
+      result.Value = uintptr(dataValue)
+    case 3:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.FsetxattrArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.FsetxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetxattrArgs(decoder *Decoder) (types.GetxattrArgs, error) {
-	var result types.GetxattrArgs
-	var err error
+  var result types.GetxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.GetxattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.GetxattrArgs{}, err
-			}
-		case 2:
-			var dataValue uint64
-			err = decoder.DecodeUint64(&dataValue)
-			if err != nil {
-				return types.GetxattrArgs{}, err
-			}
-			result.Value = uintptr(dataValue)
-		case 3:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.GetxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.GetxattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.GetxattrArgs{}, err
+      }
+    case 2:
+      var dataValue uint64
+      err = decoder.DecodeUint64(&dataValue)
+      if err != nil {
+        return types.GetxattrArgs{}, err
+      }
+      result.Value = uintptr(dataValue)
+    case 3:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.GetxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLgetxattrArgs(decoder *Decoder) (types.LgetxattrArgs, error) {
-	var result types.LgetxattrArgs
-	var err error
+  var result types.LgetxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LgetxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LgetxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LgetxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LgetxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LgetxattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LgetxattrArgs{}, err
-			}
-		case 2:
-			var dataValue uint64
-			err = decoder.DecodeUint64(&dataValue)
-			if err != nil {
-				return types.LgetxattrArgs{}, err
-			}
-			result.Value = uintptr(dataValue)
-		case 3:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.LgetxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LgetxattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LgetxattrArgs{}, err
+      }
+    case 2:
+      var dataValue uint64
+      err = decoder.DecodeUint64(&dataValue)
+      if err != nil {
+        return types.LgetxattrArgs{}, err
+      }
+      result.Value = uintptr(dataValue)
+    case 3:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.LgetxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFgetxattrArgs(decoder *Decoder) (types.FgetxattrArgs, error) {
-	var result types.FgetxattrArgs
-	var err error
+  var result types.FgetxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FgetxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FgetxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FgetxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FgetxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FgetxattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FgetxattrArgs{}, err
-			}
-		case 2:
-			var dataValue uint64
-			err = decoder.DecodeUint64(&dataValue)
-			if err != nil {
-				return types.FgetxattrArgs{}, err
-			}
-			result.Value = uintptr(dataValue)
-		case 3:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.FgetxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FgetxattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FgetxattrArgs{}, err
+      }
+    case 2:
+      var dataValue uint64
+      err = decoder.DecodeUint64(&dataValue)
+      if err != nil {
+        return types.FgetxattrArgs{}, err
+      }
+      result.Value = uintptr(dataValue)
+    case 3:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.FgetxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseListxattrArgs(decoder *Decoder) (types.ListxattrArgs, error) {
-	var result types.ListxattrArgs
-	var err error
+  var result types.ListxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ListxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ListxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ListxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ListxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ListxattrArgs{}, err
-			}
-		case 1:
-			result.List, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ListxattrArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.ListxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ListxattrArgs{}, err
+      }
+    case 1:
+      result.List, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ListxattrArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.ListxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLlistxattrArgs(decoder *Decoder) (types.LlistxattrArgs, error) {
-	var result types.LlistxattrArgs
-	var err error
+  var result types.LlistxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LlistxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LlistxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LlistxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LlistxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LlistxattrArgs{}, err
-			}
-		case 1:
-			result.List, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LlistxattrArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.LlistxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LlistxattrArgs{}, err
+      }
+    case 1:
+      result.List, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LlistxattrArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.LlistxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFlistxattrArgs(decoder *Decoder) (types.FlistxattrArgs, error) {
-	var result types.FlistxattrArgs
-	var err error
+  var result types.FlistxattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FlistxattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FlistxattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FlistxattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FlistxattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FlistxattrArgs{}, err
-			}
-		case 1:
-			result.List, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FlistxattrArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.FlistxattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FlistxattrArgs{}, err
+      }
+    case 1:
+      result.List, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FlistxattrArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.FlistxattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRemovexattrArgs(decoder *Decoder) (types.RemovexattrArgs, error) {
-	var result types.RemovexattrArgs
-	var err error
+  var result types.RemovexattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RemovexattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RemovexattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RemovexattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RemovexattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RemovexattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RemovexattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RemovexattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RemovexattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLremovexattrArgs(decoder *Decoder) (types.LremovexattrArgs, error) {
-	var result types.LremovexattrArgs
-	var err error
+  var result types.LremovexattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LremovexattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LremovexattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LremovexattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LremovexattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LremovexattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LremovexattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LremovexattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LremovexattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFremovexattrArgs(decoder *Decoder) (types.FremovexattrArgs, error) {
-	var result types.FremovexattrArgs
-	var err error
+  var result types.FremovexattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FremovexattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FremovexattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FremovexattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FremovexattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FremovexattrArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FremovexattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FremovexattrArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FremovexattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTkillArgs(decoder *Decoder) (types.TkillArgs, error) {
-	var result types.TkillArgs
-	var err error
+  var result types.TkillArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TkillArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TkillArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TkillArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TkillArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Tid)
-			if err != nil {
-				return types.TkillArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.TkillArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Tid)
+      if err != nil {
+        return types.TkillArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.TkillArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTimeArgs(decoder *Decoder) (types.TimeArgs, error) {
-	var result types.TimeArgs
-	var err error
+  var result types.TimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataTloc uint64
-			err = decoder.DecodeUint64(&dataTloc)
-			if err != nil {
-				return types.TimeArgs{}, err
-			}
-			result.Tloc = uintptr(dataTloc)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataTloc uint64
+      err = decoder.DecodeUint64(&dataTloc)
+      if err != nil {
+        return types.TimeArgs{}, err
+      }
+      result.Tloc = uintptr(dataTloc)
+    }
+  }
+  return result, nil
 }
 
 func ParseFutexArgs(decoder *Decoder) (types.FutexArgs, error) {
-	var result types.FutexArgs
-	var err error
+  var result types.FutexArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FutexArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FutexArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FutexArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FutexArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataUaddr uint64
-			err = decoder.DecodeUint64(&dataUaddr)
-			if err != nil {
-				return types.FutexArgs{}, err
-			}
-			result.Uaddr = uintptr(dataUaddr)
-		case 1:
-			err = decoder.DecodeInt32(&result.FutexOp)
-			if err != nil {
-				return types.FutexArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Val)
-			if err != nil {
-				return types.FutexArgs{}, err
-			}
-		case 3:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.FutexArgs{}, err
-			}
-		case 4:
-			var dataUaddr2 uint64
-			err = decoder.DecodeUint64(&dataUaddr2)
-			if err != nil {
-				return types.FutexArgs{}, err
-			}
-			result.Uaddr2 = uintptr(dataUaddr2)
-		case 5:
-			err = decoder.DecodeInt32(&result.Val3)
-			if err != nil {
-				return types.FutexArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataUaddr uint64
+      err = decoder.DecodeUint64(&dataUaddr)
+      if err != nil {
+        return types.FutexArgs{}, err
+      }
+      result.Uaddr = uintptr(dataUaddr)
+    case 1:
+      err = decoder.DecodeInt32(&result.FutexOp)
+      if err != nil {
+        return types.FutexArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Val)
+      if err != nil {
+        return types.FutexArgs{}, err
+      }
+    case 3:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.FutexArgs{}, err
+      }
+    case 4:
+      var dataUaddr2 uint64
+      err = decoder.DecodeUint64(&dataUaddr2)
+      if err != nil {
+        return types.FutexArgs{}, err
+      }
+      result.Uaddr2 = uintptr(dataUaddr2)
+    case 5:
+      err = decoder.DecodeInt32(&result.Val3)
+      if err != nil {
+        return types.FutexArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedSetaffinityArgs(decoder *Decoder) (types.SchedSetaffinityArgs, error) {
-	var result types.SchedSetaffinityArgs
-	var err error
+  var result types.SchedSetaffinityArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedSetaffinityArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedSetaffinityArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedSetaffinityArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedSetaffinityArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedSetaffinityArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Cpusetsize)
-			if err != nil {
-				return types.SchedSetaffinityArgs{}, err
-			}
-		case 2:
-			var dataMask uint64
-			err = decoder.DecodeUint64(&dataMask)
-			if err != nil {
-				return types.SchedSetaffinityArgs{}, err
-			}
-			result.Mask = uintptr(dataMask)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedSetaffinityArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Cpusetsize)
+      if err != nil {
+        return types.SchedSetaffinityArgs{}, err
+      }
+    case 2:
+      var dataMask uint64
+      err = decoder.DecodeUint64(&dataMask)
+      if err != nil {
+        return types.SchedSetaffinityArgs{}, err
+      }
+      result.Mask = uintptr(dataMask)
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedGetaffinityArgs(decoder *Decoder) (types.SchedGetaffinityArgs, error) {
-	var result types.SchedGetaffinityArgs
-	var err error
+  var result types.SchedGetaffinityArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedGetaffinityArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedGetaffinityArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedGetaffinityArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedGetaffinityArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedGetaffinityArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Cpusetsize)
-			if err != nil {
-				return types.SchedGetaffinityArgs{}, err
-			}
-		case 2:
-			var dataMask uint64
-			err = decoder.DecodeUint64(&dataMask)
-			if err != nil {
-				return types.SchedGetaffinityArgs{}, err
-			}
-			result.Mask = uintptr(dataMask)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedGetaffinityArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Cpusetsize)
+      if err != nil {
+        return types.SchedGetaffinityArgs{}, err
+      }
+    case 2:
+      var dataMask uint64
+      err = decoder.DecodeUint64(&dataMask)
+      if err != nil {
+        return types.SchedGetaffinityArgs{}, err
+      }
+      result.Mask = uintptr(dataMask)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetThreadAreaArgs(decoder *Decoder) (types.SetThreadAreaArgs, error) {
-	var result types.SetThreadAreaArgs
-	var err error
+  var result types.SetThreadAreaArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetThreadAreaArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetThreadAreaArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetThreadAreaArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetThreadAreaArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataUInfo uint64
-			err = decoder.DecodeUint64(&dataUInfo)
-			if err != nil {
-				return types.SetThreadAreaArgs{}, err
-			}
-			result.UInfo = uintptr(dataUInfo)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataUInfo uint64
+      err = decoder.DecodeUint64(&dataUInfo)
+      if err != nil {
+        return types.SetThreadAreaArgs{}, err
+      }
+      result.UInfo = uintptr(dataUInfo)
+    }
+  }
+  return result, nil
 }
 
 func ParseIoSetupArgs(decoder *Decoder) (types.IoSetupArgs, error) {
-	var result types.IoSetupArgs
-	var err error
+  var result types.IoSetupArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoSetupArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoSetupArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoSetupArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoSetupArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.NrEvents)
-			if err != nil {
-				return types.IoSetupArgs{}, err
-			}
-		case 1:
-			var dataCtxIdp uint64
-			err = decoder.DecodeUint64(&dataCtxIdp)
-			if err != nil {
-				return types.IoSetupArgs{}, err
-			}
-			result.CtxIdp = uintptr(dataCtxIdp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.NrEvents)
+      if err != nil {
+        return types.IoSetupArgs{}, err
+      }
+    case 1:
+      var dataCtxIdp uint64
+      err = decoder.DecodeUint64(&dataCtxIdp)
+      if err != nil {
+        return types.IoSetupArgs{}, err
+      }
+      result.CtxIdp = uintptr(dataCtxIdp)
+    }
+  }
+  return result, nil
 }
 
 func ParseIoDestroyArgs(decoder *Decoder) (types.IoDestroyArgs, error) {
-	var result types.IoDestroyArgs
-	var err error
+  var result types.IoDestroyArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoDestroyArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoDestroyArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoDestroyArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoDestroyArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataCtxId uint64
-			err = decoder.DecodeUint64(&dataCtxId)
-			if err != nil {
-				return types.IoDestroyArgs{}, err
-			}
-			result.CtxId = uintptr(dataCtxId)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataCtxId uint64
+      err = decoder.DecodeUint64(&dataCtxId)
+      if err != nil {
+        return types.IoDestroyArgs{}, err
+      }
+      result.CtxId = uintptr(dataCtxId)
+    }
+  }
+  return result, nil
 }
 
 func ParseIoGeteventsArgs(decoder *Decoder) (types.IoGeteventsArgs, error) {
-	var result types.IoGeteventsArgs
-	var err error
+  var result types.IoGeteventsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoGeteventsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoGeteventsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoGeteventsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoGeteventsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataCtxId uint64
-			err = decoder.DecodeUint64(&dataCtxId)
-			if err != nil {
-				return types.IoGeteventsArgs{}, err
-			}
-			result.CtxId = uintptr(dataCtxId)
-		case 1:
-			err = decoder.DecodeInt64(&result.MinNr)
-			if err != nil {
-				return types.IoGeteventsArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt64(&result.Nr)
-			if err != nil {
-				return types.IoGeteventsArgs{}, err
-			}
-		case 3:
-			var dataEvents uint64
-			err = decoder.DecodeUint64(&dataEvents)
-			if err != nil {
-				return types.IoGeteventsArgs{}, err
-			}
-			result.Events = uintptr(dataEvents)
-		case 4:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.IoGeteventsArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataCtxId uint64
+      err = decoder.DecodeUint64(&dataCtxId)
+      if err != nil {
+        return types.IoGeteventsArgs{}, err
+      }
+      result.CtxId = uintptr(dataCtxId)
+    case 1:
+      err = decoder.DecodeInt64(&result.MinNr)
+      if err != nil {
+        return types.IoGeteventsArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt64(&result.Nr)
+      if err != nil {
+        return types.IoGeteventsArgs{}, err
+      }
+    case 3:
+      var dataEvents uint64
+      err = decoder.DecodeUint64(&dataEvents)
+      if err != nil {
+        return types.IoGeteventsArgs{}, err
+      }
+      result.Events = uintptr(dataEvents)
+    case 4:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.IoGeteventsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseIoSubmitArgs(decoder *Decoder) (types.IoSubmitArgs, error) {
-	var result types.IoSubmitArgs
-	var err error
+  var result types.IoSubmitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoSubmitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoSubmitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoSubmitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoSubmitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataCtxId uint64
-			err = decoder.DecodeUint64(&dataCtxId)
-			if err != nil {
-				return types.IoSubmitArgs{}, err
-			}
-			result.CtxId = uintptr(dataCtxId)
-		case 1:
-			err = decoder.DecodeInt64(&result.Nr)
-			if err != nil {
-				return types.IoSubmitArgs{}, err
-			}
-		case 2:
-			var dataIocbpp uint64
-			err = decoder.DecodeUint64(&dataIocbpp)
-			if err != nil {
-				return types.IoSubmitArgs{}, err
-			}
-			result.Iocbpp = uintptr(dataIocbpp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataCtxId uint64
+      err = decoder.DecodeUint64(&dataCtxId)
+      if err != nil {
+        return types.IoSubmitArgs{}, err
+      }
+      result.CtxId = uintptr(dataCtxId)
+    case 1:
+      err = decoder.DecodeInt64(&result.Nr)
+      if err != nil {
+        return types.IoSubmitArgs{}, err
+      }
+    case 2:
+      var dataIocbpp uint64
+      err = decoder.DecodeUint64(&dataIocbpp)
+      if err != nil {
+        return types.IoSubmitArgs{}, err
+      }
+      result.Iocbpp = uintptr(dataIocbpp)
+    }
+  }
+  return result, nil
 }
 
 func ParseIoCancelArgs(decoder *Decoder) (types.IoCancelArgs, error) {
-	var result types.IoCancelArgs
-	var err error
+  var result types.IoCancelArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoCancelArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoCancelArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoCancelArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoCancelArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataCtxId uint64
-			err = decoder.DecodeUint64(&dataCtxId)
-			if err != nil {
-				return types.IoCancelArgs{}, err
-			}
-			result.CtxId = uintptr(dataCtxId)
-		case 1:
-			var dataIocb uint64
-			err = decoder.DecodeUint64(&dataIocb)
-			if err != nil {
-				return types.IoCancelArgs{}, err
-			}
-			result.Iocb = uintptr(dataIocb)
-		case 2:
-			var dataResult uint64
-			err = decoder.DecodeUint64(&dataResult)
-			if err != nil {
-				return types.IoCancelArgs{}, err
-			}
-			result.Result = uintptr(dataResult)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataCtxId uint64
+      err = decoder.DecodeUint64(&dataCtxId)
+      if err != nil {
+        return types.IoCancelArgs{}, err
+      }
+      result.CtxId = uintptr(dataCtxId)
+    case 1:
+      var dataIocb uint64
+      err = decoder.DecodeUint64(&dataIocb)
+      if err != nil {
+        return types.IoCancelArgs{}, err
+      }
+      result.Iocb = uintptr(dataIocb)
+    case 2:
+      var dataResult uint64
+      err = decoder.DecodeUint64(&dataResult)
+      if err != nil {
+        return types.IoCancelArgs{}, err
+      }
+      result.Result = uintptr(dataResult)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetThreadAreaArgs(decoder *Decoder) (types.GetThreadAreaArgs, error) {
-	var result types.GetThreadAreaArgs
-	var err error
+  var result types.GetThreadAreaArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetThreadAreaArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetThreadAreaArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetThreadAreaArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetThreadAreaArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataUInfo uint64
-			err = decoder.DecodeUint64(&dataUInfo)
-			if err != nil {
-				return types.GetThreadAreaArgs{}, err
-			}
-			result.UInfo = uintptr(dataUInfo)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataUInfo uint64
+      err = decoder.DecodeUint64(&dataUInfo)
+      if err != nil {
+        return types.GetThreadAreaArgs{}, err
+      }
+      result.UInfo = uintptr(dataUInfo)
+    }
+  }
+  return result, nil
 }
 
 func ParseLookupDcookieArgs(decoder *Decoder) (types.LookupDcookieArgs, error) {
-	var result types.LookupDcookieArgs
-	var err error
+  var result types.LookupDcookieArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LookupDcookieArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LookupDcookieArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LookupDcookieArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LookupDcookieArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Cookie)
-			if err != nil {
-				return types.LookupDcookieArgs{}, err
-			}
-		case 1:
-			result.Buffer, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LookupDcookieArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.LookupDcookieArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Cookie)
+      if err != nil {
+        return types.LookupDcookieArgs{}, err
+      }
+    case 1:
+      result.Buffer, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LookupDcookieArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.LookupDcookieArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEpollCreateArgs(decoder *Decoder) (types.EpollCreateArgs, error) {
-	var result types.EpollCreateArgs
-	var err error
+  var result types.EpollCreateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.EpollCreateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.EpollCreateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.EpollCreateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.EpollCreateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Size)
-			if err != nil {
-				return types.EpollCreateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Size)
+      if err != nil {
+        return types.EpollCreateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEpollCtlOldArgs(decoder *Decoder) (types.EpollCtlOldArgs, error) {
-	return types.EpollCtlOldArgs{}, nil
+  return types.EpollCtlOldArgs{}, nil
 }
 
 func ParseEpollWaitOldArgs(decoder *Decoder) (types.EpollWaitOldArgs, error) {
-	return types.EpollWaitOldArgs{}, nil
+  return types.EpollWaitOldArgs{}, nil
 }
 
 func ParseRemapFilePagesArgs(decoder *Decoder) (types.RemapFilePagesArgs, error) {
-	var result types.RemapFilePagesArgs
-	var err error
+  var result types.RemapFilePagesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RemapFilePagesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RemapFilePagesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RemapFilePagesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RemapFilePagesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.RemapFilePagesArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.RemapFilePagesArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Prot)
-			if err != nil {
-				return types.RemapFilePagesArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Pgoff)
-			if err != nil {
-				return types.RemapFilePagesArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.RemapFilePagesArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.RemapFilePagesArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.RemapFilePagesArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Prot)
+      if err != nil {
+        return types.RemapFilePagesArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Pgoff)
+      if err != nil {
+        return types.RemapFilePagesArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.RemapFilePagesArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetdents64Args(decoder *Decoder) (types.Getdents64Args, error) {
-	var result types.Getdents64Args
-	var err error
+  var result types.Getdents64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Getdents64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Getdents64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Getdents64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Getdents64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Fd)
-			if err != nil {
-				return types.Getdents64Args{}, err
-			}
-		case 1:
-			var dataDirp uint64
-			err = decoder.DecodeUint64(&dataDirp)
-			if err != nil {
-				return types.Getdents64Args{}, err
-			}
-			result.Dirp = uintptr(dataDirp)
-		case 2:
-			err = decoder.DecodeUint32(&result.Count)
-			if err != nil {
-				return types.Getdents64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Fd)
+      if err != nil {
+        return types.Getdents64Args{}, err
+      }
+    case 1:
+      var dataDirp uint64
+      err = decoder.DecodeUint64(&dataDirp)
+      if err != nil {
+        return types.Getdents64Args{}, err
+      }
+      result.Dirp = uintptr(dataDirp)
+    case 2:
+      err = decoder.DecodeUint32(&result.Count)
+      if err != nil {
+        return types.Getdents64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetTidAddressArgs(decoder *Decoder) (types.SetTidAddressArgs, error) {
-	var result types.SetTidAddressArgs
-	var err error
+  var result types.SetTidAddressArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetTidAddressArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetTidAddressArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetTidAddressArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetTidAddressArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataTidptr uint64
-			err = decoder.DecodeUint64(&dataTidptr)
-			if err != nil {
-				return types.SetTidAddressArgs{}, err
-			}
-			result.Tidptr = uintptr(dataTidptr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataTidptr uint64
+      err = decoder.DecodeUint64(&dataTidptr)
+      if err != nil {
+        return types.SetTidAddressArgs{}, err
+      }
+      result.Tidptr = uintptr(dataTidptr)
+    }
+  }
+  return result, nil
 }
 
 func ParseRestartSyscallArgs(decoder *Decoder) (types.RestartSyscallArgs, error) {
-	return types.RestartSyscallArgs{}, nil
+  return types.RestartSyscallArgs{}, nil
 }
 
 func ParseSemtimedopArgs(decoder *Decoder) (types.SemtimedopArgs, error) {
-	var result types.SemtimedopArgs
-	var err error
+  var result types.SemtimedopArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SemtimedopArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SemtimedopArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SemtimedopArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SemtimedopArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Semid)
-			if err != nil {
-				return types.SemtimedopArgs{}, err
-			}
-		case 1:
-			var dataSops uint64
-			err = decoder.DecodeUint64(&dataSops)
-			if err != nil {
-				return types.SemtimedopArgs{}, err
-			}
-			result.Sops = uintptr(dataSops)
-		case 2:
-			err = decoder.DecodeUint64(&result.Nsops)
-			if err != nil {
-				return types.SemtimedopArgs{}, err
-			}
-		case 3:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.SemtimedopArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Semid)
+      if err != nil {
+        return types.SemtimedopArgs{}, err
+      }
+    case 1:
+      var dataSops uint64
+      err = decoder.DecodeUint64(&dataSops)
+      if err != nil {
+        return types.SemtimedopArgs{}, err
+      }
+      result.Sops = uintptr(dataSops)
+    case 2:
+      err = decoder.DecodeUint64(&result.Nsops)
+      if err != nil {
+        return types.SemtimedopArgs{}, err
+      }
+    case 3:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.SemtimedopArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFadvise64Args(decoder *Decoder) (types.Fadvise64Args, error) {
-	var result types.Fadvise64Args
-	var err error
+  var result types.Fadvise64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Fadvise64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Fadvise64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Fadvise64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Fadvise64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Fadvise64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.Fadvise64Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.Fadvise64Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Advice)
-			if err != nil {
-				return types.Fadvise64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Fadvise64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.Fadvise64Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.Fadvise64Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Advice)
+      if err != nil {
+        return types.Fadvise64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerCreateArgs(decoder *Decoder) (types.TimerCreateArgs, error) {
-	var result types.TimerCreateArgs
-	var err error
+  var result types.TimerCreateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerCreateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerCreateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerCreateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerCreateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Clockid)
-			if err != nil {
-				return types.TimerCreateArgs{}, err
-			}
-		case 1:
-			var dataSevp uint64
-			err = decoder.DecodeUint64(&dataSevp)
-			if err != nil {
-				return types.TimerCreateArgs{}, err
-			}
-			result.Sevp = uintptr(dataSevp)
-		case 2:
-			var dataTimerId uint64
-			err = decoder.DecodeUint64(&dataTimerId)
-			if err != nil {
-				return types.TimerCreateArgs{}, err
-			}
-			result.TimerId = uintptr(dataTimerId)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Clockid)
+      if err != nil {
+        return types.TimerCreateArgs{}, err
+      }
+    case 1:
+      var dataSevp uint64
+      err = decoder.DecodeUint64(&dataSevp)
+      if err != nil {
+        return types.TimerCreateArgs{}, err
+      }
+      result.Sevp = uintptr(dataSevp)
+    case 2:
+      var dataTimerId uint64
+      err = decoder.DecodeUint64(&dataTimerId)
+      if err != nil {
+        return types.TimerCreateArgs{}, err
+      }
+      result.TimerId = uintptr(dataTimerId)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerSettimeArgs(decoder *Decoder) (types.TimerSettimeArgs, error) {
-	var result types.TimerSettimeArgs
-	var err error
+  var result types.TimerSettimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerSettimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerSettimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerSettimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerSettimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.TimerId)
-			if err != nil {
-				return types.TimerSettimeArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.TimerSettimeArgs{}, err
-			}
-		case 2:
-			var dataNewValue uint64
-			err = decoder.DecodeUint64(&dataNewValue)
-			if err != nil {
-				return types.TimerSettimeArgs{}, err
-			}
-			result.NewValue = uintptr(dataNewValue)
-		case 3:
-			var dataOldValue uint64
-			err = decoder.DecodeUint64(&dataOldValue)
-			if err != nil {
-				return types.TimerSettimeArgs{}, err
-			}
-			result.OldValue = uintptr(dataOldValue)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.TimerId)
+      if err != nil {
+        return types.TimerSettimeArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.TimerSettimeArgs{}, err
+      }
+    case 2:
+      var dataNewValue uint64
+      err = decoder.DecodeUint64(&dataNewValue)
+      if err != nil {
+        return types.TimerSettimeArgs{}, err
+      }
+      result.NewValue = uintptr(dataNewValue)
+    case 3:
+      var dataOldValue uint64
+      err = decoder.DecodeUint64(&dataOldValue)
+      if err != nil {
+        return types.TimerSettimeArgs{}, err
+      }
+      result.OldValue = uintptr(dataOldValue)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerGettimeArgs(decoder *Decoder) (types.TimerGettimeArgs, error) {
-	var result types.TimerGettimeArgs
-	var err error
+  var result types.TimerGettimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerGettimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerGettimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerGettimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerGettimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.TimerId)
-			if err != nil {
-				return types.TimerGettimeArgs{}, err
-			}
-		case 1:
-			var dataCurrValue uint64
-			err = decoder.DecodeUint64(&dataCurrValue)
-			if err != nil {
-				return types.TimerGettimeArgs{}, err
-			}
-			result.CurrValue = uintptr(dataCurrValue)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.TimerId)
+      if err != nil {
+        return types.TimerGettimeArgs{}, err
+      }
+    case 1:
+      var dataCurrValue uint64
+      err = decoder.DecodeUint64(&dataCurrValue)
+      if err != nil {
+        return types.TimerGettimeArgs{}, err
+      }
+      result.CurrValue = uintptr(dataCurrValue)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerGetoverrunArgs(decoder *Decoder) (types.TimerGetoverrunArgs, error) {
-	var result types.TimerGetoverrunArgs
-	var err error
+  var result types.TimerGetoverrunArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerGetoverrunArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerGetoverrunArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerGetoverrunArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerGetoverrunArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.TimerId)
-			if err != nil {
-				return types.TimerGetoverrunArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.TimerId)
+      if err != nil {
+        return types.TimerGetoverrunArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerDeleteArgs(decoder *Decoder) (types.TimerDeleteArgs, error) {
-	var result types.TimerDeleteArgs
-	var err error
+  var result types.TimerDeleteArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerDeleteArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerDeleteArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerDeleteArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerDeleteArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.TimerId)
-			if err != nil {
-				return types.TimerDeleteArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.TimerId)
+      if err != nil {
+        return types.TimerDeleteArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseClockSettimeArgs(decoder *Decoder) (types.ClockSettimeArgs, error) {
-	var result types.ClockSettimeArgs
-	var err error
+  var result types.ClockSettimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockSettimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockSettimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockSettimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockSettimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Clockid)
-			if err != nil {
-				return types.ClockSettimeArgs{}, err
-			}
-		case 1:
-			result.Tp, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.ClockSettimeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Clockid)
+      if err != nil {
+        return types.ClockSettimeArgs{}, err
+      }
+    case 1:
+      result.Tp, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.ClockSettimeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseClockGettimeArgs(decoder *Decoder) (types.ClockGettimeArgs, error) {
-	var result types.ClockGettimeArgs
-	var err error
+  var result types.ClockGettimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockGettimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockGettimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockGettimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockGettimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Clockid)
-			if err != nil {
-				return types.ClockGettimeArgs{}, err
-			}
-		case 1:
-			result.Tp, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.ClockGettimeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Clockid)
+      if err != nil {
+        return types.ClockGettimeArgs{}, err
+      }
+    case 1:
+      result.Tp, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.ClockGettimeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseClockGetresArgs(decoder *Decoder) (types.ClockGetresArgs, error) {
-	var result types.ClockGetresArgs
-	var err error
+  var result types.ClockGetresArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockGetresArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockGetresArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockGetresArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockGetresArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Clockid)
-			if err != nil {
-				return types.ClockGetresArgs{}, err
-			}
-		case 1:
-			result.Res, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.ClockGetresArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Clockid)
+      if err != nil {
+        return types.ClockGetresArgs{}, err
+      }
+    case 1:
+      result.Res, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.ClockGetresArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseClockNanosleepArgs(decoder *Decoder) (types.ClockNanosleepArgs, error) {
-	var result types.ClockNanosleepArgs
-	var err error
+  var result types.ClockNanosleepArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockNanosleepArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockNanosleepArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockNanosleepArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockNanosleepArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Clockid)
-			if err != nil {
-				return types.ClockNanosleepArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.ClockNanosleepArgs{}, err
-			}
-		case 2:
-			result.Request, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.ClockNanosleepArgs{}, err
-			}
-		case 3:
-			result.Remain, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.ClockNanosleepArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Clockid)
+      if err != nil {
+        return types.ClockNanosleepArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.ClockNanosleepArgs{}, err
+      }
+    case 2:
+      result.Request, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.ClockNanosleepArgs{}, err
+      }
+    case 3:
+      result.Remain, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.ClockNanosleepArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseExitGroupArgs(decoder *Decoder) (types.ExitGroupArgs, error) {
-	var result types.ExitGroupArgs
-	var err error
+  var result types.ExitGroupArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ExitGroupArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ExitGroupArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ExitGroupArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ExitGroupArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Status)
-			if err != nil {
-				return types.ExitGroupArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Status)
+      if err != nil {
+        return types.ExitGroupArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEpollWaitArgs(decoder *Decoder) (types.EpollWaitArgs, error) {
-	var result types.EpollWaitArgs
-	var err error
+  var result types.EpollWaitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.EpollWaitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.EpollWaitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.EpollWaitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.EpollWaitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Epfd)
-			if err != nil {
-				return types.EpollWaitArgs{}, err
-			}
-		case 1:
-			var dataEvents uint64
-			err = decoder.DecodeUint64(&dataEvents)
-			if err != nil {
-				return types.EpollWaitArgs{}, err
-			}
-			result.Events = uintptr(dataEvents)
-		case 2:
-			err = decoder.DecodeInt32(&result.Maxevents)
-			if err != nil {
-				return types.EpollWaitArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Timeout)
-			if err != nil {
-				return types.EpollWaitArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Epfd)
+      if err != nil {
+        return types.EpollWaitArgs{}, err
+      }
+    case 1:
+      var dataEvents uint64
+      err = decoder.DecodeUint64(&dataEvents)
+      if err != nil {
+        return types.EpollWaitArgs{}, err
+      }
+      result.Events = uintptr(dataEvents)
+    case 2:
+      err = decoder.DecodeInt32(&result.Maxevents)
+      if err != nil {
+        return types.EpollWaitArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Timeout)
+      if err != nil {
+        return types.EpollWaitArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEpollCtlArgs(decoder *Decoder) (types.EpollCtlArgs, error) {
-	var result types.EpollCtlArgs
-	var err error
+  var result types.EpollCtlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.EpollCtlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.EpollCtlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.EpollCtlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.EpollCtlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Epfd)
-			if err != nil {
-				return types.EpollCtlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Op)
-			if err != nil {
-				return types.EpollCtlArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.EpollCtlArgs{}, err
-			}
-		case 3:
-			var dataEvent uint64
-			err = decoder.DecodeUint64(&dataEvent)
-			if err != nil {
-				return types.EpollCtlArgs{}, err
-			}
-			result.Event = uintptr(dataEvent)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Epfd)
+      if err != nil {
+        return types.EpollCtlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Op)
+      if err != nil {
+        return types.EpollCtlArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.EpollCtlArgs{}, err
+      }
+    case 3:
+      var dataEvent uint64
+      err = decoder.DecodeUint64(&dataEvent)
+      if err != nil {
+        return types.EpollCtlArgs{}, err
+      }
+      result.Event = uintptr(dataEvent)
+    }
+  }
+  return result, nil
 }
 
 func ParseTgkillArgs(decoder *Decoder) (types.TgkillArgs, error) {
-	var result types.TgkillArgs
-	var err error
+  var result types.TgkillArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TgkillArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TgkillArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TgkillArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TgkillArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Tgid)
-			if err != nil {
-				return types.TgkillArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Tid)
-			if err != nil {
-				return types.TgkillArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.TgkillArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Tgid)
+      if err != nil {
+        return types.TgkillArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Tid)
+      if err != nil {
+        return types.TgkillArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.TgkillArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUtimesArgs(decoder *Decoder) (types.UtimesArgs, error) {
-	var result types.UtimesArgs
-	var err error
+  var result types.UtimesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UtimesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UtimesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UtimesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UtimesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Filename, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UtimesArgs{}, err
-			}
-		case 1:
-			var dataTimes uint64
-			err = decoder.DecodeUint64(&dataTimes)
-			if err != nil {
-				return types.UtimesArgs{}, err
-			}
-			result.Times = uintptr(dataTimes)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Filename, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UtimesArgs{}, err
+      }
+    case 1:
+      var dataTimes uint64
+      err = decoder.DecodeUint64(&dataTimes)
+      if err != nil {
+        return types.UtimesArgs{}, err
+      }
+      result.Times = uintptr(dataTimes)
+    }
+  }
+  return result, nil
 }
 
 func ParseVserverArgs(decoder *Decoder) (types.VserverArgs, error) {
-	return types.VserverArgs{}, nil
+  return types.VserverArgs{}, nil
 }
 
 func ParseMbindArgs(decoder *Decoder) (types.MbindArgs, error) {
-	var result types.MbindArgs
-	var err error
+  var result types.MbindArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MbindArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MbindArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MbindArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MbindArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MbindArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.MbindArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Mode)
-			if err != nil {
-				return types.MbindArgs{}, err
-			}
-		case 3:
-			var dataNodemask uint64
-			err = decoder.DecodeUint64(&dataNodemask)
-			if err != nil {
-				return types.MbindArgs{}, err
-			}
-			result.Nodemask = uintptr(dataNodemask)
-		case 4:
-			err = decoder.DecodeUint64(&result.Maxnode)
-			if err != nil {
-				return types.MbindArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.MbindArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MbindArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.MbindArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Mode)
+      if err != nil {
+        return types.MbindArgs{}, err
+      }
+    case 3:
+      var dataNodemask uint64
+      err = decoder.DecodeUint64(&dataNodemask)
+      if err != nil {
+        return types.MbindArgs{}, err
+      }
+      result.Nodemask = uintptr(dataNodemask)
+    case 4:
+      err = decoder.DecodeUint64(&result.Maxnode)
+      if err != nil {
+        return types.MbindArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.MbindArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetMempolicyArgs(decoder *Decoder) (types.SetMempolicyArgs, error) {
-	var result types.SetMempolicyArgs
-	var err error
+  var result types.SetMempolicyArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetMempolicyArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetMempolicyArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetMempolicyArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetMempolicyArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Mode)
-			if err != nil {
-				return types.SetMempolicyArgs{}, err
-			}
-		case 1:
-			var dataNodemask uint64
-			err = decoder.DecodeUint64(&dataNodemask)
-			if err != nil {
-				return types.SetMempolicyArgs{}, err
-			}
-			result.Nodemask = uintptr(dataNodemask)
-		case 2:
-			err = decoder.DecodeUint64(&result.Maxnode)
-			if err != nil {
-				return types.SetMempolicyArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Mode)
+      if err != nil {
+        return types.SetMempolicyArgs{}, err
+      }
+    case 1:
+      var dataNodemask uint64
+      err = decoder.DecodeUint64(&dataNodemask)
+      if err != nil {
+        return types.SetMempolicyArgs{}, err
+      }
+      result.Nodemask = uintptr(dataNodemask)
+    case 2:
+      err = decoder.DecodeUint64(&result.Maxnode)
+      if err != nil {
+        return types.SetMempolicyArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetMempolicyArgs(decoder *Decoder) (types.GetMempolicyArgs, error) {
-	var result types.GetMempolicyArgs
-	var err error
+  var result types.GetMempolicyArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetMempolicyArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetMempolicyArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetMempolicyArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetMempolicyArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataMode uint64
-			err = decoder.DecodeUint64(&dataMode)
-			if err != nil {
-				return types.GetMempolicyArgs{}, err
-			}
-			result.Mode = uintptr(dataMode)
-		case 1:
-			var dataNodemask uint64
-			err = decoder.DecodeUint64(&dataNodemask)
-			if err != nil {
-				return types.GetMempolicyArgs{}, err
-			}
-			result.Nodemask = uintptr(dataNodemask)
-		case 2:
-			err = decoder.DecodeUint64(&result.Maxnode)
-			if err != nil {
-				return types.GetMempolicyArgs{}, err
-			}
-		case 3:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.GetMempolicyArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 4:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.GetMempolicyArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataMode uint64
+      err = decoder.DecodeUint64(&dataMode)
+      if err != nil {
+        return types.GetMempolicyArgs{}, err
+      }
+      result.Mode = uintptr(dataMode)
+    case 1:
+      var dataNodemask uint64
+      err = decoder.DecodeUint64(&dataNodemask)
+      if err != nil {
+        return types.GetMempolicyArgs{}, err
+      }
+      result.Nodemask = uintptr(dataNodemask)
+    case 2:
+      err = decoder.DecodeUint64(&result.Maxnode)
+      if err != nil {
+        return types.GetMempolicyArgs{}, err
+      }
+    case 3:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.GetMempolicyArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 4:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.GetMempolicyArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMqOpenArgs(decoder *Decoder) (types.MqOpenArgs, error) {
-	var result types.MqOpenArgs
-	var err error
+  var result types.MqOpenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqOpenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqOpenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqOpenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqOpenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MqOpenArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Oflag)
-			if err != nil {
-				return types.MqOpenArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.MqOpenArgs{}, err
-			}
-		case 3:
-			var dataAttr uint64
-			err = decoder.DecodeUint64(&dataAttr)
-			if err != nil {
-				return types.MqOpenArgs{}, err
-			}
-			result.Attr = uintptr(dataAttr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MqOpenArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Oflag)
+      if err != nil {
+        return types.MqOpenArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.MqOpenArgs{}, err
+      }
+    case 3:
+      var dataAttr uint64
+      err = decoder.DecodeUint64(&dataAttr)
+      if err != nil {
+        return types.MqOpenArgs{}, err
+      }
+      result.Attr = uintptr(dataAttr)
+    }
+  }
+  return result, nil
 }
 
 func ParseMqUnlinkArgs(decoder *Decoder) (types.MqUnlinkArgs, error) {
-	var result types.MqUnlinkArgs
-	var err error
+  var result types.MqUnlinkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqUnlinkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqUnlinkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqUnlinkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqUnlinkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MqUnlinkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MqUnlinkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMqTimedsendArgs(decoder *Decoder) (types.MqTimedsendArgs, error) {
-	var result types.MqTimedsendArgs
-	var err error
+  var result types.MqTimedsendArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqTimedsendArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqTimedsendArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqTimedsendArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqTimedsendArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Mqdes)
-			if err != nil {
-				return types.MqTimedsendArgs{}, err
-			}
-		case 1:
-			result.MsgPtr, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MqTimedsendArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.MsgLen)
-			if err != nil {
-				return types.MqTimedsendArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.MsgPrio)
-			if err != nil {
-				return types.MqTimedsendArgs{}, err
-			}
-		case 4:
-			result.AbsTimeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.MqTimedsendArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Mqdes)
+      if err != nil {
+        return types.MqTimedsendArgs{}, err
+      }
+    case 1:
+      result.MsgPtr, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MqTimedsendArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.MsgLen)
+      if err != nil {
+        return types.MqTimedsendArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.MsgPrio)
+      if err != nil {
+        return types.MqTimedsendArgs{}, err
+      }
+    case 4:
+      result.AbsTimeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.MqTimedsendArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMqTimedreceiveArgs(decoder *Decoder) (types.MqTimedreceiveArgs, error) {
-	var result types.MqTimedreceiveArgs
-	var err error
+  var result types.MqTimedreceiveArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqTimedreceiveArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqTimedreceiveArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqTimedreceiveArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqTimedreceiveArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Mqdes)
-			if err != nil {
-				return types.MqTimedreceiveArgs{}, err
-			}
-		case 1:
-			result.MsgPtr, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MqTimedreceiveArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.MsgLen)
-			if err != nil {
-				return types.MqTimedreceiveArgs{}, err
-			}
-		case 3:
-			var dataMsgPrio uint64
-			err = decoder.DecodeUint64(&dataMsgPrio)
-			if err != nil {
-				return types.MqTimedreceiveArgs{}, err
-			}
-			result.MsgPrio = uintptr(dataMsgPrio)
-		case 4:
-			result.AbsTimeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.MqTimedreceiveArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Mqdes)
+      if err != nil {
+        return types.MqTimedreceiveArgs{}, err
+      }
+    case 1:
+      result.MsgPtr, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MqTimedreceiveArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.MsgLen)
+      if err != nil {
+        return types.MqTimedreceiveArgs{}, err
+      }
+    case 3:
+      var dataMsgPrio uint64
+      err = decoder.DecodeUint64(&dataMsgPrio)
+      if err != nil {
+        return types.MqTimedreceiveArgs{}, err
+      }
+      result.MsgPrio = uintptr(dataMsgPrio)
+    case 4:
+      result.AbsTimeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.MqTimedreceiveArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMqNotifyArgs(decoder *Decoder) (types.MqNotifyArgs, error) {
-	var result types.MqNotifyArgs
-	var err error
+  var result types.MqNotifyArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqNotifyArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqNotifyArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqNotifyArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqNotifyArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Mqdes)
-			if err != nil {
-				return types.MqNotifyArgs{}, err
-			}
-		case 1:
-			var dataSevp uint64
-			err = decoder.DecodeUint64(&dataSevp)
-			if err != nil {
-				return types.MqNotifyArgs{}, err
-			}
-			result.Sevp = uintptr(dataSevp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Mqdes)
+      if err != nil {
+        return types.MqNotifyArgs{}, err
+      }
+    case 1:
+      var dataSevp uint64
+      err = decoder.DecodeUint64(&dataSevp)
+      if err != nil {
+        return types.MqNotifyArgs{}, err
+      }
+      result.Sevp = uintptr(dataSevp)
+    }
+  }
+  return result, nil
 }
 
 func ParseMqGetsetattrArgs(decoder *Decoder) (types.MqGetsetattrArgs, error) {
-	var result types.MqGetsetattrArgs
-	var err error
+  var result types.MqGetsetattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqGetsetattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqGetsetattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqGetsetattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqGetsetattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Mqdes)
-			if err != nil {
-				return types.MqGetsetattrArgs{}, err
-			}
-		case 1:
-			var dataNewattr uint64
-			err = decoder.DecodeUint64(&dataNewattr)
-			if err != nil {
-				return types.MqGetsetattrArgs{}, err
-			}
-			result.Newattr = uintptr(dataNewattr)
-		case 2:
-			var dataOldattr uint64
-			err = decoder.DecodeUint64(&dataOldattr)
-			if err != nil {
-				return types.MqGetsetattrArgs{}, err
-			}
-			result.Oldattr = uintptr(dataOldattr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Mqdes)
+      if err != nil {
+        return types.MqGetsetattrArgs{}, err
+      }
+    case 1:
+      var dataNewattr uint64
+      err = decoder.DecodeUint64(&dataNewattr)
+      if err != nil {
+        return types.MqGetsetattrArgs{}, err
+      }
+      result.Newattr = uintptr(dataNewattr)
+    case 2:
+      var dataOldattr uint64
+      err = decoder.DecodeUint64(&dataOldattr)
+      if err != nil {
+        return types.MqGetsetattrArgs{}, err
+      }
+      result.Oldattr = uintptr(dataOldattr)
+    }
+  }
+  return result, nil
 }
 
 func ParseKexecLoadArgs(decoder *Decoder) (types.KexecLoadArgs, error) {
-	var result types.KexecLoadArgs
-	var err error
+  var result types.KexecLoadArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KexecLoadArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KexecLoadArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KexecLoadArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KexecLoadArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Entry)
-			if err != nil {
-				return types.KexecLoadArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.NrSegments)
-			if err != nil {
-				return types.KexecLoadArgs{}, err
-			}
-		case 2:
-			var dataSegments uint64
-			err = decoder.DecodeUint64(&dataSegments)
-			if err != nil {
-				return types.KexecLoadArgs{}, err
-			}
-			result.Segments = uintptr(dataSegments)
-		case 3:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.KexecLoadArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Entry)
+      if err != nil {
+        return types.KexecLoadArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.NrSegments)
+      if err != nil {
+        return types.KexecLoadArgs{}, err
+      }
+    case 2:
+      var dataSegments uint64
+      err = decoder.DecodeUint64(&dataSegments)
+      if err != nil {
+        return types.KexecLoadArgs{}, err
+      }
+      result.Segments = uintptr(dataSegments)
+    case 3:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.KexecLoadArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseWaitidArgs(decoder *Decoder) (types.WaitidArgs, error) {
-	var result types.WaitidArgs
-	var err error
+  var result types.WaitidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.WaitidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.WaitidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.WaitidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.WaitidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Idtype)
-			if err != nil {
-				return types.WaitidArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Id)
-			if err != nil {
-				return types.WaitidArgs{}, err
-			}
-		case 2:
-			var dataInfop uint64
-			err = decoder.DecodeUint64(&dataInfop)
-			if err != nil {
-				return types.WaitidArgs{}, err
-			}
-			result.Infop = uintptr(dataInfop)
-		case 3:
-			err = decoder.DecodeInt32(&result.Options)
-			if err != nil {
-				return types.WaitidArgs{}, err
-			}
-		case 4:
-			var dataRusage uint64
-			err = decoder.DecodeUint64(&dataRusage)
-			if err != nil {
-				return types.WaitidArgs{}, err
-			}
-			result.Rusage = uintptr(dataRusage)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Idtype)
+      if err != nil {
+        return types.WaitidArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Id)
+      if err != nil {
+        return types.WaitidArgs{}, err
+      }
+    case 2:
+      var dataInfop uint64
+      err = decoder.DecodeUint64(&dataInfop)
+      if err != nil {
+        return types.WaitidArgs{}, err
+      }
+      result.Infop = uintptr(dataInfop)
+    case 3:
+      err = decoder.DecodeInt32(&result.Options)
+      if err != nil {
+        return types.WaitidArgs{}, err
+      }
+    case 4:
+      var dataRusage uint64
+      err = decoder.DecodeUint64(&dataRusage)
+      if err != nil {
+        return types.WaitidArgs{}, err
+      }
+      result.Rusage = uintptr(dataRusage)
+    }
+  }
+  return result, nil
 }
 
 func ParseAddKeyArgs(decoder *Decoder) (types.AddKeyArgs, error) {
-	var result types.AddKeyArgs
-	var err error
+  var result types.AddKeyArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.AddKeyArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.AddKeyArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.AddKeyArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.AddKeyArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Type, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.AddKeyArgs{}, err
-			}
-		case 1:
-			result.Description, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.AddKeyArgs{}, err
-			}
-		case 2:
-			var dataPayload uint64
-			err = decoder.DecodeUint64(&dataPayload)
-			if err != nil {
-				return types.AddKeyArgs{}, err
-			}
-			result.Payload = uintptr(dataPayload)
-		case 3:
-			err = decoder.DecodeUint64(&result.Plen)
-			if err != nil {
-				return types.AddKeyArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Keyring)
-			if err != nil {
-				return types.AddKeyArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Type, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.AddKeyArgs{}, err
+      }
+    case 1:
+      result.Description, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.AddKeyArgs{}, err
+      }
+    case 2:
+      var dataPayload uint64
+      err = decoder.DecodeUint64(&dataPayload)
+      if err != nil {
+        return types.AddKeyArgs{}, err
+      }
+      result.Payload = uintptr(dataPayload)
+    case 3:
+      err = decoder.DecodeUint64(&result.Plen)
+      if err != nil {
+        return types.AddKeyArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Keyring)
+      if err != nil {
+        return types.AddKeyArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRequestKeyArgs(decoder *Decoder) (types.RequestKeyArgs, error) {
-	var result types.RequestKeyArgs
-	var err error
+  var result types.RequestKeyArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RequestKeyArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RequestKeyArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RequestKeyArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RequestKeyArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Type, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RequestKeyArgs{}, err
-			}
-		case 1:
-			result.Description, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RequestKeyArgs{}, err
-			}
-		case 2:
-			result.CalloutInfo, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RequestKeyArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.DestKeyring)
-			if err != nil {
-				return types.RequestKeyArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Type, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RequestKeyArgs{}, err
+      }
+    case 1:
+      result.Description, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RequestKeyArgs{}, err
+      }
+    case 2:
+      result.CalloutInfo, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RequestKeyArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.DestKeyring)
+      if err != nil {
+        return types.RequestKeyArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseKeyctlArgs(decoder *Decoder) (types.KeyctlArgs, error) {
-	var result types.KeyctlArgs
-	var err error
+  var result types.KeyctlArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KeyctlArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KeyctlArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KeyctlArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KeyctlArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Operation)
-			if err != nil {
-				return types.KeyctlArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Arg2)
-			if err != nil {
-				return types.KeyctlArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Arg3)
-			if err != nil {
-				return types.KeyctlArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Arg4)
-			if err != nil {
-				return types.KeyctlArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Arg5)
-			if err != nil {
-				return types.KeyctlArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Operation)
+      if err != nil {
+        return types.KeyctlArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Arg2)
+      if err != nil {
+        return types.KeyctlArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Arg3)
+      if err != nil {
+        return types.KeyctlArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Arg4)
+      if err != nil {
+        return types.KeyctlArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Arg5)
+      if err != nil {
+        return types.KeyctlArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseIoprioSetArgs(decoder *Decoder) (types.IoprioSetArgs, error) {
-	var result types.IoprioSetArgs
-	var err error
+  var result types.IoprioSetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoprioSetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoprioSetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoprioSetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoprioSetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Which)
-			if err != nil {
-				return types.IoprioSetArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Who)
-			if err != nil {
-				return types.IoprioSetArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Ioprio)
-			if err != nil {
-				return types.IoprioSetArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Which)
+      if err != nil {
+        return types.IoprioSetArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Who)
+      if err != nil {
+        return types.IoprioSetArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Ioprio)
+      if err != nil {
+        return types.IoprioSetArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseIoprioGetArgs(decoder *Decoder) (types.IoprioGetArgs, error) {
-	var result types.IoprioGetArgs
-	var err error
+  var result types.IoprioGetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoprioGetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoprioGetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoprioGetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoprioGetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Which)
-			if err != nil {
-				return types.IoprioGetArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Who)
-			if err != nil {
-				return types.IoprioGetArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Which)
+      if err != nil {
+        return types.IoprioGetArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Who)
+      if err != nil {
+        return types.IoprioGetArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseInotifyInitArgs(decoder *Decoder) (types.InotifyInitArgs, error) {
-	return types.InotifyInitArgs{}, nil
+  return types.InotifyInitArgs{}, nil
 }
 
 func ParseInotifyAddWatchArgs(decoder *Decoder) (types.InotifyAddWatchArgs, error) {
-	var result types.InotifyAddWatchArgs
-	var err error
+  var result types.InotifyAddWatchArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.InotifyAddWatchArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.InotifyAddWatchArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.InotifyAddWatchArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.InotifyAddWatchArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.InotifyAddWatchArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.InotifyAddWatchArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mask)
-			if err != nil {
-				return types.InotifyAddWatchArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.InotifyAddWatchArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.InotifyAddWatchArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mask)
+      if err != nil {
+        return types.InotifyAddWatchArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseInotifyRmWatchArgs(decoder *Decoder) (types.InotifyRmWatchArgs, error) {
-	var result types.InotifyRmWatchArgs
-	var err error
+  var result types.InotifyRmWatchArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.InotifyRmWatchArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.InotifyRmWatchArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.InotifyRmWatchArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.InotifyRmWatchArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.InotifyRmWatchArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Wd)
-			if err != nil {
-				return types.InotifyRmWatchArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.InotifyRmWatchArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Wd)
+      if err != nil {
+        return types.InotifyRmWatchArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMigratePagesArgs(decoder *Decoder) (types.MigratePagesArgs, error) {
-	var result types.MigratePagesArgs
-	var err error
+  var result types.MigratePagesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MigratePagesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MigratePagesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MigratePagesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MigratePagesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.MigratePagesArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Maxnode)
-			if err != nil {
-				return types.MigratePagesArgs{}, err
-			}
-		case 2:
-			var dataOldNodes uint64
-			err = decoder.DecodeUint64(&dataOldNodes)
-			if err != nil {
-				return types.MigratePagesArgs{}, err
-			}
-			result.OldNodes = uintptr(dataOldNodes)
-		case 3:
-			var dataNewNodes uint64
-			err = decoder.DecodeUint64(&dataNewNodes)
-			if err != nil {
-				return types.MigratePagesArgs{}, err
-			}
-			result.NewNodes = uintptr(dataNewNodes)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.MigratePagesArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Maxnode)
+      if err != nil {
+        return types.MigratePagesArgs{}, err
+      }
+    case 2:
+      var dataOldNodes uint64
+      err = decoder.DecodeUint64(&dataOldNodes)
+      if err != nil {
+        return types.MigratePagesArgs{}, err
+      }
+      result.OldNodes = uintptr(dataOldNodes)
+    case 3:
+      var dataNewNodes uint64
+      err = decoder.DecodeUint64(&dataNewNodes)
+      if err != nil {
+        return types.MigratePagesArgs{}, err
+      }
+      result.NewNodes = uintptr(dataNewNodes)
+    }
+  }
+  return result, nil
 }
 
 func ParseOpenatArgs(decoder *Decoder) (types.OpenatArgs, error) {
-	var result types.OpenatArgs
-	var err error
+  var result types.OpenatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OpenatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OpenatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OpenatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OpenatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.OpenatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.OpenatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.OpenatArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.OpenatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.OpenatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.OpenatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.OpenatArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.OpenatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMkdiratArgs(decoder *Decoder) (types.MkdiratArgs, error) {
-	var result types.MkdiratArgs
-	var err error
+  var result types.MkdiratArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MkdiratArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MkdiratArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MkdiratArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MkdiratArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.MkdiratArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MkdiratArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.MkdiratArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.MkdiratArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MkdiratArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.MkdiratArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMknodatArgs(decoder *Decoder) (types.MknodatArgs, error) {
-	var result types.MknodatArgs
-	var err error
+  var result types.MknodatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MknodatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MknodatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MknodatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MknodatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.MknodatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MknodatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.MknodatArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.MknodatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.MknodatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MknodatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.MknodatArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.MknodatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFchownatArgs(decoder *Decoder) (types.FchownatArgs, error) {
-	var result types.FchownatArgs
-	var err error
+  var result types.FchownatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FchownatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FchownatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FchownatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FchownatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.FchownatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FchownatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Owner)
-			if err != nil {
-				return types.FchownatArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Group)
-			if err != nil {
-				return types.FchownatArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.FchownatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.FchownatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FchownatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Owner)
+      if err != nil {
+        return types.FchownatArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Group)
+      if err != nil {
+        return types.FchownatArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.FchownatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFutimesatArgs(decoder *Decoder) (types.FutimesatArgs, error) {
-	var result types.FutimesatArgs
-	var err error
+  var result types.FutimesatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FutimesatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FutimesatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FutimesatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FutimesatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.FutimesatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FutimesatArgs{}, err
-			}
-		case 2:
-			var dataTimes uint64
-			err = decoder.DecodeUint64(&dataTimes)
-			if err != nil {
-				return types.FutimesatArgs{}, err
-			}
-			result.Times = uintptr(dataTimes)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.FutimesatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FutimesatArgs{}, err
+      }
+    case 2:
+      var dataTimes uint64
+      err = decoder.DecodeUint64(&dataTimes)
+      if err != nil {
+        return types.FutimesatArgs{}, err
+      }
+      result.Times = uintptr(dataTimes)
+    }
+  }
+  return result, nil
 }
 
 func ParseNewfstatatArgs(decoder *Decoder) (types.NewfstatatArgs, error) {
-	var result types.NewfstatatArgs
-	var err error
+  var result types.NewfstatatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NewfstatatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NewfstatatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NewfstatatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NewfstatatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.NewfstatatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NewfstatatArgs{}, err
-			}
-		case 2:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.NewfstatatArgs{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.NewfstatatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.NewfstatatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NewfstatatArgs{}, err
+      }
+    case 2:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.NewfstatatArgs{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.NewfstatatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUnlinkatArgs(decoder *Decoder) (types.UnlinkatArgs, error) {
-	var result types.UnlinkatArgs
-	var err error
+  var result types.UnlinkatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UnlinkatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UnlinkatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UnlinkatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UnlinkatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.UnlinkatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UnlinkatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.UnlinkatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.UnlinkatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UnlinkatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.UnlinkatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRenameatArgs(decoder *Decoder) (types.RenameatArgs, error) {
-	var result types.RenameatArgs
-	var err error
+  var result types.RenameatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RenameatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RenameatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RenameatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RenameatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Olddirfd)
-			if err != nil {
-				return types.RenameatArgs{}, err
-			}
-		case 1:
-			result.Oldpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RenameatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Newdirfd)
-			if err != nil {
-				return types.RenameatArgs{}, err
-			}
-		case 3:
-			result.Newpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RenameatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Olddirfd)
+      if err != nil {
+        return types.RenameatArgs{}, err
+      }
+    case 1:
+      result.Oldpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RenameatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Newdirfd)
+      if err != nil {
+        return types.RenameatArgs{}, err
+      }
+    case 3:
+      result.Newpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RenameatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLinkatArgs(decoder *Decoder) (types.LinkatArgs, error) {
-	var result types.LinkatArgs
-	var err error
+  var result types.LinkatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LinkatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LinkatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LinkatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LinkatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Olddirfd)
-			if err != nil {
-				return types.LinkatArgs{}, err
-			}
-		case 1:
-			result.Oldpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LinkatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Newdirfd)
-			if err != nil {
-				return types.LinkatArgs{}, err
-			}
-		case 3:
-			result.Newpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LinkatArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.LinkatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Olddirfd)
+      if err != nil {
+        return types.LinkatArgs{}, err
+      }
+    case 1:
+      result.Oldpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LinkatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Newdirfd)
+      if err != nil {
+        return types.LinkatArgs{}, err
+      }
+    case 3:
+      result.Newpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LinkatArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.LinkatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSymlinkatArgs(decoder *Decoder) (types.SymlinkatArgs, error) {
-	var result types.SymlinkatArgs
-	var err error
+  var result types.SymlinkatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SymlinkatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SymlinkatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SymlinkatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SymlinkatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Target, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SymlinkatArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Newdirfd)
-			if err != nil {
-				return types.SymlinkatArgs{}, err
-			}
-		case 2:
-			result.Linkpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SymlinkatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Target, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SymlinkatArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Newdirfd)
+      if err != nil {
+        return types.SymlinkatArgs{}, err
+      }
+    case 2:
+      result.Linkpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SymlinkatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseReadlinkatArgs(decoder *Decoder) (types.ReadlinkatArgs, error) {
-	var result types.ReadlinkatArgs
-	var err error
+  var result types.ReadlinkatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ReadlinkatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ReadlinkatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ReadlinkatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ReadlinkatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.ReadlinkatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ReadlinkatArgs{}, err
-			}
-		case 2:
-			result.Buf, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ReadlinkatArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Bufsiz)
-			if err != nil {
-				return types.ReadlinkatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.ReadlinkatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ReadlinkatArgs{}, err
+      }
+    case 2:
+      result.Buf, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ReadlinkatArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Bufsiz)
+      if err != nil {
+        return types.ReadlinkatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFchmodatArgs(decoder *Decoder) (types.FchmodatArgs, error) {
-	var result types.FchmodatArgs
-	var err error
+  var result types.FchmodatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FchmodatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FchmodatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FchmodatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FchmodatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.FchmodatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FchmodatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.FchmodatArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.FchmodatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.FchmodatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FchmodatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.FchmodatArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.FchmodatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFaccessatArgs(decoder *Decoder) (types.FaccessatArgs, error) {
-	var result types.FaccessatArgs
-	var err error
+  var result types.FaccessatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FaccessatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FaccessatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FaccessatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FaccessatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.FaccessatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FaccessatArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Mode)
-			if err != nil {
-				return types.FaccessatArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.FaccessatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.FaccessatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FaccessatArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Mode)
+      if err != nil {
+        return types.FaccessatArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.FaccessatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePselect6Args(decoder *Decoder) (types.Pselect6Args, error) {
-	var result types.Pselect6Args
-	var err error
+  var result types.Pselect6Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Pselect6Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Pselect6Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Pselect6Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Pselect6Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Nfds)
-			if err != nil {
-				return types.Pselect6Args{}, err
-			}
-		case 1:
-			var dataReadfds uint64
-			err = decoder.DecodeUint64(&dataReadfds)
-			if err != nil {
-				return types.Pselect6Args{}, err
-			}
-			result.Readfds = uintptr(dataReadfds)
-		case 2:
-			var dataWritefds uint64
-			err = decoder.DecodeUint64(&dataWritefds)
-			if err != nil {
-				return types.Pselect6Args{}, err
-			}
-			result.Writefds = uintptr(dataWritefds)
-		case 3:
-			var dataExceptfds uint64
-			err = decoder.DecodeUint64(&dataExceptfds)
-			if err != nil {
-				return types.Pselect6Args{}, err
-			}
-			result.Exceptfds = uintptr(dataExceptfds)
-		case 4:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.Pselect6Args{}, err
-			}
-		case 5:
-			var dataSigmask uint64
-			err = decoder.DecodeUint64(&dataSigmask)
-			if err != nil {
-				return types.Pselect6Args{}, err
-			}
-			result.Sigmask = uintptr(dataSigmask)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Nfds)
+      if err != nil {
+        return types.Pselect6Args{}, err
+      }
+    case 1:
+      var dataReadfds uint64
+      err = decoder.DecodeUint64(&dataReadfds)
+      if err != nil {
+        return types.Pselect6Args{}, err
+      }
+      result.Readfds = uintptr(dataReadfds)
+    case 2:
+      var dataWritefds uint64
+      err = decoder.DecodeUint64(&dataWritefds)
+      if err != nil {
+        return types.Pselect6Args{}, err
+      }
+      result.Writefds = uintptr(dataWritefds)
+    case 3:
+      var dataExceptfds uint64
+      err = decoder.DecodeUint64(&dataExceptfds)
+      if err != nil {
+        return types.Pselect6Args{}, err
+      }
+      result.Exceptfds = uintptr(dataExceptfds)
+    case 4:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.Pselect6Args{}, err
+      }
+    case 5:
+      var dataSigmask uint64
+      err = decoder.DecodeUint64(&dataSigmask)
+      if err != nil {
+        return types.Pselect6Args{}, err
+      }
+      result.Sigmask = uintptr(dataSigmask)
+    }
+  }
+  return result, nil
 }
 
 func ParsePpollArgs(decoder *Decoder) (types.PpollArgs, error) {
-	var result types.PpollArgs
-	var err error
+  var result types.PpollArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PpollArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PpollArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PpollArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PpollArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataFds uint64
-			err = decoder.DecodeUint64(&dataFds)
-			if err != nil {
-				return types.PpollArgs{}, err
-			}
-			result.Fds = uintptr(dataFds)
-		case 1:
-			err = decoder.DecodeUint32(&result.Nfds)
-			if err != nil {
-				return types.PpollArgs{}, err
-			}
-		case 2:
-			result.TmoP, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.PpollArgs{}, err
-			}
-		case 3:
-			var dataSigmask uint64
-			err = decoder.DecodeUint64(&dataSigmask)
-			if err != nil {
-				return types.PpollArgs{}, err
-			}
-			result.Sigmask = uintptr(dataSigmask)
-		case 4:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.PpollArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataFds uint64
+      err = decoder.DecodeUint64(&dataFds)
+      if err != nil {
+        return types.PpollArgs{}, err
+      }
+      result.Fds = uintptr(dataFds)
+    case 1:
+      err = decoder.DecodeUint32(&result.Nfds)
+      if err != nil {
+        return types.PpollArgs{}, err
+      }
+    case 2:
+      result.TmoP, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.PpollArgs{}, err
+      }
+    case 3:
+      var dataSigmask uint64
+      err = decoder.DecodeUint64(&dataSigmask)
+      if err != nil {
+        return types.PpollArgs{}, err
+      }
+      result.Sigmask = uintptr(dataSigmask)
+    case 4:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.PpollArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUnshareArgs(decoder *Decoder) (types.UnshareArgs, error) {
-	var result types.UnshareArgs
-	var err error
+  var result types.UnshareArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UnshareArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UnshareArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UnshareArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UnshareArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.UnshareArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.UnshareArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetRobustListArgs(decoder *Decoder) (types.SetRobustListArgs, error) {
-	var result types.SetRobustListArgs
-	var err error
+  var result types.SetRobustListArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetRobustListArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetRobustListArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetRobustListArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetRobustListArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataHead uint64
-			err = decoder.DecodeUint64(&dataHead)
-			if err != nil {
-				return types.SetRobustListArgs{}, err
-			}
-			result.Head = uintptr(dataHead)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.SetRobustListArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataHead uint64
+      err = decoder.DecodeUint64(&dataHead)
+      if err != nil {
+        return types.SetRobustListArgs{}, err
+      }
+      result.Head = uintptr(dataHead)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.SetRobustListArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetRobustListArgs(decoder *Decoder) (types.GetRobustListArgs, error) {
-	var result types.GetRobustListArgs
-	var err error
+  var result types.GetRobustListArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetRobustListArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetRobustListArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetRobustListArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetRobustListArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.GetRobustListArgs{}, err
-			}
-		case 1:
-			var dataHeadPtr uint64
-			err = decoder.DecodeUint64(&dataHeadPtr)
-			if err != nil {
-				return types.GetRobustListArgs{}, err
-			}
-			result.HeadPtr = uintptr(dataHeadPtr)
-		case 2:
-			var dataLenPtr uint64
-			err = decoder.DecodeUint64(&dataLenPtr)
-			if err != nil {
-				return types.GetRobustListArgs{}, err
-			}
-			result.LenPtr = uintptr(dataLenPtr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.GetRobustListArgs{}, err
+      }
+    case 1:
+      var dataHeadPtr uint64
+      err = decoder.DecodeUint64(&dataHeadPtr)
+      if err != nil {
+        return types.GetRobustListArgs{}, err
+      }
+      result.HeadPtr = uintptr(dataHeadPtr)
+    case 2:
+      var dataLenPtr uint64
+      err = decoder.DecodeUint64(&dataLenPtr)
+      if err != nil {
+        return types.GetRobustListArgs{}, err
+      }
+      result.LenPtr = uintptr(dataLenPtr)
+    }
+  }
+  return result, nil
 }
 
 func ParseSpliceArgs(decoder *Decoder) (types.SpliceArgs, error) {
-	var result types.SpliceArgs
-	var err error
+  var result types.SpliceArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SpliceArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SpliceArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SpliceArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SpliceArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.FdIn)
-			if err != nil {
-				return types.SpliceArgs{}, err
-			}
-		case 1:
-			var dataOffIn uint64
-			err = decoder.DecodeUint64(&dataOffIn)
-			if err != nil {
-				return types.SpliceArgs{}, err
-			}
-			result.OffIn = uintptr(dataOffIn)
-		case 2:
-			err = decoder.DecodeInt32(&result.FdOut)
-			if err != nil {
-				return types.SpliceArgs{}, err
-			}
-		case 3:
-			var dataOffOut uint64
-			err = decoder.DecodeUint64(&dataOffOut)
-			if err != nil {
-				return types.SpliceArgs{}, err
-			}
-			result.OffOut = uintptr(dataOffOut)
-		case 4:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.SpliceArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.SpliceArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.FdIn)
+      if err != nil {
+        return types.SpliceArgs{}, err
+      }
+    case 1:
+      var dataOffIn uint64
+      err = decoder.DecodeUint64(&dataOffIn)
+      if err != nil {
+        return types.SpliceArgs{}, err
+      }
+      result.OffIn = uintptr(dataOffIn)
+    case 2:
+      err = decoder.DecodeInt32(&result.FdOut)
+      if err != nil {
+        return types.SpliceArgs{}, err
+      }
+    case 3:
+      var dataOffOut uint64
+      err = decoder.DecodeUint64(&dataOffOut)
+      if err != nil {
+        return types.SpliceArgs{}, err
+      }
+      result.OffOut = uintptr(dataOffOut)
+    case 4:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.SpliceArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.SpliceArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTeeArgs(decoder *Decoder) (types.TeeArgs, error) {
-	var result types.TeeArgs
-	var err error
+  var result types.TeeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TeeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TeeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TeeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TeeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.FdIn)
-			if err != nil {
-				return types.TeeArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.FdOut)
-			if err != nil {
-				return types.TeeArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.TeeArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.TeeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.FdIn)
+      if err != nil {
+        return types.TeeArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.FdOut)
+      if err != nil {
+        return types.TeeArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.TeeArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.TeeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSyncFileRangeArgs(decoder *Decoder) (types.SyncFileRangeArgs, error) {
-	var result types.SyncFileRangeArgs
-	var err error
+  var result types.SyncFileRangeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SyncFileRangeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SyncFileRangeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SyncFileRangeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SyncFileRangeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.SyncFileRangeArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.SyncFileRangeArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Nbytes)
-			if err != nil {
-				return types.SyncFileRangeArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.SyncFileRangeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.SyncFileRangeArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.SyncFileRangeArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Nbytes)
+      if err != nil {
+        return types.SyncFileRangeArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.SyncFileRangeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseVmspliceArgs(decoder *Decoder) (types.VmspliceArgs, error) {
-	var result types.VmspliceArgs
-	var err error
+  var result types.VmspliceArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.VmspliceArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.VmspliceArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.VmspliceArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.VmspliceArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.VmspliceArgs{}, err
-			}
-		case 1:
-			var dataIov uint64
-			err = decoder.DecodeUint64(&dataIov)
-			if err != nil {
-				return types.VmspliceArgs{}, err
-			}
-			result.Iov = uintptr(dataIov)
-		case 2:
-			err = decoder.DecodeUint64(&result.NrSegs)
-			if err != nil {
-				return types.VmspliceArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.VmspliceArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.VmspliceArgs{}, err
+      }
+    case 1:
+      var dataIov uint64
+      err = decoder.DecodeUint64(&dataIov)
+      if err != nil {
+        return types.VmspliceArgs{}, err
+      }
+      result.Iov = uintptr(dataIov)
+    case 2:
+      err = decoder.DecodeUint64(&result.NrSegs)
+      if err != nil {
+        return types.VmspliceArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.VmspliceArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMovePagesArgs(decoder *Decoder) (types.MovePagesArgs, error) {
-	var result types.MovePagesArgs
-	var err error
+  var result types.MovePagesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MovePagesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MovePagesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MovePagesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MovePagesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.MovePagesArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.MovePagesArgs{}, err
-			}
-		case 2:
-			var dataPages uint64
-			err = decoder.DecodeUint64(&dataPages)
-			if err != nil {
-				return types.MovePagesArgs{}, err
-			}
-			result.Pages = uintptr(dataPages)
-		case 3:
-			var dataNodes uint64
-			err = decoder.DecodeUint64(&dataNodes)
-			if err != nil {
-				return types.MovePagesArgs{}, err
-			}
-			result.Nodes = uintptr(dataNodes)
-		case 4:
-			var dataStatus uint64
-			err = decoder.DecodeUint64(&dataStatus)
-			if err != nil {
-				return types.MovePagesArgs{}, err
-			}
-			result.Status = uintptr(dataStatus)
-		case 5:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.MovePagesArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.MovePagesArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.MovePagesArgs{}, err
+      }
+    case 2:
+      var dataPages uint64
+      err = decoder.DecodeUint64(&dataPages)
+      if err != nil {
+        return types.MovePagesArgs{}, err
+      }
+      result.Pages = uintptr(dataPages)
+    case 3:
+      var dataNodes uint64
+      err = decoder.DecodeUint64(&dataNodes)
+      if err != nil {
+        return types.MovePagesArgs{}, err
+      }
+      result.Nodes = uintptr(dataNodes)
+    case 4:
+      var dataStatus uint64
+      err = decoder.DecodeUint64(&dataStatus)
+      if err != nil {
+        return types.MovePagesArgs{}, err
+      }
+      result.Status = uintptr(dataStatus)
+    case 5:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.MovePagesArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUtimensatArgs(decoder *Decoder) (types.UtimensatArgs, error) {
-	var result types.UtimensatArgs
-	var err error
+  var result types.UtimensatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UtimensatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UtimensatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UtimensatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UtimensatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.UtimensatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UtimensatArgs{}, err
-			}
-		case 2:
-			result.Times, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.UtimensatArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.UtimensatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.UtimensatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UtimensatArgs{}, err
+      }
+    case 2:
+      result.Times, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.UtimensatArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.UtimensatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEpollPwaitArgs(decoder *Decoder) (types.EpollPwaitArgs, error) {
-	var result types.EpollPwaitArgs
-	var err error
+  var result types.EpollPwaitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.EpollPwaitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.EpollPwaitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.EpollPwaitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.EpollPwaitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Epfd)
-			if err != nil {
-				return types.EpollPwaitArgs{}, err
-			}
-		case 1:
-			var dataEvents uint64
-			err = decoder.DecodeUint64(&dataEvents)
-			if err != nil {
-				return types.EpollPwaitArgs{}, err
-			}
-			result.Events = uintptr(dataEvents)
-		case 2:
-			err = decoder.DecodeInt32(&result.Maxevents)
-			if err != nil {
-				return types.EpollPwaitArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Timeout)
-			if err != nil {
-				return types.EpollPwaitArgs{}, err
-			}
-		case 4:
-			var dataSigmask uint64
-			err = decoder.DecodeUint64(&dataSigmask)
-			if err != nil {
-				return types.EpollPwaitArgs{}, err
-			}
-			result.Sigmask = uintptr(dataSigmask)
-		case 5:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.EpollPwaitArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Epfd)
+      if err != nil {
+        return types.EpollPwaitArgs{}, err
+      }
+    case 1:
+      var dataEvents uint64
+      err = decoder.DecodeUint64(&dataEvents)
+      if err != nil {
+        return types.EpollPwaitArgs{}, err
+      }
+      result.Events = uintptr(dataEvents)
+    case 2:
+      err = decoder.DecodeInt32(&result.Maxevents)
+      if err != nil {
+        return types.EpollPwaitArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Timeout)
+      if err != nil {
+        return types.EpollPwaitArgs{}, err
+      }
+    case 4:
+      var dataSigmask uint64
+      err = decoder.DecodeUint64(&dataSigmask)
+      if err != nil {
+        return types.EpollPwaitArgs{}, err
+      }
+      result.Sigmask = uintptr(dataSigmask)
+    case 5:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.EpollPwaitArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSignalfdArgs(decoder *Decoder) (types.SignalfdArgs, error) {
-	var result types.SignalfdArgs
-	var err error
+  var result types.SignalfdArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SignalfdArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SignalfdArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SignalfdArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SignalfdArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.SignalfdArgs{}, err
-			}
-		case 1:
-			var dataMask uint64
-			err = decoder.DecodeUint64(&dataMask)
-			if err != nil {
-				return types.SignalfdArgs{}, err
-			}
-			result.Mask = uintptr(dataMask)
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SignalfdArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.SignalfdArgs{}, err
+      }
+    case 1:
+      var dataMask uint64
+      err = decoder.DecodeUint64(&dataMask)
+      if err != nil {
+        return types.SignalfdArgs{}, err
+      }
+      result.Mask = uintptr(dataMask)
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SignalfdArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerfdCreateArgs(decoder *Decoder) (types.TimerfdCreateArgs, error) {
-	var result types.TimerfdCreateArgs
-	var err error
+  var result types.TimerfdCreateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerfdCreateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerfdCreateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerfdCreateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerfdCreateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Clockid)
-			if err != nil {
-				return types.TimerfdCreateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.TimerfdCreateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Clockid)
+      if err != nil {
+        return types.TimerfdCreateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.TimerfdCreateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEventfdArgs(decoder *Decoder) (types.EventfdArgs, error) {
-	var result types.EventfdArgs
-	var err error
+  var result types.EventfdArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.EventfdArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.EventfdArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.EventfdArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.EventfdArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Initval)
-			if err != nil {
-				return types.EventfdArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.EventfdArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Initval)
+      if err != nil {
+        return types.EventfdArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.EventfdArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFallocateArgs(decoder *Decoder) (types.FallocateArgs, error) {
-	var result types.FallocateArgs
-	var err error
+  var result types.FallocateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FallocateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FallocateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FallocateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FallocateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FallocateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Mode)
-			if err != nil {
-				return types.FallocateArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.FallocateArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.FallocateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FallocateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Mode)
+      if err != nil {
+        return types.FallocateArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.FallocateArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.FallocateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerfdSettimeArgs(decoder *Decoder) (types.TimerfdSettimeArgs, error) {
-	var result types.TimerfdSettimeArgs
-	var err error
+  var result types.TimerfdSettimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerfdSettimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerfdSettimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerfdSettimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerfdSettimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.TimerfdSettimeArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.TimerfdSettimeArgs{}, err
-			}
-		case 2:
-			var dataNewValue uint64
-			err = decoder.DecodeUint64(&dataNewValue)
-			if err != nil {
-				return types.TimerfdSettimeArgs{}, err
-			}
-			result.NewValue = uintptr(dataNewValue)
-		case 3:
-			var dataOldValue uint64
-			err = decoder.DecodeUint64(&dataOldValue)
-			if err != nil {
-				return types.TimerfdSettimeArgs{}, err
-			}
-			result.OldValue = uintptr(dataOldValue)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.TimerfdSettimeArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.TimerfdSettimeArgs{}, err
+      }
+    case 2:
+      var dataNewValue uint64
+      err = decoder.DecodeUint64(&dataNewValue)
+      if err != nil {
+        return types.TimerfdSettimeArgs{}, err
+      }
+      result.NewValue = uintptr(dataNewValue)
+    case 3:
+      var dataOldValue uint64
+      err = decoder.DecodeUint64(&dataOldValue)
+      if err != nil {
+        return types.TimerfdSettimeArgs{}, err
+      }
+      result.OldValue = uintptr(dataOldValue)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerfdGettimeArgs(decoder *Decoder) (types.TimerfdGettimeArgs, error) {
-	var result types.TimerfdGettimeArgs
-	var err error
+  var result types.TimerfdGettimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerfdGettimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerfdGettimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerfdGettimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerfdGettimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.TimerfdGettimeArgs{}, err
-			}
-		case 1:
-			var dataCurrValue uint64
-			err = decoder.DecodeUint64(&dataCurrValue)
-			if err != nil {
-				return types.TimerfdGettimeArgs{}, err
-			}
-			result.CurrValue = uintptr(dataCurrValue)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.TimerfdGettimeArgs{}, err
+      }
+    case 1:
+      var dataCurrValue uint64
+      err = decoder.DecodeUint64(&dataCurrValue)
+      if err != nil {
+        return types.TimerfdGettimeArgs{}, err
+      }
+      result.CurrValue = uintptr(dataCurrValue)
+    }
+  }
+  return result, nil
 }
 
 func ParseAccept4Args(decoder *Decoder) (types.Accept4Args, error) {
-	var result types.Accept4Args
-	var err error
+  var result types.Accept4Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Accept4Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Accept4Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Accept4Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Accept4Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.Accept4Args{}, err
-			}
-		case 1:
-			result.Addr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.Accept4Args{}, err
-			}
-		case 2:
-			var dataAddrlen uint64
-			err = decoder.DecodeUint64(&dataAddrlen)
-			if err != nil {
-				return types.Accept4Args{}, err
-			}
-			result.Addrlen = uintptr(dataAddrlen)
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Accept4Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.Accept4Args{}, err
+      }
+    case 1:
+      result.Addr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.Accept4Args{}, err
+      }
+    case 2:
+      var dataAddrlen uint64
+      err = decoder.DecodeUint64(&dataAddrlen)
+      if err != nil {
+        return types.Accept4Args{}, err
+      }
+      result.Addrlen = uintptr(dataAddrlen)
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Accept4Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSignalfd4Args(decoder *Decoder) (types.Signalfd4Args, error) {
-	var result types.Signalfd4Args
-	var err error
+  var result types.Signalfd4Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Signalfd4Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Signalfd4Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Signalfd4Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Signalfd4Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Signalfd4Args{}, err
-			}
-		case 1:
-			var dataMask uint64
-			err = decoder.DecodeUint64(&dataMask)
-			if err != nil {
-				return types.Signalfd4Args{}, err
-			}
-			result.Mask = uintptr(dataMask)
-		case 2:
-			err = decoder.DecodeUint64(&result.Sizemask)
-			if err != nil {
-				return types.Signalfd4Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Signalfd4Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Signalfd4Args{}, err
+      }
+    case 1:
+      var dataMask uint64
+      err = decoder.DecodeUint64(&dataMask)
+      if err != nil {
+        return types.Signalfd4Args{}, err
+      }
+      result.Mask = uintptr(dataMask)
+    case 2:
+      err = decoder.DecodeUint64(&result.Sizemask)
+      if err != nil {
+        return types.Signalfd4Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Signalfd4Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEventfd2Args(decoder *Decoder) (types.Eventfd2Args, error) {
-	var result types.Eventfd2Args
-	var err error
+  var result types.Eventfd2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Eventfd2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Eventfd2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Eventfd2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Eventfd2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Initval)
-			if err != nil {
-				return types.Eventfd2Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Eventfd2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Initval)
+      if err != nil {
+        return types.Eventfd2Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Eventfd2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEpollCreate1Args(decoder *Decoder) (types.EpollCreate1Args, error) {
-	var result types.EpollCreate1Args
-	var err error
+  var result types.EpollCreate1Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.EpollCreate1Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.EpollCreate1Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.EpollCreate1Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.EpollCreate1Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.EpollCreate1Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.EpollCreate1Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDup3Args(decoder *Decoder) (types.Dup3Args, error) {
-	var result types.Dup3Args
-	var err error
+  var result types.Dup3Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Dup3Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Dup3Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Dup3Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Dup3Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Oldfd)
-			if err != nil {
-				return types.Dup3Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Newfd)
-			if err != nil {
-				return types.Dup3Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Dup3Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Oldfd)
+      if err != nil {
+        return types.Dup3Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Newfd)
+      if err != nil {
+        return types.Dup3Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Dup3Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePipe2Args(decoder *Decoder) (types.Pipe2Args, error) {
-	var result types.Pipe2Args
-	var err error
+  var result types.Pipe2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Pipe2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Pipe2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Pipe2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Pipe2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeIntArray(result.Pipefd[:], 2)
-			if err != nil {
-				return types.Pipe2Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Pipe2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeIntArray(result.Pipefd[:], 2)
+      if err != nil {
+        return types.Pipe2Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Pipe2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseInotifyInit1Args(decoder *Decoder) (types.InotifyInit1Args, error) {
-	var result types.InotifyInit1Args
-	var err error
+  var result types.InotifyInit1Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.InotifyInit1Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.InotifyInit1Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.InotifyInit1Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.InotifyInit1Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.InotifyInit1Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.InotifyInit1Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePreadvArgs(decoder *Decoder) (types.PreadvArgs, error) {
-	var result types.PreadvArgs
-	var err error
+  var result types.PreadvArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PreadvArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PreadvArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PreadvArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PreadvArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.PreadvArgs{}, err
-			}
-		case 1:
-			var dataIov uint64
-			err = decoder.DecodeUint64(&dataIov)
-			if err != nil {
-				return types.PreadvArgs{}, err
-			}
-			result.Iov = uintptr(dataIov)
-		case 2:
-			err = decoder.DecodeUint64(&result.Iovcnt)
-			if err != nil {
-				return types.PreadvArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.PosL)
-			if err != nil {
-				return types.PreadvArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.PosH)
-			if err != nil {
-				return types.PreadvArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.PreadvArgs{}, err
+      }
+    case 1:
+      var dataIov uint64
+      err = decoder.DecodeUint64(&dataIov)
+      if err != nil {
+        return types.PreadvArgs{}, err
+      }
+      result.Iov = uintptr(dataIov)
+    case 2:
+      err = decoder.DecodeUint64(&result.Iovcnt)
+      if err != nil {
+        return types.PreadvArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.PosL)
+      if err != nil {
+        return types.PreadvArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.PosH)
+      if err != nil {
+        return types.PreadvArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePwritevArgs(decoder *Decoder) (types.PwritevArgs, error) {
-	var result types.PwritevArgs
-	var err error
+  var result types.PwritevArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PwritevArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PwritevArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PwritevArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PwritevArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.PwritevArgs{}, err
-			}
-		case 1:
-			var dataIov uint64
-			err = decoder.DecodeUint64(&dataIov)
-			if err != nil {
-				return types.PwritevArgs{}, err
-			}
-			result.Iov = uintptr(dataIov)
-		case 2:
-			err = decoder.DecodeUint64(&result.Iovcnt)
-			if err != nil {
-				return types.PwritevArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.PosL)
-			if err != nil {
-				return types.PwritevArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.PosH)
-			if err != nil {
-				return types.PwritevArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.PwritevArgs{}, err
+      }
+    case 1:
+      var dataIov uint64
+      err = decoder.DecodeUint64(&dataIov)
+      if err != nil {
+        return types.PwritevArgs{}, err
+      }
+      result.Iov = uintptr(dataIov)
+    case 2:
+      err = decoder.DecodeUint64(&result.Iovcnt)
+      if err != nil {
+        return types.PwritevArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.PosL)
+      if err != nil {
+        return types.PwritevArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.PosH)
+      if err != nil {
+        return types.PwritevArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRtTgsigqueueinfoArgs(decoder *Decoder) (types.RtTgsigqueueinfoArgs, error) {
-	var result types.RtTgsigqueueinfoArgs
-	var err error
+  var result types.RtTgsigqueueinfoArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtTgsigqueueinfoArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtTgsigqueueinfoArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtTgsigqueueinfoArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtTgsigqueueinfoArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Tgid)
-			if err != nil {
-				return types.RtTgsigqueueinfoArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Tid)
-			if err != nil {
-				return types.RtTgsigqueueinfoArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.RtTgsigqueueinfoArgs{}, err
-			}
-		case 3:
-			var dataInfo uint64
-			err = decoder.DecodeUint64(&dataInfo)
-			if err != nil {
-				return types.RtTgsigqueueinfoArgs{}, err
-			}
-			result.Info = uintptr(dataInfo)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Tgid)
+      if err != nil {
+        return types.RtTgsigqueueinfoArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Tid)
+      if err != nil {
+        return types.RtTgsigqueueinfoArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.RtTgsigqueueinfoArgs{}, err
+      }
+    case 3:
+      var dataInfo uint64
+      err = decoder.DecodeUint64(&dataInfo)
+      if err != nil {
+        return types.RtTgsigqueueinfoArgs{}, err
+      }
+      result.Info = uintptr(dataInfo)
+    }
+  }
+  return result, nil
 }
 
 func ParsePerfEventOpenArgs(decoder *Decoder) (types.PerfEventOpenArgs, error) {
-	var result types.PerfEventOpenArgs
-	var err error
+  var result types.PerfEventOpenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PerfEventOpenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PerfEventOpenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PerfEventOpenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PerfEventOpenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAttr uint64
-			err = decoder.DecodeUint64(&dataAttr)
-			if err != nil {
-				return types.PerfEventOpenArgs{}, err
-			}
-			result.Attr = uintptr(dataAttr)
-		case 1:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.PerfEventOpenArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Cpu)
-			if err != nil {
-				return types.PerfEventOpenArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.GroupFd)
-			if err != nil {
-				return types.PerfEventOpenArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.PerfEventOpenArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAttr uint64
+      err = decoder.DecodeUint64(&dataAttr)
+      if err != nil {
+        return types.PerfEventOpenArgs{}, err
+      }
+      result.Attr = uintptr(dataAttr)
+    case 1:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.PerfEventOpenArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Cpu)
+      if err != nil {
+        return types.PerfEventOpenArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.GroupFd)
+      if err != nil {
+        return types.PerfEventOpenArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.PerfEventOpenArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRecvmmsgArgs(decoder *Decoder) (types.RecvmmsgArgs, error) {
-	var result types.RecvmmsgArgs
-	var err error
+  var result types.RecvmmsgArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RecvmmsgArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RecvmmsgArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RecvmmsgArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RecvmmsgArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.RecvmmsgArgs{}, err
-			}
-		case 1:
-			var dataMsgvec uint64
-			err = decoder.DecodeUint64(&dataMsgvec)
-			if err != nil {
-				return types.RecvmmsgArgs{}, err
-			}
-			result.Msgvec = uintptr(dataMsgvec)
-		case 2:
-			err = decoder.DecodeUint32(&result.Vlen)
-			if err != nil {
-				return types.RecvmmsgArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.RecvmmsgArgs{}, err
-			}
-		case 4:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.RecvmmsgArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.RecvmmsgArgs{}, err
+      }
+    case 1:
+      var dataMsgvec uint64
+      err = decoder.DecodeUint64(&dataMsgvec)
+      if err != nil {
+        return types.RecvmmsgArgs{}, err
+      }
+      result.Msgvec = uintptr(dataMsgvec)
+    case 2:
+      err = decoder.DecodeUint32(&result.Vlen)
+      if err != nil {
+        return types.RecvmmsgArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.RecvmmsgArgs{}, err
+      }
+    case 4:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.RecvmmsgArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFanotifyInitArgs(decoder *Decoder) (types.FanotifyInitArgs, error) {
-	var result types.FanotifyInitArgs
-	var err error
+  var result types.FanotifyInitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FanotifyInitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FanotifyInitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FanotifyInitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FanotifyInitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.FanotifyInitArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.EventFFlags)
-			if err != nil {
-				return types.FanotifyInitArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.FanotifyInitArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.EventFFlags)
+      if err != nil {
+        return types.FanotifyInitArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFanotifyMarkArgs(decoder *Decoder) (types.FanotifyMarkArgs, error) {
-	var result types.FanotifyMarkArgs
-	var err error
+  var result types.FanotifyMarkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FanotifyMarkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FanotifyMarkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FanotifyMarkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FanotifyMarkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.FanotifyFd)
-			if err != nil {
-				return types.FanotifyMarkArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.FanotifyMarkArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Mask)
-			if err != nil {
-				return types.FanotifyMarkArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.FanotifyMarkArgs{}, err
-			}
-		case 4:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FanotifyMarkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.FanotifyFd)
+      if err != nil {
+        return types.FanotifyMarkArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.FanotifyMarkArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Mask)
+      if err != nil {
+        return types.FanotifyMarkArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.FanotifyMarkArgs{}, err
+      }
+    case 4:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FanotifyMarkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePrlimit64Args(decoder *Decoder) (types.Prlimit64Args, error) {
-	var result types.Prlimit64Args
-	var err error
+  var result types.Prlimit64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Prlimit64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Prlimit64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Prlimit64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Prlimit64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.Prlimit64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Resource)
-			if err != nil {
-				return types.Prlimit64Args{}, err
-			}
-		case 2:
-			var dataNewLimit uint64
-			err = decoder.DecodeUint64(&dataNewLimit)
-			if err != nil {
-				return types.Prlimit64Args{}, err
-			}
-			result.NewLimit = uintptr(dataNewLimit)
-		case 3:
-			var dataOldLimit uint64
-			err = decoder.DecodeUint64(&dataOldLimit)
-			if err != nil {
-				return types.Prlimit64Args{}, err
-			}
-			result.OldLimit = uintptr(dataOldLimit)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.Prlimit64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Resource)
+      if err != nil {
+        return types.Prlimit64Args{}, err
+      }
+    case 2:
+      var dataNewLimit uint64
+      err = decoder.DecodeUint64(&dataNewLimit)
+      if err != nil {
+        return types.Prlimit64Args{}, err
+      }
+      result.NewLimit = uintptr(dataNewLimit)
+    case 3:
+      var dataOldLimit uint64
+      err = decoder.DecodeUint64(&dataOldLimit)
+      if err != nil {
+        return types.Prlimit64Args{}, err
+      }
+      result.OldLimit = uintptr(dataOldLimit)
+    }
+  }
+  return result, nil
 }
 
 func ParseNameToHandleAtArgs(decoder *Decoder) (types.NameToHandleAtArgs, error) {
-	var result types.NameToHandleAtArgs
-	var err error
+  var result types.NameToHandleAtArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NameToHandleAtArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NameToHandleAtArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NameToHandleAtArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NameToHandleAtArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.NameToHandleAtArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NameToHandleAtArgs{}, err
-			}
-		case 2:
-			var dataHandle uint64
-			err = decoder.DecodeUint64(&dataHandle)
-			if err != nil {
-				return types.NameToHandleAtArgs{}, err
-			}
-			result.Handle = uintptr(dataHandle)
-		case 3:
-			var dataMountId uint64
-			err = decoder.DecodeUint64(&dataMountId)
-			if err != nil {
-				return types.NameToHandleAtArgs{}, err
-			}
-			result.MountId = uintptr(dataMountId)
-		case 4:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.NameToHandleAtArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.NameToHandleAtArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NameToHandleAtArgs{}, err
+      }
+    case 2:
+      var dataHandle uint64
+      err = decoder.DecodeUint64(&dataHandle)
+      if err != nil {
+        return types.NameToHandleAtArgs{}, err
+      }
+      result.Handle = uintptr(dataHandle)
+    case 3:
+      var dataMountId uint64
+      err = decoder.DecodeUint64(&dataMountId)
+      if err != nil {
+        return types.NameToHandleAtArgs{}, err
+      }
+      result.MountId = uintptr(dataMountId)
+    case 4:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.NameToHandleAtArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseOpenByHandleAtArgs(decoder *Decoder) (types.OpenByHandleAtArgs, error) {
-	var result types.OpenByHandleAtArgs
-	var err error
+  var result types.OpenByHandleAtArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OpenByHandleAtArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OpenByHandleAtArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OpenByHandleAtArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OpenByHandleAtArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.MountFd)
-			if err != nil {
-				return types.OpenByHandleAtArgs{}, err
-			}
-		case 1:
-			var dataHandle uint64
-			err = decoder.DecodeUint64(&dataHandle)
-			if err != nil {
-				return types.OpenByHandleAtArgs{}, err
-			}
-			result.Handle = uintptr(dataHandle)
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.OpenByHandleAtArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.MountFd)
+      if err != nil {
+        return types.OpenByHandleAtArgs{}, err
+      }
+    case 1:
+      var dataHandle uint64
+      err = decoder.DecodeUint64(&dataHandle)
+      if err != nil {
+        return types.OpenByHandleAtArgs{}, err
+      }
+      result.Handle = uintptr(dataHandle)
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.OpenByHandleAtArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseClockAdjtimeArgs(decoder *Decoder) (types.ClockAdjtimeArgs, error) {
-	var result types.ClockAdjtimeArgs
-	var err error
+  var result types.ClockAdjtimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockAdjtimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockAdjtimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockAdjtimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockAdjtimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.ClkId)
-			if err != nil {
-				return types.ClockAdjtimeArgs{}, err
-			}
-		case 1:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.ClockAdjtimeArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.ClkId)
+      if err != nil {
+        return types.ClockAdjtimeArgs{}, err
+      }
+    case 1:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.ClockAdjtimeArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseSyncfsArgs(decoder *Decoder) (types.SyncfsArgs, error) {
-	var result types.SyncfsArgs
-	var err error
+  var result types.SyncfsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SyncfsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SyncfsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SyncfsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SyncfsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.SyncfsArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.SyncfsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSendmmsgArgs(decoder *Decoder) (types.SendmmsgArgs, error) {
-	var result types.SendmmsgArgs
-	var err error
+  var result types.SendmmsgArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SendmmsgArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SendmmsgArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SendmmsgArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SendmmsgArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SendmmsgArgs{}, err
-			}
-		case 1:
-			var dataMsgvec uint64
-			err = decoder.DecodeUint64(&dataMsgvec)
-			if err != nil {
-				return types.SendmmsgArgs{}, err
-			}
-			result.Msgvec = uintptr(dataMsgvec)
-		case 2:
-			err = decoder.DecodeUint32(&result.Vlen)
-			if err != nil {
-				return types.SendmmsgArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SendmmsgArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SendmmsgArgs{}, err
+      }
+    case 1:
+      var dataMsgvec uint64
+      err = decoder.DecodeUint64(&dataMsgvec)
+      if err != nil {
+        return types.SendmmsgArgs{}, err
+      }
+      result.Msgvec = uintptr(dataMsgvec)
+    case 2:
+      err = decoder.DecodeUint32(&result.Vlen)
+      if err != nil {
+        return types.SendmmsgArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SendmmsgArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSetnsArgs(decoder *Decoder) (types.SetnsArgs, error) {
-	var result types.SetnsArgs
-	var err error
+  var result types.SetnsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SetnsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SetnsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SetnsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SetnsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.SetnsArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Nstype)
-			if err != nil {
-				return types.SetnsArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.SetnsArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Nstype)
+      if err != nil {
+        return types.SetnsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseGetcpuArgs(decoder *Decoder) (types.GetcpuArgs, error) {
-	var result types.GetcpuArgs
-	var err error
+  var result types.GetcpuArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetcpuArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetcpuArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetcpuArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetcpuArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataCpu uint64
-			err = decoder.DecodeUint64(&dataCpu)
-			if err != nil {
-				return types.GetcpuArgs{}, err
-			}
-			result.Cpu = uintptr(dataCpu)
-		case 1:
-			var dataNode uint64
-			err = decoder.DecodeUint64(&dataNode)
-			if err != nil {
-				return types.GetcpuArgs{}, err
-			}
-			result.Node = uintptr(dataNode)
-		case 2:
-			var dataTcache uint64
-			err = decoder.DecodeUint64(&dataTcache)
-			if err != nil {
-				return types.GetcpuArgs{}, err
-			}
-			result.Tcache = uintptr(dataTcache)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataCpu uint64
+      err = decoder.DecodeUint64(&dataCpu)
+      if err != nil {
+        return types.GetcpuArgs{}, err
+      }
+      result.Cpu = uintptr(dataCpu)
+    case 1:
+      var dataNode uint64
+      err = decoder.DecodeUint64(&dataNode)
+      if err != nil {
+        return types.GetcpuArgs{}, err
+      }
+      result.Node = uintptr(dataNode)
+    case 2:
+      var dataTcache uint64
+      err = decoder.DecodeUint64(&dataTcache)
+      if err != nil {
+        return types.GetcpuArgs{}, err
+      }
+      result.Tcache = uintptr(dataTcache)
+    }
+  }
+  return result, nil
 }
 
 func ParseProcessVmReadvArgs(decoder *Decoder) (types.ProcessVmReadvArgs, error) {
-	var result types.ProcessVmReadvArgs
-	var err error
+  var result types.ProcessVmReadvArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ProcessVmReadvArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ProcessVmReadvArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ProcessVmReadvArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ProcessVmReadvArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.ProcessVmReadvArgs{}, err
-			}
-		case 1:
-			var dataLocalIov uint64
-			err = decoder.DecodeUint64(&dataLocalIov)
-			if err != nil {
-				return types.ProcessVmReadvArgs{}, err
-			}
-			result.LocalIov = uintptr(dataLocalIov)
-		case 2:
-			err = decoder.DecodeUint64(&result.Liovcnt)
-			if err != nil {
-				return types.ProcessVmReadvArgs{}, err
-			}
-		case 3:
-			var dataRemoteIov uint64
-			err = decoder.DecodeUint64(&dataRemoteIov)
-			if err != nil {
-				return types.ProcessVmReadvArgs{}, err
-			}
-			result.RemoteIov = uintptr(dataRemoteIov)
-		case 4:
-			err = decoder.DecodeUint64(&result.Riovcnt)
-			if err != nil {
-				return types.ProcessVmReadvArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.ProcessVmReadvArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.ProcessVmReadvArgs{}, err
+      }
+    case 1:
+      var dataLocalIov uint64
+      err = decoder.DecodeUint64(&dataLocalIov)
+      if err != nil {
+        return types.ProcessVmReadvArgs{}, err
+      }
+      result.LocalIov = uintptr(dataLocalIov)
+    case 2:
+      err = decoder.DecodeUint64(&result.Liovcnt)
+      if err != nil {
+        return types.ProcessVmReadvArgs{}, err
+      }
+    case 3:
+      var dataRemoteIov uint64
+      err = decoder.DecodeUint64(&dataRemoteIov)
+      if err != nil {
+        return types.ProcessVmReadvArgs{}, err
+      }
+      result.RemoteIov = uintptr(dataRemoteIov)
+    case 4:
+      err = decoder.DecodeUint64(&result.Riovcnt)
+      if err != nil {
+        return types.ProcessVmReadvArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.ProcessVmReadvArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseProcessVmWritevArgs(decoder *Decoder) (types.ProcessVmWritevArgs, error) {
-	var result types.ProcessVmWritevArgs
-	var err error
+  var result types.ProcessVmWritevArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ProcessVmWritevArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ProcessVmWritevArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ProcessVmWritevArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ProcessVmWritevArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.ProcessVmWritevArgs{}, err
-			}
-		case 1:
-			var dataLocalIov uint64
-			err = decoder.DecodeUint64(&dataLocalIov)
-			if err != nil {
-				return types.ProcessVmWritevArgs{}, err
-			}
-			result.LocalIov = uintptr(dataLocalIov)
-		case 2:
-			err = decoder.DecodeUint64(&result.Liovcnt)
-			if err != nil {
-				return types.ProcessVmWritevArgs{}, err
-			}
-		case 3:
-			var dataRemoteIov uint64
-			err = decoder.DecodeUint64(&dataRemoteIov)
-			if err != nil {
-				return types.ProcessVmWritevArgs{}, err
-			}
-			result.RemoteIov = uintptr(dataRemoteIov)
-		case 4:
-			err = decoder.DecodeUint64(&result.Riovcnt)
-			if err != nil {
-				return types.ProcessVmWritevArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.ProcessVmWritevArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.ProcessVmWritevArgs{}, err
+      }
+    case 1:
+      var dataLocalIov uint64
+      err = decoder.DecodeUint64(&dataLocalIov)
+      if err != nil {
+        return types.ProcessVmWritevArgs{}, err
+      }
+      result.LocalIov = uintptr(dataLocalIov)
+    case 2:
+      err = decoder.DecodeUint64(&result.Liovcnt)
+      if err != nil {
+        return types.ProcessVmWritevArgs{}, err
+      }
+    case 3:
+      var dataRemoteIov uint64
+      err = decoder.DecodeUint64(&dataRemoteIov)
+      if err != nil {
+        return types.ProcessVmWritevArgs{}, err
+      }
+      result.RemoteIov = uintptr(dataRemoteIov)
+    case 4:
+      err = decoder.DecodeUint64(&result.Riovcnt)
+      if err != nil {
+        return types.ProcessVmWritevArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.ProcessVmWritevArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseKcmpArgs(decoder *Decoder) (types.KcmpArgs, error) {
-	var result types.KcmpArgs
-	var err error
+  var result types.KcmpArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KcmpArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KcmpArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KcmpArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KcmpArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid1)
-			if err != nil {
-				return types.KcmpArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Pid2)
-			if err != nil {
-				return types.KcmpArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.KcmpArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Idx1)
-			if err != nil {
-				return types.KcmpArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Idx2)
-			if err != nil {
-				return types.KcmpArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid1)
+      if err != nil {
+        return types.KcmpArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Pid2)
+      if err != nil {
+        return types.KcmpArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.KcmpArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Idx1)
+      if err != nil {
+        return types.KcmpArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Idx2)
+      if err != nil {
+        return types.KcmpArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFinitModuleArgs(decoder *Decoder) (types.FinitModuleArgs, error) {
-	var result types.FinitModuleArgs
-	var err error
+  var result types.FinitModuleArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FinitModuleArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FinitModuleArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FinitModuleArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FinitModuleArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.FinitModuleArgs{}, err
-			}
-		case 1:
-			result.ParamValues, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FinitModuleArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.FinitModuleArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.FinitModuleArgs{}, err
+      }
+    case 1:
+      result.ParamValues, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FinitModuleArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.FinitModuleArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedSetattrArgs(decoder *Decoder) (types.SchedSetattrArgs, error) {
-	var result types.SchedSetattrArgs
-	var err error
+  var result types.SchedSetattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedSetattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedSetattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedSetattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedSetattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedSetattrArgs{}, err
-			}
-		case 1:
-			var dataAttr uint64
-			err = decoder.DecodeUint64(&dataAttr)
-			if err != nil {
-				return types.SchedSetattrArgs{}, err
-			}
-			result.Attr = uintptr(dataAttr)
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.SchedSetattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedSetattrArgs{}, err
+      }
+    case 1:
+      var dataAttr uint64
+      err = decoder.DecodeUint64(&dataAttr)
+      if err != nil {
+        return types.SchedSetattrArgs{}, err
+      }
+      result.Attr = uintptr(dataAttr)
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.SchedSetattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedGetattrArgs(decoder *Decoder) (types.SchedGetattrArgs, error) {
-	var result types.SchedGetattrArgs
-	var err error
+  var result types.SchedGetattrArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedGetattrArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedGetattrArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedGetattrArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedGetattrArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedGetattrArgs{}, err
-			}
-		case 1:
-			var dataAttr uint64
-			err = decoder.DecodeUint64(&dataAttr)
-			if err != nil {
-				return types.SchedGetattrArgs{}, err
-			}
-			result.Attr = uintptr(dataAttr)
-		case 2:
-			err = decoder.DecodeUint32(&result.Size)
-			if err != nil {
-				return types.SchedGetattrArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.SchedGetattrArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedGetattrArgs{}, err
+      }
+    case 1:
+      var dataAttr uint64
+      err = decoder.DecodeUint64(&dataAttr)
+      if err != nil {
+        return types.SchedGetattrArgs{}, err
+      }
+      result.Attr = uintptr(dataAttr)
+    case 2:
+      err = decoder.DecodeUint32(&result.Size)
+      if err != nil {
+        return types.SchedGetattrArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.SchedGetattrArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRenameat2Args(decoder *Decoder) (types.Renameat2Args, error) {
-	var result types.Renameat2Args
-	var err error
+  var result types.Renameat2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Renameat2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Renameat2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Renameat2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Renameat2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Olddirfd)
-			if err != nil {
-				return types.Renameat2Args{}, err
-			}
-		case 1:
-			result.Oldpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Renameat2Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Newdirfd)
-			if err != nil {
-				return types.Renameat2Args{}, err
-			}
-		case 3:
-			result.Newpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Renameat2Args{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.Renameat2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Olddirfd)
+      if err != nil {
+        return types.Renameat2Args{}, err
+      }
+    case 1:
+      result.Oldpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Renameat2Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Newdirfd)
+      if err != nil {
+        return types.Renameat2Args{}, err
+      }
+    case 3:
+      result.Newpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Renameat2Args{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.Renameat2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSeccompArgs(decoder *Decoder) (types.SeccompArgs, error) {
-	var result types.SeccompArgs
-	var err error
+  var result types.SeccompArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SeccompArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SeccompArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SeccompArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SeccompArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Operation)
-			if err != nil {
-				return types.SeccompArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.SeccompArgs{}, err
-			}
-		case 2:
-			var dataArgs uint64
-			err = decoder.DecodeUint64(&dataArgs)
-			if err != nil {
-				return types.SeccompArgs{}, err
-			}
-			result.Args = uintptr(dataArgs)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Operation)
+      if err != nil {
+        return types.SeccompArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.SeccompArgs{}, err
+      }
+    case 2:
+      var dataArgs uint64
+      err = decoder.DecodeUint64(&dataArgs)
+      if err != nil {
+        return types.SeccompArgs{}, err
+      }
+      result.Args = uintptr(dataArgs)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetrandomArgs(decoder *Decoder) (types.GetrandomArgs, error) {
-	var result types.GetrandomArgs
-	var err error
+  var result types.GetrandomArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.GetrandomArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.GetrandomArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.GetrandomArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.GetrandomArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.GetrandomArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		case 1:
-			err = decoder.DecodeUint64(&result.Buflen)
-			if err != nil {
-				return types.GetrandomArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.GetrandomArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.GetrandomArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    case 1:
+      err = decoder.DecodeUint64(&result.Buflen)
+      if err != nil {
+        return types.GetrandomArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.GetrandomArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMemfdCreateArgs(decoder *Decoder) (types.MemfdCreateArgs, error) {
-	var result types.MemfdCreateArgs
-	var err error
+  var result types.MemfdCreateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MemfdCreateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MemfdCreateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MemfdCreateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MemfdCreateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MemfdCreateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.MemfdCreateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MemfdCreateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.MemfdCreateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseKexecFileLoadArgs(decoder *Decoder) (types.KexecFileLoadArgs, error) {
-	var result types.KexecFileLoadArgs
-	var err error
+  var result types.KexecFileLoadArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KexecFileLoadArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KexecFileLoadArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KexecFileLoadArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KexecFileLoadArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.KernelFd)
-			if err != nil {
-				return types.KexecFileLoadArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.InitrdFd)
-			if err != nil {
-				return types.KexecFileLoadArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.CmdlineLen)
-			if err != nil {
-				return types.KexecFileLoadArgs{}, err
-			}
-		case 3:
-			result.Cmdline, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.KexecFileLoadArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.KexecFileLoadArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.KernelFd)
+      if err != nil {
+        return types.KexecFileLoadArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.InitrdFd)
+      if err != nil {
+        return types.KexecFileLoadArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.CmdlineLen)
+      if err != nil {
+        return types.KexecFileLoadArgs{}, err
+      }
+    case 3:
+      result.Cmdline, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.KexecFileLoadArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.KexecFileLoadArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseBpfArgs(decoder *Decoder) (types.BpfArgs, error) {
-	var result types.BpfArgs
-	var err error
+  var result types.BpfArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.BpfArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.BpfArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.BpfArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.BpfArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.BpfArgs{}, err
-			}
-		case 1:
-			var dataAttr uint64
-			err = decoder.DecodeUint64(&dataAttr)
-			if err != nil {
-				return types.BpfArgs{}, err
-			}
-			result.Attr = uintptr(dataAttr)
-		case 2:
-			err = decoder.DecodeUint32(&result.Size)
-			if err != nil {
-				return types.BpfArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.BpfArgs{}, err
+      }
+    case 1:
+      var dataAttr uint64
+      err = decoder.DecodeUint64(&dataAttr)
+      if err != nil {
+        return types.BpfArgs{}, err
+      }
+      result.Attr = uintptr(dataAttr)
+    case 2:
+      err = decoder.DecodeUint32(&result.Size)
+      if err != nil {
+        return types.BpfArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseExecveatArgs(decoder *Decoder) (types.ExecveatArgs, error) {
-	var result types.ExecveatArgs
-	var err error
+  var result types.ExecveatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ExecveatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ExecveatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ExecveatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ExecveatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.ExecveatArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExecveatArgs{}, err
-			}
-		case 2:
-			result.Argv, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.ExecveatArgs{}, err
-			}
-		case 3:
-			result.Envp, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.ExecveatArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.ExecveatArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.ExecveatArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExecveatArgs{}, err
+      }
+    case 2:
+      result.Argv, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.ExecveatArgs{}, err
+      }
+    case 3:
+      result.Envp, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.ExecveatArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.ExecveatArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseUserfaultfdArgs(decoder *Decoder) (types.UserfaultfdArgs, error) {
-	var result types.UserfaultfdArgs
-	var err error
+  var result types.UserfaultfdArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UserfaultfdArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UserfaultfdArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UserfaultfdArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UserfaultfdArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.UserfaultfdArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.UserfaultfdArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMembarrierArgs(decoder *Decoder) (types.MembarrierArgs, error) {
-	var result types.MembarrierArgs
-	var err error
+  var result types.MembarrierArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MembarrierArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MembarrierArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MembarrierArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MembarrierArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.MembarrierArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.MembarrierArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.MembarrierArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.MembarrierArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMlock2Args(decoder *Decoder) (types.Mlock2Args, error) {
-	var result types.Mlock2Args
-	var err error
+  var result types.Mlock2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Mlock2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Mlock2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Mlock2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Mlock2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.Mlock2Args{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.Mlock2Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Mlock2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.Mlock2Args{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.Mlock2Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Mlock2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCopyFileRangeArgs(decoder *Decoder) (types.CopyFileRangeArgs, error) {
-	var result types.CopyFileRangeArgs
-	var err error
+  var result types.CopyFileRangeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CopyFileRangeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CopyFileRangeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CopyFileRangeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CopyFileRangeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.FdIn)
-			if err != nil {
-				return types.CopyFileRangeArgs{}, err
-			}
-		case 1:
-			var dataOffIn uint64
-			err = decoder.DecodeUint64(&dataOffIn)
-			if err != nil {
-				return types.CopyFileRangeArgs{}, err
-			}
-			result.OffIn = uintptr(dataOffIn)
-		case 2:
-			err = decoder.DecodeInt32(&result.FdOut)
-			if err != nil {
-				return types.CopyFileRangeArgs{}, err
-			}
-		case 3:
-			var dataOffOut uint64
-			err = decoder.DecodeUint64(&dataOffOut)
-			if err != nil {
-				return types.CopyFileRangeArgs{}, err
-			}
-			result.OffOut = uintptr(dataOffOut)
-		case 4:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.CopyFileRangeArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.CopyFileRangeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.FdIn)
+      if err != nil {
+        return types.CopyFileRangeArgs{}, err
+      }
+    case 1:
+      var dataOffIn uint64
+      err = decoder.DecodeUint64(&dataOffIn)
+      if err != nil {
+        return types.CopyFileRangeArgs{}, err
+      }
+      result.OffIn = uintptr(dataOffIn)
+    case 2:
+      err = decoder.DecodeInt32(&result.FdOut)
+      if err != nil {
+        return types.CopyFileRangeArgs{}, err
+      }
+    case 3:
+      var dataOffOut uint64
+      err = decoder.DecodeUint64(&dataOffOut)
+      if err != nil {
+        return types.CopyFileRangeArgs{}, err
+      }
+      result.OffOut = uintptr(dataOffOut)
+    case 4:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.CopyFileRangeArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.CopyFileRangeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePreadv2Args(decoder *Decoder) (types.Preadv2Args, error) {
-	var result types.Preadv2Args
-	var err error
+  var result types.Preadv2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Preadv2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Preadv2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Preadv2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Preadv2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Preadv2Args{}, err
-			}
-		case 1:
-			var dataIov uint64
-			err = decoder.DecodeUint64(&dataIov)
-			if err != nil {
-				return types.Preadv2Args{}, err
-			}
-			result.Iov = uintptr(dataIov)
-		case 2:
-			err = decoder.DecodeUint64(&result.Iovcnt)
-			if err != nil {
-				return types.Preadv2Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.PosL)
-			if err != nil {
-				return types.Preadv2Args{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.PosH)
-			if err != nil {
-				return types.Preadv2Args{}, err
-			}
-		case 5:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Preadv2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Preadv2Args{}, err
+      }
+    case 1:
+      var dataIov uint64
+      err = decoder.DecodeUint64(&dataIov)
+      if err != nil {
+        return types.Preadv2Args{}, err
+      }
+      result.Iov = uintptr(dataIov)
+    case 2:
+      err = decoder.DecodeUint64(&result.Iovcnt)
+      if err != nil {
+        return types.Preadv2Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.PosL)
+      if err != nil {
+        return types.Preadv2Args{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.PosH)
+      if err != nil {
+        return types.Preadv2Args{}, err
+      }
+    case 5:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Preadv2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePwritev2Args(decoder *Decoder) (types.Pwritev2Args, error) {
-	var result types.Pwritev2Args
-	var err error
+  var result types.Pwritev2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Pwritev2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Pwritev2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Pwritev2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Pwritev2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Pwritev2Args{}, err
-			}
-		case 1:
-			var dataIov uint64
-			err = decoder.DecodeUint64(&dataIov)
-			if err != nil {
-				return types.Pwritev2Args{}, err
-			}
-			result.Iov = uintptr(dataIov)
-		case 2:
-			err = decoder.DecodeUint64(&result.Iovcnt)
-			if err != nil {
-				return types.Pwritev2Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.PosL)
-			if err != nil {
-				return types.Pwritev2Args{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.PosH)
-			if err != nil {
-				return types.Pwritev2Args{}, err
-			}
-		case 5:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.Pwritev2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Pwritev2Args{}, err
+      }
+    case 1:
+      var dataIov uint64
+      err = decoder.DecodeUint64(&dataIov)
+      if err != nil {
+        return types.Pwritev2Args{}, err
+      }
+      result.Iov = uintptr(dataIov)
+    case 2:
+      err = decoder.DecodeUint64(&result.Iovcnt)
+      if err != nil {
+        return types.Pwritev2Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.PosL)
+      if err != nil {
+        return types.Pwritev2Args{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.PosH)
+      if err != nil {
+        return types.Pwritev2Args{}, err
+      }
+    case 5:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.Pwritev2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePkeyMprotectArgs(decoder *Decoder) (types.PkeyMprotectArgs, error) {
-	var result types.PkeyMprotectArgs
-	var err error
+  var result types.PkeyMprotectArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PkeyMprotectArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PkeyMprotectArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PkeyMprotectArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PkeyMprotectArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.PkeyMprotectArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.PkeyMprotectArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Prot)
-			if err != nil {
-				return types.PkeyMprotectArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Pkey)
-			if err != nil {
-				return types.PkeyMprotectArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.PkeyMprotectArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.PkeyMprotectArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Prot)
+      if err != nil {
+        return types.PkeyMprotectArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Pkey)
+      if err != nil {
+        return types.PkeyMprotectArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePkeyAllocArgs(decoder *Decoder) (types.PkeyAllocArgs, error) {
-	var result types.PkeyAllocArgs
-	var err error
+  var result types.PkeyAllocArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PkeyAllocArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PkeyAllocArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PkeyAllocArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PkeyAllocArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.PkeyAllocArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.AccessRights)
-			if err != nil {
-				return types.PkeyAllocArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.PkeyAllocArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.AccessRights)
+      if err != nil {
+        return types.PkeyAllocArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePkeyFreeArgs(decoder *Decoder) (types.PkeyFreeArgs, error) {
-	var result types.PkeyFreeArgs
-	var err error
+  var result types.PkeyFreeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PkeyFreeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PkeyFreeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PkeyFreeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PkeyFreeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pkey)
-			if err != nil {
-				return types.PkeyFreeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pkey)
+      if err != nil {
+        return types.PkeyFreeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseStatxArgs(decoder *Decoder) (types.StatxArgs, error) {
-	var result types.StatxArgs
-	var err error
+  var result types.StatxArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.StatxArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.StatxArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.StatxArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.StatxArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.StatxArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.StatxArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.StatxArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Mask)
-			if err != nil {
-				return types.StatxArgs{}, err
-			}
-		case 4:
-			var dataStatxbuf uint64
-			err = decoder.DecodeUint64(&dataStatxbuf)
-			if err != nil {
-				return types.StatxArgs{}, err
-			}
-			result.Statxbuf = uintptr(dataStatxbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.StatxArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.StatxArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.StatxArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Mask)
+      if err != nil {
+        return types.StatxArgs{}, err
+      }
+    case 4:
+      var dataStatxbuf uint64
+      err = decoder.DecodeUint64(&dataStatxbuf)
+      if err != nil {
+        return types.StatxArgs{}, err
+      }
+      result.Statxbuf = uintptr(dataStatxbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseIoPgeteventsArgs(decoder *Decoder) (types.IoPgeteventsArgs, error) {
-	var result types.IoPgeteventsArgs
-	var err error
+  var result types.IoPgeteventsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoPgeteventsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoPgeteventsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoPgeteventsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoPgeteventsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataCtxId uint64
-			err = decoder.DecodeUint64(&dataCtxId)
-			if err != nil {
-				return types.IoPgeteventsArgs{}, err
-			}
-			result.CtxId = uintptr(dataCtxId)
-		case 1:
-			err = decoder.DecodeInt64(&result.MinNr)
-			if err != nil {
-				return types.IoPgeteventsArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt64(&result.Nr)
-			if err != nil {
-				return types.IoPgeteventsArgs{}, err
-			}
-		case 3:
-			var dataEvents uint64
-			err = decoder.DecodeUint64(&dataEvents)
-			if err != nil {
-				return types.IoPgeteventsArgs{}, err
-			}
-			result.Events = uintptr(dataEvents)
-		case 4:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.IoPgeteventsArgs{}, err
-			}
-		case 5:
-			var dataUsig uint64
-			err = decoder.DecodeUint64(&dataUsig)
-			if err != nil {
-				return types.IoPgeteventsArgs{}, err
-			}
-			result.Usig = uintptr(dataUsig)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataCtxId uint64
+      err = decoder.DecodeUint64(&dataCtxId)
+      if err != nil {
+        return types.IoPgeteventsArgs{}, err
+      }
+      result.CtxId = uintptr(dataCtxId)
+    case 1:
+      err = decoder.DecodeInt64(&result.MinNr)
+      if err != nil {
+        return types.IoPgeteventsArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt64(&result.Nr)
+      if err != nil {
+        return types.IoPgeteventsArgs{}, err
+      }
+    case 3:
+      var dataEvents uint64
+      err = decoder.DecodeUint64(&dataEvents)
+      if err != nil {
+        return types.IoPgeteventsArgs{}, err
+      }
+      result.Events = uintptr(dataEvents)
+    case 4:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.IoPgeteventsArgs{}, err
+      }
+    case 5:
+      var dataUsig uint64
+      err = decoder.DecodeUint64(&dataUsig)
+      if err != nil {
+        return types.IoPgeteventsArgs{}, err
+      }
+      result.Usig = uintptr(dataUsig)
+    }
+  }
+  return result, nil
 }
 
 func ParseRseqArgs(decoder *Decoder) (types.RseqArgs, error) {
-	var result types.RseqArgs
-	var err error
+  var result types.RseqArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RseqArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RseqArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RseqArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RseqArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRseq uint64
-			err = decoder.DecodeUint64(&dataRseq)
-			if err != nil {
-				return types.RseqArgs{}, err
-			}
-			result.Rseq = uintptr(dataRseq)
-		case 1:
-			err = decoder.DecodeUint32(&result.RseqLen)
-			if err != nil {
-				return types.RseqArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.RseqArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Sig)
-			if err != nil {
-				return types.RseqArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRseq uint64
+      err = decoder.DecodeUint64(&dataRseq)
+      if err != nil {
+        return types.RseqArgs{}, err
+      }
+      result.Rseq = uintptr(dataRseq)
+    case 1:
+      err = decoder.DecodeUint32(&result.RseqLen)
+      if err != nil {
+        return types.RseqArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.RseqArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Sig)
+      if err != nil {
+        return types.RseqArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePidfdSendSignalArgs(decoder *Decoder) (types.PidfdSendSignalArgs, error) {
-	var result types.PidfdSendSignalArgs
-	var err error
+  var result types.PidfdSendSignalArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PidfdSendSignalArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PidfdSendSignalArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PidfdSendSignalArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PidfdSendSignalArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pidfd)
-			if err != nil {
-				return types.PidfdSendSignalArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.PidfdSendSignalArgs{}, err
-			}
-		case 2:
-			var dataInfo uint64
-			err = decoder.DecodeUint64(&dataInfo)
-			if err != nil {
-				return types.PidfdSendSignalArgs{}, err
-			}
-			result.Info = uintptr(dataInfo)
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.PidfdSendSignalArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pidfd)
+      if err != nil {
+        return types.PidfdSendSignalArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.PidfdSendSignalArgs{}, err
+      }
+    case 2:
+      var dataInfo uint64
+      err = decoder.DecodeUint64(&dataInfo)
+      if err != nil {
+        return types.PidfdSendSignalArgs{}, err
+      }
+      result.Info = uintptr(dataInfo)
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.PidfdSendSignalArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseIoUringSetupArgs(decoder *Decoder) (types.IoUringSetupArgs, error) {
-	var result types.IoUringSetupArgs
-	var err error
+  var result types.IoUringSetupArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoUringSetupArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoUringSetupArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoUringSetupArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoUringSetupArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Entries)
-			if err != nil {
-				return types.IoUringSetupArgs{}, err
-			}
-		case 1:
-			var dataP uint64
-			err = decoder.DecodeUint64(&dataP)
-			if err != nil {
-				return types.IoUringSetupArgs{}, err
-			}
-			result.P = uintptr(dataP)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Entries)
+      if err != nil {
+        return types.IoUringSetupArgs{}, err
+      }
+    case 1:
+      var dataP uint64
+      err = decoder.DecodeUint64(&dataP)
+      if err != nil {
+        return types.IoUringSetupArgs{}, err
+      }
+      result.P = uintptr(dataP)
+    }
+  }
+  return result, nil
 }
 
 func ParseIoUringEnterArgs(decoder *Decoder) (types.IoUringEnterArgs, error) {
-	var result types.IoUringEnterArgs
-	var err error
+  var result types.IoUringEnterArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoUringEnterArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoUringEnterArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoUringEnterArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoUringEnterArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Fd)
-			if err != nil {
-				return types.IoUringEnterArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.ToSubmit)
-			if err != nil {
-				return types.IoUringEnterArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.MinComplete)
-			if err != nil {
-				return types.IoUringEnterArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.IoUringEnterArgs{}, err
-			}
-		case 4:
-			var dataSig uint64
-			err = decoder.DecodeUint64(&dataSig)
-			if err != nil {
-				return types.IoUringEnterArgs{}, err
-			}
-			result.Sig = uintptr(dataSig)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Fd)
+      if err != nil {
+        return types.IoUringEnterArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.ToSubmit)
+      if err != nil {
+        return types.IoUringEnterArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.MinComplete)
+      if err != nil {
+        return types.IoUringEnterArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.IoUringEnterArgs{}, err
+      }
+    case 4:
+      var dataSig uint64
+      err = decoder.DecodeUint64(&dataSig)
+      if err != nil {
+        return types.IoUringEnterArgs{}, err
+      }
+      result.Sig = uintptr(dataSig)
+    }
+  }
+  return result, nil
 }
 
 func ParseIoUringRegisterArgs(decoder *Decoder) (types.IoUringRegisterArgs, error) {
-	var result types.IoUringRegisterArgs
-	var err error
+  var result types.IoUringRegisterArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IoUringRegisterArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IoUringRegisterArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IoUringRegisterArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IoUringRegisterArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Fd)
-			if err != nil {
-				return types.IoUringRegisterArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Opcode)
-			if err != nil {
-				return types.IoUringRegisterArgs{}, err
-			}
-		case 2:
-			var dataArg uint64
-			err = decoder.DecodeUint64(&dataArg)
-			if err != nil {
-				return types.IoUringRegisterArgs{}, err
-			}
-			result.Arg = uintptr(dataArg)
-		case 3:
-			err = decoder.DecodeUint32(&result.NrArgs)
-			if err != nil {
-				return types.IoUringRegisterArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Fd)
+      if err != nil {
+        return types.IoUringRegisterArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Opcode)
+      if err != nil {
+        return types.IoUringRegisterArgs{}, err
+      }
+    case 2:
+      var dataArg uint64
+      err = decoder.DecodeUint64(&dataArg)
+      if err != nil {
+        return types.IoUringRegisterArgs{}, err
+      }
+      result.Arg = uintptr(dataArg)
+    case 3:
+      err = decoder.DecodeUint32(&result.NrArgs)
+      if err != nil {
+        return types.IoUringRegisterArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseOpenTreeArgs(decoder *Decoder) (types.OpenTreeArgs, error) {
-	var result types.OpenTreeArgs
-	var err error
+  var result types.OpenTreeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OpenTreeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OpenTreeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OpenTreeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OpenTreeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dfd)
-			if err != nil {
-				return types.OpenTreeArgs{}, err
-			}
-		case 1:
-			result.Filename, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.OpenTreeArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.OpenTreeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dfd)
+      if err != nil {
+        return types.OpenTreeArgs{}, err
+      }
+    case 1:
+      result.Filename, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.OpenTreeArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.OpenTreeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMoveMountArgs(decoder *Decoder) (types.MoveMountArgs, error) {
-	var result types.MoveMountArgs
-	var err error
+  var result types.MoveMountArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MoveMountArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MoveMountArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MoveMountArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MoveMountArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.FromDfd)
-			if err != nil {
-				return types.MoveMountArgs{}, err
-			}
-		case 1:
-			result.FromPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MoveMountArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.ToDfd)
-			if err != nil {
-				return types.MoveMountArgs{}, err
-			}
-		case 3:
-			result.ToPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MoveMountArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.MoveMountArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.FromDfd)
+      if err != nil {
+        return types.MoveMountArgs{}, err
+      }
+    case 1:
+      result.FromPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MoveMountArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.ToDfd)
+      if err != nil {
+        return types.MoveMountArgs{}, err
+      }
+    case 3:
+      result.ToPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MoveMountArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.MoveMountArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFsopenArgs(decoder *Decoder) (types.FsopenArgs, error) {
-	var result types.FsopenArgs
-	var err error
+  var result types.FsopenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FsopenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FsopenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FsopenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FsopenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Fsname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FsopenArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.FsopenArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Fsname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FsopenArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.FsopenArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFsconfigArgs(decoder *Decoder) (types.FsconfigArgs, error) {
-	var result types.FsconfigArgs
-	var err error
+  var result types.FsconfigArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FsconfigArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FsconfigArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FsconfigArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FsconfigArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataFsFd uint64
-			err = decoder.DecodeUint64(&dataFsFd)
-			if err != nil {
-				return types.FsconfigArgs{}, err
-			}
-			result.FsFd = uintptr(dataFsFd)
-		case 1:
-			err = decoder.DecodeUint32(&result.Cmd)
-			if err != nil {
-				return types.FsconfigArgs{}, err
-			}
-		case 2:
-			result.Key, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FsconfigArgs{}, err
-			}
-		case 3:
-			var dataValue uint64
-			err = decoder.DecodeUint64(&dataValue)
-			if err != nil {
-				return types.FsconfigArgs{}, err
-			}
-			result.Value = uintptr(dataValue)
-		case 4:
-			err = decoder.DecodeInt32(&result.Aux)
-			if err != nil {
-				return types.FsconfigArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataFsFd uint64
+      err = decoder.DecodeUint64(&dataFsFd)
+      if err != nil {
+        return types.FsconfigArgs{}, err
+      }
+      result.FsFd = uintptr(dataFsFd)
+    case 1:
+      err = decoder.DecodeUint32(&result.Cmd)
+      if err != nil {
+        return types.FsconfigArgs{}, err
+      }
+    case 2:
+      result.Key, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FsconfigArgs{}, err
+      }
+    case 3:
+      var dataValue uint64
+      err = decoder.DecodeUint64(&dataValue)
+      if err != nil {
+        return types.FsconfigArgs{}, err
+      }
+      result.Value = uintptr(dataValue)
+    case 4:
+      err = decoder.DecodeInt32(&result.Aux)
+      if err != nil {
+        return types.FsconfigArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFsmountArgs(decoder *Decoder) (types.FsmountArgs, error) {
-	var result types.FsmountArgs
-	var err error
+  var result types.FsmountArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FsmountArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FsmountArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FsmountArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FsmountArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fsfd)
-			if err != nil {
-				return types.FsmountArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.FsmountArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.MsFlags)
-			if err != nil {
-				return types.FsmountArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fsfd)
+      if err != nil {
+        return types.FsmountArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.FsmountArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.MsFlags)
+      if err != nil {
+        return types.FsmountArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFspickArgs(decoder *Decoder) (types.FspickArgs, error) {
-	var result types.FspickArgs
-	var err error
+  var result types.FspickArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FspickArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FspickArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FspickArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FspickArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.FspickArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FspickArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.FspickArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.FspickArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FspickArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.FspickArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePidfdOpenArgs(decoder *Decoder) (types.PidfdOpenArgs, error) {
-	var result types.PidfdOpenArgs
-	var err error
+  var result types.PidfdOpenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PidfdOpenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PidfdOpenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PidfdOpenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PidfdOpenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.PidfdOpenArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.PidfdOpenArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.PidfdOpenArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.PidfdOpenArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseClone3Args(decoder *Decoder) (types.Clone3Args, error) {
-	var result types.Clone3Args
-	var err error
+  var result types.Clone3Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Clone3Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Clone3Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Clone3Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Clone3Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataClArgs uint64
-			err = decoder.DecodeUint64(&dataClArgs)
-			if err != nil {
-				return types.Clone3Args{}, err
-			}
-			result.ClArgs = uintptr(dataClArgs)
-		case 1:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.Clone3Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataClArgs uint64
+      err = decoder.DecodeUint64(&dataClArgs)
+      if err != nil {
+        return types.Clone3Args{}, err
+      }
+      result.ClArgs = uintptr(dataClArgs)
+    case 1:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.Clone3Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCloseRangeArgs(decoder *Decoder) (types.CloseRangeArgs, error) {
-	var result types.CloseRangeArgs
-	var err error
+  var result types.CloseRangeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CloseRangeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CloseRangeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CloseRangeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CloseRangeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.First)
-			if err != nil {
-				return types.CloseRangeArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Last)
-			if err != nil {
-				return types.CloseRangeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.First)
+      if err != nil {
+        return types.CloseRangeArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Last)
+      if err != nil {
+        return types.CloseRangeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseOpenat2Args(decoder *Decoder) (types.Openat2Args, error) {
-	var result types.Openat2Args
-	var err error
+  var result types.Openat2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Openat2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Openat2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Openat2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Openat2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dirfd)
-			if err != nil {
-				return types.Openat2Args{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Openat2Args{}, err
-			}
-		case 2:
-			var dataHow uint64
-			err = decoder.DecodeUint64(&dataHow)
-			if err != nil {
-				return types.Openat2Args{}, err
-			}
-			result.How = uintptr(dataHow)
-		case 3:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.Openat2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dirfd)
+      if err != nil {
+        return types.Openat2Args{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Openat2Args{}, err
+      }
+    case 2:
+      var dataHow uint64
+      err = decoder.DecodeUint64(&dataHow)
+      if err != nil {
+        return types.Openat2Args{}, err
+      }
+      result.How = uintptr(dataHow)
+    case 3:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.Openat2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePidfdGetfdArgs(decoder *Decoder) (types.PidfdGetfdArgs, error) {
-	var result types.PidfdGetfdArgs
-	var err error
+  var result types.PidfdGetfdArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PidfdGetfdArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PidfdGetfdArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PidfdGetfdArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PidfdGetfdArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pidfd)
-			if err != nil {
-				return types.PidfdGetfdArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Targetfd)
-			if err != nil {
-				return types.PidfdGetfdArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.PidfdGetfdArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pidfd)
+      if err != nil {
+        return types.PidfdGetfdArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Targetfd)
+      if err != nil {
+        return types.PidfdGetfdArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.PidfdGetfdArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFaccessat2Args(decoder *Decoder) (types.Faccessat2Args, error) {
-	var result types.Faccessat2Args
-	var err error
+  var result types.Faccessat2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Faccessat2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Faccessat2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Faccessat2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Faccessat2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Faccessat2Args{}, err
-			}
-		case 1:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Faccessat2Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Mode)
-			if err != nil {
-				return types.Faccessat2Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Flag)
-			if err != nil {
-				return types.Faccessat2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Faccessat2Args{}, err
+      }
+    case 1:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Faccessat2Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Mode)
+      if err != nil {
+        return types.Faccessat2Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Flag)
+      if err != nil {
+        return types.Faccessat2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseProcessMadviseArgs(decoder *Decoder) (types.ProcessMadviseArgs, error) {
-	var result types.ProcessMadviseArgs
-	var err error
+  var result types.ProcessMadviseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ProcessMadviseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ProcessMadviseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ProcessMadviseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ProcessMadviseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pidfd)
-			if err != nil {
-				return types.ProcessMadviseArgs{}, err
-			}
-		case 1:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.ProcessMadviseArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 2:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.ProcessMadviseArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Advice)
-			if err != nil {
-				return types.ProcessMadviseArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.ProcessMadviseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pidfd)
+      if err != nil {
+        return types.ProcessMadviseArgs{}, err
+      }
+    case 1:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.ProcessMadviseArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 2:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.ProcessMadviseArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Advice)
+      if err != nil {
+        return types.ProcessMadviseArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.ProcessMadviseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseEpollPwait2Args(decoder *Decoder) (types.EpollPwait2Args, error) {
-	var result types.EpollPwait2Args
-	var err error
+  var result types.EpollPwait2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.EpollPwait2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.EpollPwait2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.EpollPwait2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.EpollPwait2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.EpollPwait2Args{}, err
-			}
-		case 1:
-			var dataEvents uint64
-			err = decoder.DecodeUint64(&dataEvents)
-			if err != nil {
-				return types.EpollPwait2Args{}, err
-			}
-			result.Events = uintptr(dataEvents)
-		case 2:
-			err = decoder.DecodeInt32(&result.Maxevents)
-			if err != nil {
-				return types.EpollPwait2Args{}, err
-			}
-		case 3:
-			result.Timeout, err = decoder.ReadTimespec()
-			if err != nil {
-				return types.EpollPwait2Args{}, err
-			}
-		case 4:
-			var dataSigset uint64
-			err = decoder.DecodeUint64(&dataSigset)
-			if err != nil {
-				return types.EpollPwait2Args{}, err
-			}
-			result.Sigset = uintptr(dataSigset)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.EpollPwait2Args{}, err
+      }
+    case 1:
+      var dataEvents uint64
+      err = decoder.DecodeUint64(&dataEvents)
+      if err != nil {
+        return types.EpollPwait2Args{}, err
+      }
+      result.Events = uintptr(dataEvents)
+    case 2:
+      err = decoder.DecodeInt32(&result.Maxevents)
+      if err != nil {
+        return types.EpollPwait2Args{}, err
+      }
+    case 3:
+      result.Timeout, err = decoder.ReadTimespec()
+      if err != nil {
+        return types.EpollPwait2Args{}, err
+      }
+    case 4:
+      var dataSigset uint64
+      err = decoder.DecodeUint64(&dataSigset)
+      if err != nil {
+        return types.EpollPwait2Args{}, err
+      }
+      result.Sigset = uintptr(dataSigset)
+    }
+  }
+  return result, nil
 }
 
 func ParseMountSetattArgs(decoder *Decoder) (types.MountSetattArgs, error) {
-	var result types.MountSetattArgs
-	var err error
+  var result types.MountSetattArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MountSetattArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MountSetattArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MountSetattArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MountSetattArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Dfd)
-			if err != nil {
-				return types.MountSetattArgs{}, err
-			}
-		case 1:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MountSetattArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.MountSetattArgs{}, err
-			}
-		case 3:
-			var dataUattr uint64
-			err = decoder.DecodeUint64(&dataUattr)
-			if err != nil {
-				return types.MountSetattArgs{}, err
-			}
-			result.Uattr = uintptr(dataUattr)
-		case 4:
-			err = decoder.DecodeUint64(&result.Usize)
-			if err != nil {
-				return types.MountSetattArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Dfd)
+      if err != nil {
+        return types.MountSetattArgs{}, err
+      }
+    case 1:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MountSetattArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.MountSetattArgs{}, err
+      }
+    case 3:
+      var dataUattr uint64
+      err = decoder.DecodeUint64(&dataUattr)
+      if err != nil {
+        return types.MountSetattArgs{}, err
+      }
+      result.Uattr = uintptr(dataUattr)
+    case 4:
+      err = decoder.DecodeUint64(&result.Usize)
+      if err != nil {
+        return types.MountSetattArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseQuotactlFdArgs(decoder *Decoder) (types.QuotactlFdArgs, error) {
-	var result types.QuotactlFdArgs
-	var err error
+  var result types.QuotactlFdArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.QuotactlFdArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.QuotactlFdArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.QuotactlFdArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.QuotactlFdArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Fd)
-			if err != nil {
-				return types.QuotactlFdArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Cmd)
-			if err != nil {
-				return types.QuotactlFdArgs{}, err
-			}
-		case 2:
-			var dataId uint64
-			err = decoder.DecodeUint64(&dataId)
-			if err != nil {
-				return types.QuotactlFdArgs{}, err
-			}
-			result.Id = uintptr(dataId)
-		case 3:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.QuotactlFdArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Fd)
+      if err != nil {
+        return types.QuotactlFdArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Cmd)
+      if err != nil {
+        return types.QuotactlFdArgs{}, err
+      }
+    case 2:
+      var dataId uint64
+      err = decoder.DecodeUint64(&dataId)
+      if err != nil {
+        return types.QuotactlFdArgs{}, err
+      }
+      result.Id = uintptr(dataId)
+    case 3:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.QuotactlFdArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    }
+  }
+  return result, nil
 }
 
 func ParseLandlockCreateRulesetArgs(decoder *Decoder) (types.LandlockCreateRulesetArgs, error) {
-	var result types.LandlockCreateRulesetArgs
-	var err error
+  var result types.LandlockCreateRulesetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LandlockCreateRulesetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LandlockCreateRulesetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LandlockCreateRulesetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LandlockCreateRulesetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAttr uint64
-			err = decoder.DecodeUint64(&dataAttr)
-			if err != nil {
-				return types.LandlockCreateRulesetArgs{}, err
-			}
-			result.Attr = uintptr(dataAttr)
-		case 1:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.LandlockCreateRulesetArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.LandlockCreateRulesetArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAttr uint64
+      err = decoder.DecodeUint64(&dataAttr)
+      if err != nil {
+        return types.LandlockCreateRulesetArgs{}, err
+      }
+      result.Attr = uintptr(dataAttr)
+    case 1:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.LandlockCreateRulesetArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.LandlockCreateRulesetArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLandlockAddRuleArgs(decoder *Decoder) (types.LandlockAddRuleArgs, error) {
-	var result types.LandlockAddRuleArgs
-	var err error
+  var result types.LandlockAddRuleArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LandlockAddRuleArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LandlockAddRuleArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LandlockAddRuleArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LandlockAddRuleArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.RulesetFd)
-			if err != nil {
-				return types.LandlockAddRuleArgs{}, err
-			}
-		case 1:
-			var dataRuleType uint64
-			err = decoder.DecodeUint64(&dataRuleType)
-			if err != nil {
-				return types.LandlockAddRuleArgs{}, err
-			}
-			result.RuleType = uintptr(dataRuleType)
-		case 2:
-			var dataRuleAttr uint64
-			err = decoder.DecodeUint64(&dataRuleAttr)
-			if err != nil {
-				return types.LandlockAddRuleArgs{}, err
-			}
-			result.RuleAttr = uintptr(dataRuleAttr)
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.LandlockAddRuleArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.RulesetFd)
+      if err != nil {
+        return types.LandlockAddRuleArgs{}, err
+      }
+    case 1:
+      var dataRuleType uint64
+      err = decoder.DecodeUint64(&dataRuleType)
+      if err != nil {
+        return types.LandlockAddRuleArgs{}, err
+      }
+      result.RuleType = uintptr(dataRuleType)
+    case 2:
+      var dataRuleAttr uint64
+      err = decoder.DecodeUint64(&dataRuleAttr)
+      if err != nil {
+        return types.LandlockAddRuleArgs{}, err
+      }
+      result.RuleAttr = uintptr(dataRuleAttr)
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.LandlockAddRuleArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLandloclRestrictSetArgs(decoder *Decoder) (types.LandloclRestrictSetArgs, error) {
-	var result types.LandloclRestrictSetArgs
-	var err error
+  var result types.LandloclRestrictSetArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LandloclRestrictSetArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LandloclRestrictSetArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LandloclRestrictSetArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LandloclRestrictSetArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.RulesetFd)
-			if err != nil {
-				return types.LandloclRestrictSetArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.LandloclRestrictSetArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.RulesetFd)
+      if err != nil {
+        return types.LandloclRestrictSetArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.LandloclRestrictSetArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMemfdSecretArgs(decoder *Decoder) (types.MemfdSecretArgs, error) {
-	var result types.MemfdSecretArgs
-	var err error
+  var result types.MemfdSecretArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MemfdSecretArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MemfdSecretArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MemfdSecretArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MemfdSecretArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.MemfdSecretArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.MemfdSecretArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseProcessMreleaseArgs(decoder *Decoder) (types.ProcessMreleaseArgs, error) {
-	var result types.ProcessMreleaseArgs
-	var err error
+  var result types.ProcessMreleaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ProcessMreleaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ProcessMreleaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ProcessMreleaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ProcessMreleaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pidfd)
-			if err != nil {
-				return types.ProcessMreleaseArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.ProcessMreleaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pidfd)
+      if err != nil {
+        return types.ProcessMreleaseArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.ProcessMreleaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseWaitpidArgs(decoder *Decoder) (types.WaitpidArgs, error) {
-	var result types.WaitpidArgs
-	var err error
+  var result types.WaitpidArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.WaitpidArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.WaitpidArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.WaitpidArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.WaitpidArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.WaitpidArgs{}, err
-			}
-		case 1:
-			var dataStatus uint64
-			err = decoder.DecodeUint64(&dataStatus)
-			if err != nil {
-				return types.WaitpidArgs{}, err
-			}
-			result.Status = uintptr(dataStatus)
-		case 2:
-			err = decoder.DecodeInt32(&result.Options)
-			if err != nil {
-				return types.WaitpidArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.WaitpidArgs{}, err
+      }
+    case 1:
+      var dataStatus uint64
+      err = decoder.DecodeUint64(&dataStatus)
+      if err != nil {
+        return types.WaitpidArgs{}, err
+      }
+      result.Status = uintptr(dataStatus)
+    case 2:
+      err = decoder.DecodeInt32(&result.Options)
+      if err != nil {
+        return types.WaitpidArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseOldfstatArgs(decoder *Decoder) (types.OldfstatArgs, error) {
-	return types.OldfstatArgs{}, nil
+  return types.OldfstatArgs{}, nil
 }
 
 func ParseBreakArgs(decoder *Decoder) (types.BreakArgs, error) {
-	return types.BreakArgs{}, nil
+  return types.BreakArgs{}, nil
 }
 
 func ParseOldstatArgs(decoder *Decoder) (types.OldstatArgs, error) {
-	var result types.OldstatArgs
-	var err error
+  var result types.OldstatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OldstatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OldstatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OldstatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OldstatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Filename, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.OldstatArgs{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.OldstatArgs{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Filename, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.OldstatArgs{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.OldstatArgs{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseUmountArgs(decoder *Decoder) (types.UmountArgs, error) {
-	var result types.UmountArgs
-	var err error
+  var result types.UmountArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UmountArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UmountArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UmountArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UmountArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Target, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UmountArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Target, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UmountArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseStimeArgs(decoder *Decoder) (types.StimeArgs, error) {
-	var result types.StimeArgs
-	var err error
+  var result types.StimeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.StimeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.StimeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.StimeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.StimeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataT uint64
-			err = decoder.DecodeUint64(&dataT)
-			if err != nil {
-				return types.StimeArgs{}, err
-			}
-			result.T = uintptr(dataT)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataT uint64
+      err = decoder.DecodeUint64(&dataT)
+      if err != nil {
+        return types.StimeArgs{}, err
+      }
+      result.T = uintptr(dataT)
+    }
+  }
+  return result, nil
 }
 
 func ParseSttyArgs(decoder *Decoder) (types.SttyArgs, error) {
-	return types.SttyArgs{}, nil
+  return types.SttyArgs{}, nil
 }
 
 func ParseGttyArgs(decoder *Decoder) (types.GttyArgs, error) {
-	return types.GttyArgs{}, nil
+  return types.GttyArgs{}, nil
 }
 
 func ParseNiceArgs(decoder *Decoder) (types.NiceArgs, error) {
-	var result types.NiceArgs
-	var err error
+  var result types.NiceArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NiceArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NiceArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NiceArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NiceArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Inc)
-			if err != nil {
-				return types.NiceArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Inc)
+      if err != nil {
+        return types.NiceArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFtimeArgs(decoder *Decoder) (types.FtimeArgs, error) {
-	return types.FtimeArgs{}, nil
+  return types.FtimeArgs{}, nil
 }
 
 func ParseProfArgs(decoder *Decoder) (types.ProfArgs, error) {
-	return types.ProfArgs{}, nil
+  return types.ProfArgs{}, nil
 }
 
 func ParseSignalArgs(decoder *Decoder) (types.SignalArgs, error) {
-	var result types.SignalArgs
-	var err error
+  var result types.SignalArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SignalArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SignalArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SignalArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SignalArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Signum)
-			if err != nil {
-				return types.SignalArgs{}, err
-			}
-		case 1:
-			var dataHandler uint64
-			err = decoder.DecodeUint64(&dataHandler)
-			if err != nil {
-				return types.SignalArgs{}, err
-			}
-			result.Handler = uintptr(dataHandler)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Signum)
+      if err != nil {
+        return types.SignalArgs{}, err
+      }
+    case 1:
+      var dataHandler uint64
+      err = decoder.DecodeUint64(&dataHandler)
+      if err != nil {
+        return types.SignalArgs{}, err
+      }
+      result.Handler = uintptr(dataHandler)
+    }
+  }
+  return result, nil
 }
 
 func ParseLockArgs(decoder *Decoder) (types.LockArgs, error) {
-	return types.LockArgs{}, nil
+  return types.LockArgs{}, nil
 }
 
 func ParseMpxArgs(decoder *Decoder) (types.MpxArgs, error) {
-	return types.MpxArgs{}, nil
+  return types.MpxArgs{}, nil
 }
 
 func ParseUlimitArgs(decoder *Decoder) (types.UlimitArgs, error) {
-	return types.UlimitArgs{}, nil
+  return types.UlimitArgs{}, nil
 }
 
 func ParseOldoldunameArgs(decoder *Decoder) (types.OldoldunameArgs, error) {
-	var result types.OldoldunameArgs
-	var err error
+  var result types.OldoldunameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OldoldunameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OldoldunameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OldoldunameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OldoldunameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataName uint64
-			err = decoder.DecodeUint64(&dataName)
-			if err != nil {
-				return types.OldoldunameArgs{}, err
-			}
-			result.Name = uintptr(dataName)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataName uint64
+      err = decoder.DecodeUint64(&dataName)
+      if err != nil {
+        return types.OldoldunameArgs{}, err
+      }
+      result.Name = uintptr(dataName)
+    }
+  }
+  return result, nil
 }
 
 func ParseSigactionArgs(decoder *Decoder) (types.SigactionArgs, error) {
-	var result types.SigactionArgs
-	var err error
+  var result types.SigactionArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SigactionArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SigactionArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SigactionArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SigactionArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.SigactionArgs{}, err
-			}
-		case 1:
-			var dataAct uint64
-			err = decoder.DecodeUint64(&dataAct)
-			if err != nil {
-				return types.SigactionArgs{}, err
-			}
-			result.Act = uintptr(dataAct)
-		case 2:
-			var dataOact uint64
-			err = decoder.DecodeUint64(&dataOact)
-			if err != nil {
-				return types.SigactionArgs{}, err
-			}
-			result.Oact = uintptr(dataOact)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.SigactionArgs{}, err
+      }
+    case 1:
+      var dataAct uint64
+      err = decoder.DecodeUint64(&dataAct)
+      if err != nil {
+        return types.SigactionArgs{}, err
+      }
+      result.Act = uintptr(dataAct)
+    case 2:
+      var dataOact uint64
+      err = decoder.DecodeUint64(&dataOact)
+      if err != nil {
+        return types.SigactionArgs{}, err
+      }
+      result.Oact = uintptr(dataOact)
+    }
+  }
+  return result, nil
 }
 
 func ParseSgetmaskArgs(decoder *Decoder) (types.SgetmaskArgs, error) {
-	return types.SgetmaskArgs{}, nil
+  return types.SgetmaskArgs{}, nil
 }
 
 func ParseSsetmaskArgs(decoder *Decoder) (types.SsetmaskArgs, error) {
-	var result types.SsetmaskArgs
-	var err error
+  var result types.SsetmaskArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SsetmaskArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SsetmaskArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SsetmaskArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SsetmaskArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt64(&result.Newmask)
-			if err != nil {
-				return types.SsetmaskArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt64(&result.Newmask)
+      if err != nil {
+        return types.SsetmaskArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSigsuspendArgs(decoder *Decoder) (types.SigsuspendArgs, error) {
-	var result types.SigsuspendArgs
-	var err error
+  var result types.SigsuspendArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SigsuspendArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SigsuspendArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SigsuspendArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SigsuspendArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataMask uint64
-			err = decoder.DecodeUint64(&dataMask)
-			if err != nil {
-				return types.SigsuspendArgs{}, err
-			}
-			result.Mask = uintptr(dataMask)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataMask uint64
+      err = decoder.DecodeUint64(&dataMask)
+      if err != nil {
+        return types.SigsuspendArgs{}, err
+      }
+      result.Mask = uintptr(dataMask)
+    }
+  }
+  return result, nil
 }
 
 func ParseSigpendingArgs(decoder *Decoder) (types.SigpendingArgs, error) {
-	var result types.SigpendingArgs
-	var err error
+  var result types.SigpendingArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SigpendingArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SigpendingArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SigpendingArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SigpendingArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataSet uint64
-			err = decoder.DecodeUint64(&dataSet)
-			if err != nil {
-				return types.SigpendingArgs{}, err
-			}
-			result.Set = uintptr(dataSet)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataSet uint64
+      err = decoder.DecodeUint64(&dataSet)
+      if err != nil {
+        return types.SigpendingArgs{}, err
+      }
+      result.Set = uintptr(dataSet)
+    }
+  }
+  return result, nil
 }
 
 func ParseOldlstatArgs(decoder *Decoder) (types.OldlstatArgs, error) {
-	var result types.OldlstatArgs
-	var err error
+  var result types.OldlstatArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OldlstatArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OldlstatArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OldlstatArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OldlstatArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.OldlstatArgs{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.OldlstatArgs{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.OldlstatArgs{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.OldlstatArgs{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseReaddirArgs(decoder *Decoder) (types.ReaddirArgs, error) {
-	var result types.ReaddirArgs
-	var err error
+  var result types.ReaddirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ReaddirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ReaddirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ReaddirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ReaddirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Fd)
-			if err != nil {
-				return types.ReaddirArgs{}, err
-			}
-		case 1:
-			var dataDirp uint64
-			err = decoder.DecodeUint64(&dataDirp)
-			if err != nil {
-				return types.ReaddirArgs{}, err
-			}
-			result.Dirp = uintptr(dataDirp)
-		case 2:
-			err = decoder.DecodeUint32(&result.Count)
-			if err != nil {
-				return types.ReaddirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Fd)
+      if err != nil {
+        return types.ReaddirArgs{}, err
+      }
+    case 1:
+      var dataDirp uint64
+      err = decoder.DecodeUint64(&dataDirp)
+      if err != nil {
+        return types.ReaddirArgs{}, err
+      }
+      result.Dirp = uintptr(dataDirp)
+    case 2:
+      err = decoder.DecodeUint32(&result.Count)
+      if err != nil {
+        return types.ReaddirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseProfilArgs(decoder *Decoder) (types.ProfilArgs, error) {
-	return types.ProfilArgs{}, nil
+  return types.ProfilArgs{}, nil
 }
 
 func ParseSocketcallArgs(decoder *Decoder) (types.SocketcallArgs, error) {
-	var result types.SocketcallArgs
-	var err error
+  var result types.SocketcallArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SocketcallArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SocketcallArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SocketcallArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SocketcallArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Call)
-			if err != nil {
-				return types.SocketcallArgs{}, err
-			}
-		case 1:
-			var dataArgs uint64
-			err = decoder.DecodeUint64(&dataArgs)
-			if err != nil {
-				return types.SocketcallArgs{}, err
-			}
-			result.Args = uintptr(dataArgs)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Call)
+      if err != nil {
+        return types.SocketcallArgs{}, err
+      }
+    case 1:
+      var dataArgs uint64
+      err = decoder.DecodeUint64(&dataArgs)
+      if err != nil {
+        return types.SocketcallArgs{}, err
+      }
+      result.Args = uintptr(dataArgs)
+    }
+  }
+  return result, nil
 }
 
 func ParseOldunameArgs(decoder *Decoder) (types.OldunameArgs, error) {
-	var result types.OldunameArgs
-	var err error
+  var result types.OldunameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OldunameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OldunameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OldunameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OldunameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.OldunameArgs{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.OldunameArgs{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseIdleArgs(decoder *Decoder) (types.IdleArgs, error) {
-	return types.IdleArgs{}, nil
+  return types.IdleArgs{}, nil
 }
 
 func ParseVm86oldArgs(decoder *Decoder) (types.Vm86oldArgs, error) {
-	var result types.Vm86oldArgs
-	var err error
+  var result types.Vm86oldArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Vm86oldArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Vm86oldArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Vm86oldArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Vm86oldArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataInfo uint64
-			err = decoder.DecodeUint64(&dataInfo)
-			if err != nil {
-				return types.Vm86oldArgs{}, err
-			}
-			result.Info = uintptr(dataInfo)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataInfo uint64
+      err = decoder.DecodeUint64(&dataInfo)
+      if err != nil {
+        return types.Vm86oldArgs{}, err
+      }
+      result.Info = uintptr(dataInfo)
+    }
+  }
+  return result, nil
 }
 
 func ParseIpcArgs(decoder *Decoder) (types.IpcArgs, error) {
-	var result types.IpcArgs
-	var err error
+  var result types.IpcArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.IpcArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.IpcArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.IpcArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.IpcArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Call)
-			if err != nil {
-				return types.IpcArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.First)
-			if err != nil {
-				return types.IpcArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Second)
-			if err != nil {
-				return types.IpcArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Third)
-			if err != nil {
-				return types.IpcArgs{}, err
-			}
-		case 4:
-			var dataPtr uint64
-			err = decoder.DecodeUint64(&dataPtr)
-			if err != nil {
-				return types.IpcArgs{}, err
-			}
-			result.Ptr = uintptr(dataPtr)
-		case 5:
-			err = decoder.DecodeInt64(&result.Fifth)
-			if err != nil {
-				return types.IpcArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Call)
+      if err != nil {
+        return types.IpcArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.First)
+      if err != nil {
+        return types.IpcArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Second)
+      if err != nil {
+        return types.IpcArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Third)
+      if err != nil {
+        return types.IpcArgs{}, err
+      }
+    case 4:
+      var dataPtr uint64
+      err = decoder.DecodeUint64(&dataPtr)
+      if err != nil {
+        return types.IpcArgs{}, err
+      }
+      result.Ptr = uintptr(dataPtr)
+    case 5:
+      err = decoder.DecodeInt64(&result.Fifth)
+      if err != nil {
+        return types.IpcArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSigreturnArgs(decoder *Decoder) (types.SigreturnArgs, error) {
-	return types.SigreturnArgs{}, nil
+  return types.SigreturnArgs{}, nil
 }
 
 func ParseSigprocmaskArgs(decoder *Decoder) (types.SigprocmaskArgs, error) {
-	var result types.SigprocmaskArgs
-	var err error
+  var result types.SigprocmaskArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SigprocmaskArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SigprocmaskArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SigprocmaskArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SigprocmaskArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.How)
-			if err != nil {
-				return types.SigprocmaskArgs{}, err
-			}
-		case 1:
-			var dataSet uint64
-			err = decoder.DecodeUint64(&dataSet)
-			if err != nil {
-				return types.SigprocmaskArgs{}, err
-			}
-			result.Set = uintptr(dataSet)
-		case 2:
-			var dataOldset uint64
-			err = decoder.DecodeUint64(&dataOldset)
-			if err != nil {
-				return types.SigprocmaskArgs{}, err
-			}
-			result.Oldset = uintptr(dataOldset)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.How)
+      if err != nil {
+        return types.SigprocmaskArgs{}, err
+      }
+    case 1:
+      var dataSet uint64
+      err = decoder.DecodeUint64(&dataSet)
+      if err != nil {
+        return types.SigprocmaskArgs{}, err
+      }
+      result.Set = uintptr(dataSet)
+    case 2:
+      var dataOldset uint64
+      err = decoder.DecodeUint64(&dataOldset)
+      if err != nil {
+        return types.SigprocmaskArgs{}, err
+      }
+      result.Oldset = uintptr(dataOldset)
+    }
+  }
+  return result, nil
 }
 
 func ParseBdflushArgs(decoder *Decoder) (types.BdflushArgs, error) {
-	return types.BdflushArgs{}, nil
+  return types.BdflushArgs{}, nil
 }
 
 func ParseAfs_syscallArgs(decoder *Decoder) (types.Afs_syscallArgs, error) {
-	return types.Afs_syscallArgs{}, nil
+  return types.Afs_syscallArgs{}, nil
 }
 
 func ParseLlseekArgs(decoder *Decoder) (types.LlseekArgs, error) {
-	var result types.LlseekArgs
-	var err error
+  var result types.LlseekArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LlseekArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LlseekArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LlseekArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LlseekArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Fd)
-			if err != nil {
-				return types.LlseekArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.OffsetHigh)
-			if err != nil {
-				return types.LlseekArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.OffsetLow)
-			if err != nil {
-				return types.LlseekArgs{}, err
-			}
-		case 3:
-			var dataResult uint64
-			err = decoder.DecodeUint64(&dataResult)
-			if err != nil {
-				return types.LlseekArgs{}, err
-			}
-			result.Result = uintptr(dataResult)
-		case 4:
-			err = decoder.DecodeUint32(&result.Whence)
-			if err != nil {
-				return types.LlseekArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Fd)
+      if err != nil {
+        return types.LlseekArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.OffsetHigh)
+      if err != nil {
+        return types.LlseekArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.OffsetLow)
+      if err != nil {
+        return types.LlseekArgs{}, err
+      }
+    case 3:
+      var dataResult uint64
+      err = decoder.DecodeUint64(&dataResult)
+      if err != nil {
+        return types.LlseekArgs{}, err
+      }
+      result.Result = uintptr(dataResult)
+    case 4:
+      err = decoder.DecodeUint32(&result.Whence)
+      if err != nil {
+        return types.LlseekArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseOldSelectArgs(decoder *Decoder) (types.OldSelectArgs, error) {
-	var result types.OldSelectArgs
-	var err error
+  var result types.OldSelectArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OldSelectArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OldSelectArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OldSelectArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OldSelectArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Nfds)
-			if err != nil {
-				return types.OldSelectArgs{}, err
-			}
-		case 1:
-			var dataReadfds uint64
-			err = decoder.DecodeUint64(&dataReadfds)
-			if err != nil {
-				return types.OldSelectArgs{}, err
-			}
-			result.Readfds = uintptr(dataReadfds)
-		case 2:
-			var dataWritefds uint64
-			err = decoder.DecodeUint64(&dataWritefds)
-			if err != nil {
-				return types.OldSelectArgs{}, err
-			}
-			result.Writefds = uintptr(dataWritefds)
-		case 3:
-			var dataExceptfds uint64
-			err = decoder.DecodeUint64(&dataExceptfds)
-			if err != nil {
-				return types.OldSelectArgs{}, err
-			}
-			result.Exceptfds = uintptr(dataExceptfds)
-		case 4:
-			var dataTimeout uint64
-			err = decoder.DecodeUint64(&dataTimeout)
-			if err != nil {
-				return types.OldSelectArgs{}, err
-			}
-			result.Timeout = uintptr(dataTimeout)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Nfds)
+      if err != nil {
+        return types.OldSelectArgs{}, err
+      }
+    case 1:
+      var dataReadfds uint64
+      err = decoder.DecodeUint64(&dataReadfds)
+      if err != nil {
+        return types.OldSelectArgs{}, err
+      }
+      result.Readfds = uintptr(dataReadfds)
+    case 2:
+      var dataWritefds uint64
+      err = decoder.DecodeUint64(&dataWritefds)
+      if err != nil {
+        return types.OldSelectArgs{}, err
+      }
+      result.Writefds = uintptr(dataWritefds)
+    case 3:
+      var dataExceptfds uint64
+      err = decoder.DecodeUint64(&dataExceptfds)
+      if err != nil {
+        return types.OldSelectArgs{}, err
+      }
+      result.Exceptfds = uintptr(dataExceptfds)
+    case 4:
+      var dataTimeout uint64
+      err = decoder.DecodeUint64(&dataTimeout)
+      if err != nil {
+        return types.OldSelectArgs{}, err
+      }
+      result.Timeout = uintptr(dataTimeout)
+    }
+  }
+  return result, nil
 }
 
 func ParseVm86Args(decoder *Decoder) (types.Vm86Args, error) {
-	var result types.Vm86Args
-	var err error
+  var result types.Vm86Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Vm86Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Vm86Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Vm86Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Vm86Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Fn)
-			if err != nil {
-				return types.Vm86Args{}, err
-			}
-		case 1:
-			var dataV86 uint64
-			err = decoder.DecodeUint64(&dataV86)
-			if err != nil {
-				return types.Vm86Args{}, err
-			}
-			result.V86 = uintptr(dataV86)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Fn)
+      if err != nil {
+        return types.Vm86Args{}, err
+      }
+    case 1:
+      var dataV86 uint64
+      err = decoder.DecodeUint64(&dataV86)
+      if err != nil {
+        return types.Vm86Args{}, err
+      }
+      result.V86 = uintptr(dataV86)
+    }
+  }
+  return result, nil
 }
 
 func ParseOldGetrlimitArgs(decoder *Decoder) (types.OldGetrlimitArgs, error) {
-	var result types.OldGetrlimitArgs
-	var err error
+  var result types.OldGetrlimitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.OldGetrlimitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.OldGetrlimitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.OldGetrlimitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.OldGetrlimitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Resource)
-			if err != nil {
-				return types.OldGetrlimitArgs{}, err
-			}
-		case 1:
-			var dataRlim uint64
-			err = decoder.DecodeUint64(&dataRlim)
-			if err != nil {
-				return types.OldGetrlimitArgs{}, err
-			}
-			result.Rlim = uintptr(dataRlim)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Resource)
+      if err != nil {
+        return types.OldGetrlimitArgs{}, err
+      }
+    case 1:
+      var dataRlim uint64
+      err = decoder.DecodeUint64(&dataRlim)
+      if err != nil {
+        return types.OldGetrlimitArgs{}, err
+      }
+      result.Rlim = uintptr(dataRlim)
+    }
+  }
+  return result, nil
 }
 
 func ParseMmap2Args(decoder *Decoder) (types.Mmap2Args, error) {
-	var result types.Mmap2Args
-	var err error
+  var result types.Mmap2Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Mmap2Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Mmap2Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Mmap2Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Mmap2Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Addr)
-			if err != nil {
-				return types.Mmap2Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.Mmap2Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Prot)
-			if err != nil {
-				return types.Mmap2Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.Mmap2Args{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Fd)
-			if err != nil {
-				return types.Mmap2Args{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.Pgoffset)
-			if err != nil {
-				return types.Mmap2Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Addr)
+      if err != nil {
+        return types.Mmap2Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.Mmap2Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Prot)
+      if err != nil {
+        return types.Mmap2Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.Mmap2Args{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Fd)
+      if err != nil {
+        return types.Mmap2Args{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.Pgoffset)
+      if err != nil {
+        return types.Mmap2Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTruncate64Args(decoder *Decoder) (types.Truncate64Args, error) {
-	var result types.Truncate64Args
-	var err error
+  var result types.Truncate64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Truncate64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Truncate64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Truncate64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Truncate64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Truncate64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.Truncate64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Truncate64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.Truncate64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFtruncate64Args(decoder *Decoder) (types.Ftruncate64Args, error) {
-	var result types.Ftruncate64Args
-	var err error
+  var result types.Ftruncate64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Ftruncate64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Ftruncate64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Ftruncate64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Ftruncate64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Ftruncate64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.Ftruncate64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Ftruncate64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.Ftruncate64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseStat64Args(decoder *Decoder) (types.Stat64Args, error) {
-	var result types.Stat64Args
-	var err error
+  var result types.Stat64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Stat64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Stat64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Stat64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Stat64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Stat64Args{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.Stat64Args{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Stat64Args{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.Stat64Args{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseLstat64Args(decoder *Decoder) (types.Lstat64Args, error) {
-	var result types.Lstat64Args
-	var err error
+  var result types.Lstat64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Lstat64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Lstat64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Lstat64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Lstat64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Lstat64Args{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.Lstat64Args{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Lstat64Args{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.Lstat64Args{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseFstat64Args(decoder *Decoder) (types.Fstat64Args, error) {
-	var result types.Fstat64Args
-	var err error
+  var result types.Fstat64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Fstat64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Fstat64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Fstat64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Fstat64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Fstat64Args{}, err
-			}
-		case 1:
-			var dataStatbuf uint64
-			err = decoder.DecodeUint64(&dataStatbuf)
-			if err != nil {
-				return types.Fstat64Args{}, err
-			}
-			result.Statbuf = uintptr(dataStatbuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Fstat64Args{}, err
+      }
+    case 1:
+      var dataStatbuf uint64
+      err = decoder.DecodeUint64(&dataStatbuf)
+      if err != nil {
+        return types.Fstat64Args{}, err
+      }
+      result.Statbuf = uintptr(dataStatbuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseLchown16Args(decoder *Decoder) (types.Lchown16Args, error) {
-	var result types.Lchown16Args
-	var err error
+  var result types.Lchown16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Lchown16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Lchown16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Lchown16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Lchown16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Lchown16Args{}, err
-			}
-		case 1:
-			var dataOwner uint64
-			err = decoder.DecodeUint64(&dataOwner)
-			if err != nil {
-				return types.Lchown16Args{}, err
-			}
-			result.Owner = uintptr(dataOwner)
-		case 2:
-			var dataGroup uint64
-			err = decoder.DecodeUint64(&dataGroup)
-			if err != nil {
-				return types.Lchown16Args{}, err
-			}
-			result.Group = uintptr(dataGroup)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Lchown16Args{}, err
+      }
+    case 1:
+      var dataOwner uint64
+      err = decoder.DecodeUint64(&dataOwner)
+      if err != nil {
+        return types.Lchown16Args{}, err
+      }
+      result.Owner = uintptr(dataOwner)
+    case 2:
+      var dataGroup uint64
+      err = decoder.DecodeUint64(&dataGroup)
+      if err != nil {
+        return types.Lchown16Args{}, err
+      }
+      result.Group = uintptr(dataGroup)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetuid16Args(decoder *Decoder) (types.Getuid16Args, error) {
-	return types.Getuid16Args{}, nil
+  return types.Getuid16Args{}, nil
 }
 
 func ParseGetgid16Args(decoder *Decoder) (types.Getgid16Args, error) {
-	return types.Getgid16Args{}, nil
+  return types.Getgid16Args{}, nil
 }
 
 func ParseGeteuid16Args(decoder *Decoder) (types.Geteuid16Args, error) {
-	return types.Geteuid16Args{}, nil
+  return types.Geteuid16Args{}, nil
 }
 
 func ParseGetegid16Args(decoder *Decoder) (types.Getegid16Args, error) {
-	return types.Getegid16Args{}, nil
+  return types.Getegid16Args{}, nil
 }
 
 func ParseSetreuid16Args(decoder *Decoder) (types.Setreuid16Args, error) {
-	var result types.Setreuid16Args
-	var err error
+  var result types.Setreuid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setreuid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setreuid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setreuid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setreuid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRuid uint64
-			err = decoder.DecodeUint64(&dataRuid)
-			if err != nil {
-				return types.Setreuid16Args{}, err
-			}
-			result.Ruid = uintptr(dataRuid)
-		case 1:
-			var dataEuid uint64
-			err = decoder.DecodeUint64(&dataEuid)
-			if err != nil {
-				return types.Setreuid16Args{}, err
-			}
-			result.Euid = uintptr(dataEuid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRuid uint64
+      err = decoder.DecodeUint64(&dataRuid)
+      if err != nil {
+        return types.Setreuid16Args{}, err
+      }
+      result.Ruid = uintptr(dataRuid)
+    case 1:
+      var dataEuid uint64
+      err = decoder.DecodeUint64(&dataEuid)
+      if err != nil {
+        return types.Setreuid16Args{}, err
+      }
+      result.Euid = uintptr(dataEuid)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetregid16Args(decoder *Decoder) (types.Setregid16Args, error) {
-	var result types.Setregid16Args
-	var err error
+  var result types.Setregid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setregid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setregid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setregid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setregid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRgid uint64
-			err = decoder.DecodeUint64(&dataRgid)
-			if err != nil {
-				return types.Setregid16Args{}, err
-			}
-			result.Rgid = uintptr(dataRgid)
-		case 1:
-			var dataEgid uint64
-			err = decoder.DecodeUint64(&dataEgid)
-			if err != nil {
-				return types.Setregid16Args{}, err
-			}
-			result.Egid = uintptr(dataEgid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRgid uint64
+      err = decoder.DecodeUint64(&dataRgid)
+      if err != nil {
+        return types.Setregid16Args{}, err
+      }
+      result.Rgid = uintptr(dataRgid)
+    case 1:
+      var dataEgid uint64
+      err = decoder.DecodeUint64(&dataEgid)
+      if err != nil {
+        return types.Setregid16Args{}, err
+      }
+      result.Egid = uintptr(dataEgid)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetgroups16Args(decoder *Decoder) (types.Getgroups16Args, error) {
-	var result types.Getgroups16Args
-	var err error
+  var result types.Getgroups16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Getgroups16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Getgroups16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Getgroups16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Getgroups16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Size)
-			if err != nil {
-				return types.Getgroups16Args{}, err
-			}
-		case 1:
-			var dataList uint64
-			err = decoder.DecodeUint64(&dataList)
-			if err != nil {
-				return types.Getgroups16Args{}, err
-			}
-			result.List = uintptr(dataList)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Size)
+      if err != nil {
+        return types.Getgroups16Args{}, err
+      }
+    case 1:
+      var dataList uint64
+      err = decoder.DecodeUint64(&dataList)
+      if err != nil {
+        return types.Getgroups16Args{}, err
+      }
+      result.List = uintptr(dataList)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetgroups16Args(decoder *Decoder) (types.Setgroups16Args, error) {
-	var result types.Setgroups16Args
-	var err error
+  var result types.Setgroups16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setgroups16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setgroups16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setgroups16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setgroups16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Size)
-			if err != nil {
-				return types.Setgroups16Args{}, err
-			}
-		case 1:
-			var dataList uint64
-			err = decoder.DecodeUint64(&dataList)
-			if err != nil {
-				return types.Setgroups16Args{}, err
-			}
-			result.List = uintptr(dataList)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Size)
+      if err != nil {
+        return types.Setgroups16Args{}, err
+      }
+    case 1:
+      var dataList uint64
+      err = decoder.DecodeUint64(&dataList)
+      if err != nil {
+        return types.Setgroups16Args{}, err
+      }
+      result.List = uintptr(dataList)
+    }
+  }
+  return result, nil
 }
 
 func ParseFchown16Args(decoder *Decoder) (types.Fchown16Args, error) {
-	var result types.Fchown16Args
-	var err error
+  var result types.Fchown16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Fchown16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Fchown16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Fchown16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Fchown16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Fd)
-			if err != nil {
-				return types.Fchown16Args{}, err
-			}
-		case 1:
-			var dataUser uint64
-			err = decoder.DecodeUint64(&dataUser)
-			if err != nil {
-				return types.Fchown16Args{}, err
-			}
-			result.User = uintptr(dataUser)
-		case 2:
-			var dataGroup uint64
-			err = decoder.DecodeUint64(&dataGroup)
-			if err != nil {
-				return types.Fchown16Args{}, err
-			}
-			result.Group = uintptr(dataGroup)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Fd)
+      if err != nil {
+        return types.Fchown16Args{}, err
+      }
+    case 1:
+      var dataUser uint64
+      err = decoder.DecodeUint64(&dataUser)
+      if err != nil {
+        return types.Fchown16Args{}, err
+      }
+      result.User = uintptr(dataUser)
+    case 2:
+      var dataGroup uint64
+      err = decoder.DecodeUint64(&dataGroup)
+      if err != nil {
+        return types.Fchown16Args{}, err
+      }
+      result.Group = uintptr(dataGroup)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetresuid16Args(decoder *Decoder) (types.Setresuid16Args, error) {
-	var result types.Setresuid16Args
-	var err error
+  var result types.Setresuid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setresuid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setresuid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setresuid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setresuid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRuid uint64
-			err = decoder.DecodeUint64(&dataRuid)
-			if err != nil {
-				return types.Setresuid16Args{}, err
-			}
-			result.Ruid = uintptr(dataRuid)
-		case 1:
-			var dataEuid uint64
-			err = decoder.DecodeUint64(&dataEuid)
-			if err != nil {
-				return types.Setresuid16Args{}, err
-			}
-			result.Euid = uintptr(dataEuid)
-		case 2:
-			var dataSuid uint64
-			err = decoder.DecodeUint64(&dataSuid)
-			if err != nil {
-				return types.Setresuid16Args{}, err
-			}
-			result.Suid = uintptr(dataSuid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRuid uint64
+      err = decoder.DecodeUint64(&dataRuid)
+      if err != nil {
+        return types.Setresuid16Args{}, err
+      }
+      result.Ruid = uintptr(dataRuid)
+    case 1:
+      var dataEuid uint64
+      err = decoder.DecodeUint64(&dataEuid)
+      if err != nil {
+        return types.Setresuid16Args{}, err
+      }
+      result.Euid = uintptr(dataEuid)
+    case 2:
+      var dataSuid uint64
+      err = decoder.DecodeUint64(&dataSuid)
+      if err != nil {
+        return types.Setresuid16Args{}, err
+      }
+      result.Suid = uintptr(dataSuid)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetresuid16Args(decoder *Decoder) (types.Getresuid16Args, error) {
-	var result types.Getresuid16Args
-	var err error
+  var result types.Getresuid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Getresuid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Getresuid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Getresuid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Getresuid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRuid uint64
-			err = decoder.DecodeUint64(&dataRuid)
-			if err != nil {
-				return types.Getresuid16Args{}, err
-			}
-			result.Ruid = uintptr(dataRuid)
-		case 1:
-			var dataEuid uint64
-			err = decoder.DecodeUint64(&dataEuid)
-			if err != nil {
-				return types.Getresuid16Args{}, err
-			}
-			result.Euid = uintptr(dataEuid)
-		case 2:
-			var dataSuid uint64
-			err = decoder.DecodeUint64(&dataSuid)
-			if err != nil {
-				return types.Getresuid16Args{}, err
-			}
-			result.Suid = uintptr(dataSuid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRuid uint64
+      err = decoder.DecodeUint64(&dataRuid)
+      if err != nil {
+        return types.Getresuid16Args{}, err
+      }
+      result.Ruid = uintptr(dataRuid)
+    case 1:
+      var dataEuid uint64
+      err = decoder.DecodeUint64(&dataEuid)
+      if err != nil {
+        return types.Getresuid16Args{}, err
+      }
+      result.Euid = uintptr(dataEuid)
+    case 2:
+      var dataSuid uint64
+      err = decoder.DecodeUint64(&dataSuid)
+      if err != nil {
+        return types.Getresuid16Args{}, err
+      }
+      result.Suid = uintptr(dataSuid)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetresgid16Args(decoder *Decoder) (types.Setresgid16Args, error) {
-	var result types.Setresgid16Args
-	var err error
+  var result types.Setresgid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setresgid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setresgid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setresgid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setresgid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRgid uint64
-			err = decoder.DecodeUint64(&dataRgid)
-			if err != nil {
-				return types.Setresgid16Args{}, err
-			}
-			result.Rgid = uintptr(dataRgid)
-		case 1:
-			var dataEuid uint64
-			err = decoder.DecodeUint64(&dataEuid)
-			if err != nil {
-				return types.Setresgid16Args{}, err
-			}
-			result.Euid = uintptr(dataEuid)
-		case 2:
-			var dataSuid uint64
-			err = decoder.DecodeUint64(&dataSuid)
-			if err != nil {
-				return types.Setresgid16Args{}, err
-			}
-			result.Suid = uintptr(dataSuid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRgid uint64
+      err = decoder.DecodeUint64(&dataRgid)
+      if err != nil {
+        return types.Setresgid16Args{}, err
+      }
+      result.Rgid = uintptr(dataRgid)
+    case 1:
+      var dataEuid uint64
+      err = decoder.DecodeUint64(&dataEuid)
+      if err != nil {
+        return types.Setresgid16Args{}, err
+      }
+      result.Euid = uintptr(dataEuid)
+    case 2:
+      var dataSuid uint64
+      err = decoder.DecodeUint64(&dataSuid)
+      if err != nil {
+        return types.Setresgid16Args{}, err
+      }
+      result.Suid = uintptr(dataSuid)
+    }
+  }
+  return result, nil
 }
 
 func ParseGetresgid16Args(decoder *Decoder) (types.Getresgid16Args, error) {
-	var result types.Getresgid16Args
-	var err error
+  var result types.Getresgid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Getresgid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Getresgid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Getresgid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Getresgid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataRgid uint64
-			err = decoder.DecodeUint64(&dataRgid)
-			if err != nil {
-				return types.Getresgid16Args{}, err
-			}
-			result.Rgid = uintptr(dataRgid)
-		case 1:
-			var dataEgid uint64
-			err = decoder.DecodeUint64(&dataEgid)
-			if err != nil {
-				return types.Getresgid16Args{}, err
-			}
-			result.Egid = uintptr(dataEgid)
-		case 2:
-			var dataSgid uint64
-			err = decoder.DecodeUint64(&dataSgid)
-			if err != nil {
-				return types.Getresgid16Args{}, err
-			}
-			result.Sgid = uintptr(dataSgid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataRgid uint64
+      err = decoder.DecodeUint64(&dataRgid)
+      if err != nil {
+        return types.Getresgid16Args{}, err
+      }
+      result.Rgid = uintptr(dataRgid)
+    case 1:
+      var dataEgid uint64
+      err = decoder.DecodeUint64(&dataEgid)
+      if err != nil {
+        return types.Getresgid16Args{}, err
+      }
+      result.Egid = uintptr(dataEgid)
+    case 2:
+      var dataSgid uint64
+      err = decoder.DecodeUint64(&dataSgid)
+      if err != nil {
+        return types.Getresgid16Args{}, err
+      }
+      result.Sgid = uintptr(dataSgid)
+    }
+  }
+  return result, nil
 }
 
 func ParseChown16Args(decoder *Decoder) (types.Chown16Args, error) {
-	var result types.Chown16Args
-	var err error
+  var result types.Chown16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Chown16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Chown16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Chown16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Chown16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Chown16Args{}, err
-			}
-		case 1:
-			var dataOwner uint64
-			err = decoder.DecodeUint64(&dataOwner)
-			if err != nil {
-				return types.Chown16Args{}, err
-			}
-			result.Owner = uintptr(dataOwner)
-		case 2:
-			var dataGroup uint64
-			err = decoder.DecodeUint64(&dataGroup)
-			if err != nil {
-				return types.Chown16Args{}, err
-			}
-			result.Group = uintptr(dataGroup)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Chown16Args{}, err
+      }
+    case 1:
+      var dataOwner uint64
+      err = decoder.DecodeUint64(&dataOwner)
+      if err != nil {
+        return types.Chown16Args{}, err
+      }
+      result.Owner = uintptr(dataOwner)
+    case 2:
+      var dataGroup uint64
+      err = decoder.DecodeUint64(&dataGroup)
+      if err != nil {
+        return types.Chown16Args{}, err
+      }
+      result.Group = uintptr(dataGroup)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetuid16Args(decoder *Decoder) (types.Setuid16Args, error) {
-	var result types.Setuid16Args
-	var err error
+  var result types.Setuid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setuid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setuid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setuid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setuid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataUid uint64
-			err = decoder.DecodeUint64(&dataUid)
-			if err != nil {
-				return types.Setuid16Args{}, err
-			}
-			result.Uid = uintptr(dataUid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataUid uint64
+      err = decoder.DecodeUint64(&dataUid)
+      if err != nil {
+        return types.Setuid16Args{}, err
+      }
+      result.Uid = uintptr(dataUid)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetgid16Args(decoder *Decoder) (types.Setgid16Args, error) {
-	var result types.Setgid16Args
-	var err error
+  var result types.Setgid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setgid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setgid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setgid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setgid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataGid uint64
-			err = decoder.DecodeUint64(&dataGid)
-			if err != nil {
-				return types.Setgid16Args{}, err
-			}
-			result.Gid = uintptr(dataGid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataGid uint64
+      err = decoder.DecodeUint64(&dataGid)
+      if err != nil {
+        return types.Setgid16Args{}, err
+      }
+      result.Gid = uintptr(dataGid)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetfsuid16Args(decoder *Decoder) (types.Setfsuid16Args, error) {
-	var result types.Setfsuid16Args
-	var err error
+  var result types.Setfsuid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setfsuid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setfsuid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setfsuid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setfsuid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataFsuid uint64
-			err = decoder.DecodeUint64(&dataFsuid)
-			if err != nil {
-				return types.Setfsuid16Args{}, err
-			}
-			result.Fsuid = uintptr(dataFsuid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataFsuid uint64
+      err = decoder.DecodeUint64(&dataFsuid)
+      if err != nil {
+        return types.Setfsuid16Args{}, err
+      }
+      result.Fsuid = uintptr(dataFsuid)
+    }
+  }
+  return result, nil
 }
 
 func ParseSetfsgid16Args(decoder *Decoder) (types.Setfsgid16Args, error) {
-	var result types.Setfsgid16Args
-	var err error
+  var result types.Setfsgid16Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Setfsgid16Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Setfsgid16Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Setfsgid16Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Setfsgid16Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataFsgid uint64
-			err = decoder.DecodeUint64(&dataFsgid)
-			if err != nil {
-				return types.Setfsgid16Args{}, err
-			}
-			result.Fsgid = uintptr(dataFsgid)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataFsgid uint64
+      err = decoder.DecodeUint64(&dataFsgid)
+      if err != nil {
+        return types.Setfsgid16Args{}, err
+      }
+      result.Fsgid = uintptr(dataFsgid)
+    }
+  }
+  return result, nil
 }
 
 func ParseFcntl64Args(decoder *Decoder) (types.Fcntl64Args, error) {
-	var result types.Fcntl64Args
-	var err error
+  var result types.Fcntl64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Fcntl64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Fcntl64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Fcntl64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Fcntl64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Fcntl64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.Fcntl64Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Arg)
-			if err != nil {
-				return types.Fcntl64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Fcntl64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.Fcntl64Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Arg)
+      if err != nil {
+        return types.Fcntl64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSendfile32Args(decoder *Decoder) (types.Sendfile32Args, error) {
-	var result types.Sendfile32Args
-	var err error
+  var result types.Sendfile32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Sendfile32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Sendfile32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Sendfile32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Sendfile32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.OutFd)
-			if err != nil {
-				return types.Sendfile32Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.InFd)
-			if err != nil {
-				return types.Sendfile32Args{}, err
-			}
-		case 2:
-			var dataOffset uint64
-			err = decoder.DecodeUint64(&dataOffset)
-			if err != nil {
-				return types.Sendfile32Args{}, err
-			}
-			result.Offset = uintptr(dataOffset)
-		case 3:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.Sendfile32Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.OutFd)
+      if err != nil {
+        return types.Sendfile32Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.InFd)
+      if err != nil {
+        return types.Sendfile32Args{}, err
+      }
+    case 2:
+      var dataOffset uint64
+      err = decoder.DecodeUint64(&dataOffset)
+      if err != nil {
+        return types.Sendfile32Args{}, err
+      }
+      result.Offset = uintptr(dataOffset)
+    case 3:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.Sendfile32Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseStatfs64Args(decoder *Decoder) (types.Statfs64Args, error) {
-	var result types.Statfs64Args
-	var err error
+  var result types.Statfs64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Statfs64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Statfs64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Statfs64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Statfs64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.Statfs64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Sz)
-			if err != nil {
-				return types.Statfs64Args{}, err
-			}
-		case 2:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.Statfs64Args{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.Statfs64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Sz)
+      if err != nil {
+        return types.Statfs64Args{}, err
+      }
+    case 2:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.Statfs64Args{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseFstatfs64Args(decoder *Decoder) (types.Fstatfs64Args, error) {
-	var result types.Fstatfs64Args
-	var err error
+  var result types.Fstatfs64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Fstatfs64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Fstatfs64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Fstatfs64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Fstatfs64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Fstatfs64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Sz)
-			if err != nil {
-				return types.Fstatfs64Args{}, err
-			}
-		case 2:
-			var dataBuf uint64
-			err = decoder.DecodeUint64(&dataBuf)
-			if err != nil {
-				return types.Fstatfs64Args{}, err
-			}
-			result.Buf = uintptr(dataBuf)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Fstatfs64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Sz)
+      if err != nil {
+        return types.Fstatfs64Args{}, err
+      }
+    case 2:
+      var dataBuf uint64
+      err = decoder.DecodeUint64(&dataBuf)
+      if err != nil {
+        return types.Fstatfs64Args{}, err
+      }
+      result.Buf = uintptr(dataBuf)
+    }
+  }
+  return result, nil
 }
 
 func ParseFadvise64_64Args(decoder *Decoder) (types.Fadvise64_64Args, error) {
-	var result types.Fadvise64_64Args
-	var err error
+  var result types.Fadvise64_64Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Fadvise64_64Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Fadvise64_64Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Fadvise64_64Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Fadvise64_64Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.Fadvise64_64Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Offset)
-			if err != nil {
-				return types.Fadvise64_64Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.Fadvise64_64Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Advice)
-			if err != nil {
-				return types.Fadvise64_64Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.Fadvise64_64Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Offset)
+      if err != nil {
+        return types.Fadvise64_64Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.Fadvise64_64Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Advice)
+      if err != nil {
+        return types.Fadvise64_64Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseClockGettime32Args(decoder *Decoder) (types.ClockGettime32Args, error) {
-	var result types.ClockGettime32Args
-	var err error
+  var result types.ClockGettime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockGettime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockGettime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockGettime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockGettime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.WhichClock)
-			if err != nil {
-				return types.ClockGettime32Args{}, err
-			}
-		case 1:
-			var dataTp uint64
-			err = decoder.DecodeUint64(&dataTp)
-			if err != nil {
-				return types.ClockGettime32Args{}, err
-			}
-			result.Tp = uintptr(dataTp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.WhichClock)
+      if err != nil {
+        return types.ClockGettime32Args{}, err
+      }
+    case 1:
+      var dataTp uint64
+      err = decoder.DecodeUint64(&dataTp)
+      if err != nil {
+        return types.ClockGettime32Args{}, err
+      }
+      result.Tp = uintptr(dataTp)
+    }
+  }
+  return result, nil
 }
 
 func ParseClockSettime32Args(decoder *Decoder) (types.ClockSettime32Args, error) {
-	var result types.ClockSettime32Args
-	var err error
+  var result types.ClockSettime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockSettime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockSettime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockSettime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockSettime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.WhichClock)
-			if err != nil {
-				return types.ClockSettime32Args{}, err
-			}
-		case 1:
-			var dataTp uint64
-			err = decoder.DecodeUint64(&dataTp)
-			if err != nil {
-				return types.ClockSettime32Args{}, err
-			}
-			result.Tp = uintptr(dataTp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.WhichClock)
+      if err != nil {
+        return types.ClockSettime32Args{}, err
+      }
+    case 1:
+      var dataTp uint64
+      err = decoder.DecodeUint64(&dataTp)
+      if err != nil {
+        return types.ClockSettime32Args{}, err
+      }
+      result.Tp = uintptr(dataTp)
+    }
+  }
+  return result, nil
 }
 
 func ParseClockAdjtime64Args(decoder *Decoder) (types.ClockAdjtime64Args, error) {
-	return types.ClockAdjtime64Args{}, nil
+  return types.ClockAdjtime64Args{}, nil
 }
 
 func ParseClockGetresTime32Args(decoder *Decoder) (types.ClockGetresTime32Args, error) {
-	var result types.ClockGetresTime32Args
-	var err error
+  var result types.ClockGetresTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockGetresTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockGetresTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockGetresTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockGetresTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.WhichClock)
-			if err != nil {
-				return types.ClockGetresTime32Args{}, err
-			}
-		case 1:
-			var dataTp uint64
-			err = decoder.DecodeUint64(&dataTp)
-			if err != nil {
-				return types.ClockGetresTime32Args{}, err
-			}
-			result.Tp = uintptr(dataTp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.WhichClock)
+      if err != nil {
+        return types.ClockGetresTime32Args{}, err
+      }
+    case 1:
+      var dataTp uint64
+      err = decoder.DecodeUint64(&dataTp)
+      if err != nil {
+        return types.ClockGetresTime32Args{}, err
+      }
+      result.Tp = uintptr(dataTp)
+    }
+  }
+  return result, nil
 }
 
 func ParseClockNanosleepTime32Args(decoder *Decoder) (types.ClockNanosleepTime32Args, error) {
-	var result types.ClockNanosleepTime32Args
-	var err error
+  var result types.ClockNanosleepTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ClockNanosleepTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ClockNanosleepTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ClockNanosleepTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ClockNanosleepTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.WhichClock)
-			if err != nil {
-				return types.ClockNanosleepTime32Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.ClockNanosleepTime32Args{}, err
-			}
-		case 2:
-			var dataRqtp uint64
-			err = decoder.DecodeUint64(&dataRqtp)
-			if err != nil {
-				return types.ClockNanosleepTime32Args{}, err
-			}
-			result.Rqtp = uintptr(dataRqtp)
-		case 3:
-			var dataRmtp uint64
-			err = decoder.DecodeUint64(&dataRmtp)
-			if err != nil {
-				return types.ClockNanosleepTime32Args{}, err
-			}
-			result.Rmtp = uintptr(dataRmtp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.WhichClock)
+      if err != nil {
+        return types.ClockNanosleepTime32Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.ClockNanosleepTime32Args{}, err
+      }
+    case 2:
+      var dataRqtp uint64
+      err = decoder.DecodeUint64(&dataRqtp)
+      if err != nil {
+        return types.ClockNanosleepTime32Args{}, err
+      }
+      result.Rqtp = uintptr(dataRqtp)
+    case 3:
+      var dataRmtp uint64
+      err = decoder.DecodeUint64(&dataRmtp)
+      if err != nil {
+        return types.ClockNanosleepTime32Args{}, err
+      }
+      result.Rmtp = uintptr(dataRmtp)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerGettime32Args(decoder *Decoder) (types.TimerGettime32Args, error) {
-	var result types.TimerGettime32Args
-	var err error
+  var result types.TimerGettime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerGettime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerGettime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerGettime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerGettime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.TimerId)
-			if err != nil {
-				return types.TimerGettime32Args{}, err
-			}
-		case 1:
-			var dataSetting uint64
-			err = decoder.DecodeUint64(&dataSetting)
-			if err != nil {
-				return types.TimerGettime32Args{}, err
-			}
-			result.Setting = uintptr(dataSetting)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.TimerId)
+      if err != nil {
+        return types.TimerGettime32Args{}, err
+      }
+    case 1:
+      var dataSetting uint64
+      err = decoder.DecodeUint64(&dataSetting)
+      if err != nil {
+        return types.TimerGettime32Args{}, err
+      }
+      result.Setting = uintptr(dataSetting)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerSettime32Args(decoder *Decoder) (types.TimerSettime32Args, error) {
-	var result types.TimerSettime32Args
-	var err error
+  var result types.TimerSettime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerSettime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerSettime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerSettime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerSettime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.TimerId)
-			if err != nil {
-				return types.TimerSettime32Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.TimerSettime32Args{}, err
-			}
-		case 2:
-			var dataNew uint64
-			err = decoder.DecodeUint64(&dataNew)
-			if err != nil {
-				return types.TimerSettime32Args{}, err
-			}
-			result.New = uintptr(dataNew)
-		case 3:
-			var dataOld uint64
-			err = decoder.DecodeUint64(&dataOld)
-			if err != nil {
-				return types.TimerSettime32Args{}, err
-			}
-			result.Old = uintptr(dataOld)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.TimerId)
+      if err != nil {
+        return types.TimerSettime32Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.TimerSettime32Args{}, err
+      }
+    case 2:
+      var dataNew uint64
+      err = decoder.DecodeUint64(&dataNew)
+      if err != nil {
+        return types.TimerSettime32Args{}, err
+      }
+      result.New = uintptr(dataNew)
+    case 3:
+      var dataOld uint64
+      err = decoder.DecodeUint64(&dataOld)
+      if err != nil {
+        return types.TimerSettime32Args{}, err
+      }
+      result.Old = uintptr(dataOld)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerfdGettime32Args(decoder *Decoder) (types.TimerfdGettime32Args, error) {
-	var result types.TimerfdGettime32Args
-	var err error
+  var result types.TimerfdGettime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerfdGettime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerfdGettime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerfdGettime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerfdGettime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Ufd)
-			if err != nil {
-				return types.TimerfdGettime32Args{}, err
-			}
-		case 1:
-			var dataOtmr uint64
-			err = decoder.DecodeUint64(&dataOtmr)
-			if err != nil {
-				return types.TimerfdGettime32Args{}, err
-			}
-			result.Otmr = uintptr(dataOtmr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Ufd)
+      if err != nil {
+        return types.TimerfdGettime32Args{}, err
+      }
+    case 1:
+      var dataOtmr uint64
+      err = decoder.DecodeUint64(&dataOtmr)
+      if err != nil {
+        return types.TimerfdGettime32Args{}, err
+      }
+      result.Otmr = uintptr(dataOtmr)
+    }
+  }
+  return result, nil
 }
 
 func ParseTimerfdSettime32Args(decoder *Decoder) (types.TimerfdSettime32Args, error) {
-	var result types.TimerfdSettime32Args
-	var err error
+  var result types.TimerfdSettime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TimerfdSettime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TimerfdSettime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TimerfdSettime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TimerfdSettime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Ufd)
-			if err != nil {
-				return types.TimerfdSettime32Args{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.TimerfdSettime32Args{}, err
-			}
-		case 2:
-			var dataUtmr uint64
-			err = decoder.DecodeUint64(&dataUtmr)
-			if err != nil {
-				return types.TimerfdSettime32Args{}, err
-			}
-			result.Utmr = uintptr(dataUtmr)
-		case 3:
-			var dataOtmr uint64
-			err = decoder.DecodeUint64(&dataOtmr)
-			if err != nil {
-				return types.TimerfdSettime32Args{}, err
-			}
-			result.Otmr = uintptr(dataOtmr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Ufd)
+      if err != nil {
+        return types.TimerfdSettime32Args{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.TimerfdSettime32Args{}, err
+      }
+    case 2:
+      var dataUtmr uint64
+      err = decoder.DecodeUint64(&dataUtmr)
+      if err != nil {
+        return types.TimerfdSettime32Args{}, err
+      }
+      result.Utmr = uintptr(dataUtmr)
+    case 3:
+      var dataOtmr uint64
+      err = decoder.DecodeUint64(&dataOtmr)
+      if err != nil {
+        return types.TimerfdSettime32Args{}, err
+      }
+      result.Otmr = uintptr(dataOtmr)
+    }
+  }
+  return result, nil
 }
 
 func ParseUtimensatTime32Args(decoder *Decoder) (types.UtimensatTime32Args, error) {
-	var result types.UtimensatTime32Args
-	var err error
+  var result types.UtimensatTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.UtimensatTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.UtimensatTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.UtimensatTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.UtimensatTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Dfd)
-			if err != nil {
-				return types.UtimensatTime32Args{}, err
-			}
-		case 1:
-			result.Filename, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.UtimensatTime32Args{}, err
-			}
-		case 2:
-			var dataT uint64
-			err = decoder.DecodeUint64(&dataT)
-			if err != nil {
-				return types.UtimensatTime32Args{}, err
-			}
-			result.T = uintptr(dataT)
-		case 3:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.UtimensatTime32Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Dfd)
+      if err != nil {
+        return types.UtimensatTime32Args{}, err
+      }
+    case 1:
+      result.Filename, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.UtimensatTime32Args{}, err
+      }
+    case 2:
+      var dataT uint64
+      err = decoder.DecodeUint64(&dataT)
+      if err != nil {
+        return types.UtimensatTime32Args{}, err
+      }
+      result.T = uintptr(dataT)
+    case 3:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.UtimensatTime32Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePselect6Time32Args(decoder *Decoder) (types.Pselect6Time32Args, error) {
-	var result types.Pselect6Time32Args
-	var err error
+  var result types.Pselect6Time32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.Pselect6Time32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.Pselect6Time32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.Pselect6Time32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.Pselect6Time32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.N)
-			if err != nil {
-				return types.Pselect6Time32Args{}, err
-			}
-		case 1:
-			var dataInp uint64
-			err = decoder.DecodeUint64(&dataInp)
-			if err != nil {
-				return types.Pselect6Time32Args{}, err
-			}
-			result.Inp = uintptr(dataInp)
-		case 2:
-			var dataOutp uint64
-			err = decoder.DecodeUint64(&dataOutp)
-			if err != nil {
-				return types.Pselect6Time32Args{}, err
-			}
-			result.Outp = uintptr(dataOutp)
-		case 3:
-			var dataExp uint64
-			err = decoder.DecodeUint64(&dataExp)
-			if err != nil {
-				return types.Pselect6Time32Args{}, err
-			}
-			result.Exp = uintptr(dataExp)
-		case 4:
-			var dataTsp uint64
-			err = decoder.DecodeUint64(&dataTsp)
-			if err != nil {
-				return types.Pselect6Time32Args{}, err
-			}
-			result.Tsp = uintptr(dataTsp)
-		case 5:
-			var dataSig uint64
-			err = decoder.DecodeUint64(&dataSig)
-			if err != nil {
-				return types.Pselect6Time32Args{}, err
-			}
-			result.Sig = uintptr(dataSig)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.N)
+      if err != nil {
+        return types.Pselect6Time32Args{}, err
+      }
+    case 1:
+      var dataInp uint64
+      err = decoder.DecodeUint64(&dataInp)
+      if err != nil {
+        return types.Pselect6Time32Args{}, err
+      }
+      result.Inp = uintptr(dataInp)
+    case 2:
+      var dataOutp uint64
+      err = decoder.DecodeUint64(&dataOutp)
+      if err != nil {
+        return types.Pselect6Time32Args{}, err
+      }
+      result.Outp = uintptr(dataOutp)
+    case 3:
+      var dataExp uint64
+      err = decoder.DecodeUint64(&dataExp)
+      if err != nil {
+        return types.Pselect6Time32Args{}, err
+      }
+      result.Exp = uintptr(dataExp)
+    case 4:
+      var dataTsp uint64
+      err = decoder.DecodeUint64(&dataTsp)
+      if err != nil {
+        return types.Pselect6Time32Args{}, err
+      }
+      result.Tsp = uintptr(dataTsp)
+    case 5:
+      var dataSig uint64
+      err = decoder.DecodeUint64(&dataSig)
+      if err != nil {
+        return types.Pselect6Time32Args{}, err
+      }
+      result.Sig = uintptr(dataSig)
+    }
+  }
+  return result, nil
 }
 
 func ParsePpollTime32Args(decoder *Decoder) (types.PpollTime32Args, error) {
-	var result types.PpollTime32Args
-	var err error
+  var result types.PpollTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PpollTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PpollTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PpollTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PpollTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataUfds uint64
-			err = decoder.DecodeUint64(&dataUfds)
-			if err != nil {
-				return types.PpollTime32Args{}, err
-			}
-			result.Ufds = uintptr(dataUfds)
-		case 1:
-			err = decoder.DecodeUint32(&result.Nfds)
-			if err != nil {
-				return types.PpollTime32Args{}, err
-			}
-		case 2:
-			var dataTsp uint64
-			err = decoder.DecodeUint64(&dataTsp)
-			if err != nil {
-				return types.PpollTime32Args{}, err
-			}
-			result.Tsp = uintptr(dataTsp)
-		case 3:
-			var dataSigmask uint64
-			err = decoder.DecodeUint64(&dataSigmask)
-			if err != nil {
-				return types.PpollTime32Args{}, err
-			}
-			result.Sigmask = uintptr(dataSigmask)
-		case 4:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.PpollTime32Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataUfds uint64
+      err = decoder.DecodeUint64(&dataUfds)
+      if err != nil {
+        return types.PpollTime32Args{}, err
+      }
+      result.Ufds = uintptr(dataUfds)
+    case 1:
+      err = decoder.DecodeUint32(&result.Nfds)
+      if err != nil {
+        return types.PpollTime32Args{}, err
+      }
+    case 2:
+      var dataTsp uint64
+      err = decoder.DecodeUint64(&dataTsp)
+      if err != nil {
+        return types.PpollTime32Args{}, err
+      }
+      result.Tsp = uintptr(dataTsp)
+    case 3:
+      var dataSigmask uint64
+      err = decoder.DecodeUint64(&dataSigmask)
+      if err != nil {
+        return types.PpollTime32Args{}, err
+      }
+      result.Sigmask = uintptr(dataSigmask)
+    case 4:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.PpollTime32Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseIoPgeteventsTime32Args(decoder *Decoder) (types.IoPgeteventsTime32Args, error) {
-	return types.IoPgeteventsTime32Args{}, nil
+  return types.IoPgeteventsTime32Args{}, nil
 }
 
 func ParseRecvmmsgTime32Args(decoder *Decoder) (types.RecvmmsgTime32Args, error) {
-	var result types.RecvmmsgTime32Args
-	var err error
+  var result types.RecvmmsgTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RecvmmsgTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RecvmmsgTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RecvmmsgTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RecvmmsgTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Fd)
-			if err != nil {
-				return types.RecvmmsgTime32Args{}, err
-			}
-		case 1:
-			var dataMmsg uint64
-			err = decoder.DecodeUint64(&dataMmsg)
-			if err != nil {
-				return types.RecvmmsgTime32Args{}, err
-			}
-			result.Mmsg = uintptr(dataMmsg)
-		case 2:
-			err = decoder.DecodeUint32(&result.Vlen)
-			if err != nil {
-				return types.RecvmmsgTime32Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.RecvmmsgTime32Args{}, err
-			}
-		case 4:
-			var dataTimeout uint64
-			err = decoder.DecodeUint64(&dataTimeout)
-			if err != nil {
-				return types.RecvmmsgTime32Args{}, err
-			}
-			result.Timeout = uintptr(dataTimeout)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Fd)
+      if err != nil {
+        return types.RecvmmsgTime32Args{}, err
+      }
+    case 1:
+      var dataMmsg uint64
+      err = decoder.DecodeUint64(&dataMmsg)
+      if err != nil {
+        return types.RecvmmsgTime32Args{}, err
+      }
+      result.Mmsg = uintptr(dataMmsg)
+    case 2:
+      err = decoder.DecodeUint32(&result.Vlen)
+      if err != nil {
+        return types.RecvmmsgTime32Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.RecvmmsgTime32Args{}, err
+      }
+    case 4:
+      var dataTimeout uint64
+      err = decoder.DecodeUint64(&dataTimeout)
+      if err != nil {
+        return types.RecvmmsgTime32Args{}, err
+      }
+      result.Timeout = uintptr(dataTimeout)
+    }
+  }
+  return result, nil
 }
 
 func ParseMqTimedsendTime32Args(decoder *Decoder) (types.MqTimedsendTime32Args, error) {
-	var result types.MqTimedsendTime32Args
-	var err error
+  var result types.MqTimedsendTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqTimedsendTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqTimedsendTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqTimedsendTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqTimedsendTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Mqdes)
-			if err != nil {
-				return types.MqTimedsendTime32Args{}, err
-			}
-		case 1:
-			result.UMsgPtr, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MqTimedsendTime32Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.MsgLen)
-			if err != nil {
-				return types.MqTimedsendTime32Args{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.MsgPrio)
-			if err != nil {
-				return types.MqTimedsendTime32Args{}, err
-			}
-		case 4:
-			var dataUAbsTimeout uint64
-			err = decoder.DecodeUint64(&dataUAbsTimeout)
-			if err != nil {
-				return types.MqTimedsendTime32Args{}, err
-			}
-			result.UAbsTimeout = uintptr(dataUAbsTimeout)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Mqdes)
+      if err != nil {
+        return types.MqTimedsendTime32Args{}, err
+      }
+    case 1:
+      result.UMsgPtr, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MqTimedsendTime32Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.MsgLen)
+      if err != nil {
+        return types.MqTimedsendTime32Args{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.MsgPrio)
+      if err != nil {
+        return types.MqTimedsendTime32Args{}, err
+      }
+    case 4:
+      var dataUAbsTimeout uint64
+      err = decoder.DecodeUint64(&dataUAbsTimeout)
+      if err != nil {
+        return types.MqTimedsendTime32Args{}, err
+      }
+      result.UAbsTimeout = uintptr(dataUAbsTimeout)
+    }
+  }
+  return result, nil
 }
 
 func ParseMqTimedreceiveTime32Args(decoder *Decoder) (types.MqTimedreceiveTime32Args, error) {
-	var result types.MqTimedreceiveTime32Args
-	var err error
+  var result types.MqTimedreceiveTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MqTimedreceiveTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MqTimedreceiveTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MqTimedreceiveTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MqTimedreceiveTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Mqdes)
-			if err != nil {
-				return types.MqTimedreceiveTime32Args{}, err
-			}
-		case 1:
-			result.UMsgPtr, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MqTimedreceiveTime32Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.MsgLen)
-			if err != nil {
-				return types.MqTimedreceiveTime32Args{}, err
-			}
-		case 3:
-			var dataUMsgPrio uint64
-			err = decoder.DecodeUint64(&dataUMsgPrio)
-			if err != nil {
-				return types.MqTimedreceiveTime32Args{}, err
-			}
-			result.UMsgPrio = uintptr(dataUMsgPrio)
-		case 4:
-			var dataUAbsTimeout uint64
-			err = decoder.DecodeUint64(&dataUAbsTimeout)
-			if err != nil {
-				return types.MqTimedreceiveTime32Args{}, err
-			}
-			result.UAbsTimeout = uintptr(dataUAbsTimeout)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Mqdes)
+      if err != nil {
+        return types.MqTimedreceiveTime32Args{}, err
+      }
+    case 1:
+      result.UMsgPtr, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MqTimedreceiveTime32Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.MsgLen)
+      if err != nil {
+        return types.MqTimedreceiveTime32Args{}, err
+      }
+    case 3:
+      var dataUMsgPrio uint64
+      err = decoder.DecodeUint64(&dataUMsgPrio)
+      if err != nil {
+        return types.MqTimedreceiveTime32Args{}, err
+      }
+      result.UMsgPrio = uintptr(dataUMsgPrio)
+    case 4:
+      var dataUAbsTimeout uint64
+      err = decoder.DecodeUint64(&dataUAbsTimeout)
+      if err != nil {
+        return types.MqTimedreceiveTime32Args{}, err
+      }
+      result.UAbsTimeout = uintptr(dataUAbsTimeout)
+    }
+  }
+  return result, nil
 }
 
 func ParseRtSigtimedwaitTime32Args(decoder *Decoder) (types.RtSigtimedwaitTime32Args, error) {
-	var result types.RtSigtimedwaitTime32Args
-	var err error
+  var result types.RtSigtimedwaitTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RtSigtimedwaitTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RtSigtimedwaitTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RtSigtimedwaitTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RtSigtimedwaitTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataUthese uint64
-			err = decoder.DecodeUint64(&dataUthese)
-			if err != nil {
-				return types.RtSigtimedwaitTime32Args{}, err
-			}
-			result.Uthese = uintptr(dataUthese)
-		case 1:
-			var dataUinfo uint64
-			err = decoder.DecodeUint64(&dataUinfo)
-			if err != nil {
-				return types.RtSigtimedwaitTime32Args{}, err
-			}
-			result.Uinfo = uintptr(dataUinfo)
-		case 2:
-			var dataUts uint64
-			err = decoder.DecodeUint64(&dataUts)
-			if err != nil {
-				return types.RtSigtimedwaitTime32Args{}, err
-			}
-			result.Uts = uintptr(dataUts)
-		case 3:
-			err = decoder.DecodeUint64(&result.Sigsetsize)
-			if err != nil {
-				return types.RtSigtimedwaitTime32Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataUthese uint64
+      err = decoder.DecodeUint64(&dataUthese)
+      if err != nil {
+        return types.RtSigtimedwaitTime32Args{}, err
+      }
+      result.Uthese = uintptr(dataUthese)
+    case 1:
+      var dataUinfo uint64
+      err = decoder.DecodeUint64(&dataUinfo)
+      if err != nil {
+        return types.RtSigtimedwaitTime32Args{}, err
+      }
+      result.Uinfo = uintptr(dataUinfo)
+    case 2:
+      var dataUts uint64
+      err = decoder.DecodeUint64(&dataUts)
+      if err != nil {
+        return types.RtSigtimedwaitTime32Args{}, err
+      }
+      result.Uts = uintptr(dataUts)
+    case 3:
+      err = decoder.DecodeUint64(&result.Sigsetsize)
+      if err != nil {
+        return types.RtSigtimedwaitTime32Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFutexTime32Args(decoder *Decoder) (types.FutexTime32Args, error) {
-	var result types.FutexTime32Args
-	var err error
+  var result types.FutexTime32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FutexTime32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FutexTime32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FutexTime32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FutexTime32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataUaddr uint64
-			err = decoder.DecodeUint64(&dataUaddr)
-			if err != nil {
-				return types.FutexTime32Args{}, err
-			}
-			result.Uaddr = uintptr(dataUaddr)
-		case 1:
-			err = decoder.DecodeInt32(&result.Op)
-			if err != nil {
-				return types.FutexTime32Args{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Val)
-			if err != nil {
-				return types.FutexTime32Args{}, err
-			}
-		case 3:
-			var dataUtime uint64
-			err = decoder.DecodeUint64(&dataUtime)
-			if err != nil {
-				return types.FutexTime32Args{}, err
-			}
-			result.Utime = uintptr(dataUtime)
-		case 4:
-			var dataUaddr2 uint64
-			err = decoder.DecodeUint64(&dataUaddr2)
-			if err != nil {
-				return types.FutexTime32Args{}, err
-			}
-			result.Uaddr2 = uintptr(dataUaddr2)
-		case 5:
-			err = decoder.DecodeUint32(&result.Val3)
-			if err != nil {
-				return types.FutexTime32Args{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataUaddr uint64
+      err = decoder.DecodeUint64(&dataUaddr)
+      if err != nil {
+        return types.FutexTime32Args{}, err
+      }
+      result.Uaddr = uintptr(dataUaddr)
+    case 1:
+      err = decoder.DecodeInt32(&result.Op)
+      if err != nil {
+        return types.FutexTime32Args{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Val)
+      if err != nil {
+        return types.FutexTime32Args{}, err
+      }
+    case 3:
+      var dataUtime uint64
+      err = decoder.DecodeUint64(&dataUtime)
+      if err != nil {
+        return types.FutexTime32Args{}, err
+      }
+      result.Utime = uintptr(dataUtime)
+    case 4:
+      var dataUaddr2 uint64
+      err = decoder.DecodeUint64(&dataUaddr2)
+      if err != nil {
+        return types.FutexTime32Args{}, err
+      }
+      result.Uaddr2 = uintptr(dataUaddr2)
+    case 5:
+      err = decoder.DecodeUint32(&result.Val3)
+      if err != nil {
+        return types.FutexTime32Args{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedRrGetInterval32Args(decoder *Decoder) (types.SchedRrGetInterval32Args, error) {
-	var result types.SchedRrGetInterval32Args
-	var err error
+  var result types.SchedRrGetInterval32Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedRrGetInterval32Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedRrGetInterval32Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedRrGetInterval32Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedRrGetInterval32Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SchedRrGetInterval32Args{}, err
-			}
-		case 1:
-			var dataInterval uint64
-			err = decoder.DecodeUint64(&dataInterval)
-			if err != nil {
-				return types.SchedRrGetInterval32Args{}, err
-			}
-			result.Interval = uintptr(dataInterval)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SchedRrGetInterval32Args{}, err
+      }
+    case 1:
+      var dataInterval uint64
+      err = decoder.DecodeUint64(&dataInterval)
+      if err != nil {
+        return types.SchedRrGetInterval32Args{}, err
+      }
+      result.Interval = uintptr(dataInterval)
+    }
+  }
+  return result, nil
 }
 
 func ParseSysEnterArgs(decoder *Decoder) (types.SysEnterArgs, error) {
-	var result types.SysEnterArgs
-	var err error
+  var result types.SysEnterArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SysEnterArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SysEnterArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SysEnterArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SysEnterArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Syscall)
-			if err != nil {
-				return types.SysEnterArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Syscall)
+      if err != nil {
+        return types.SysEnterArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSysExitArgs(decoder *Decoder) (types.SysExitArgs, error) {
-	var result types.SysExitArgs
-	var err error
+  var result types.SysExitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SysExitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SysExitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SysExitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SysExitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Syscall)
-			if err != nil {
-				return types.SysExitArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Syscall)
+      if err != nil {
+        return types.SysExitArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedProcessForkArgs(decoder *Decoder) (types.SchedProcessForkArgs, error) {
-	var result types.SchedProcessForkArgs
-	var err error
+  var result types.SchedProcessForkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedProcessForkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedProcessForkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedProcessForkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedProcessForkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.ParentTid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.ParentNsTid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.ParentPid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.ParentNsPid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.ChildTid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeInt32(&result.ChildNsTid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeInt32(&result.ChildPid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 7:
-			err = decoder.DecodeInt32(&result.ChildNsPid)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		case 8:
-			err = decoder.DecodeUint64(&result.StartTime)
-			if err != nil {
-				return types.SchedProcessForkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.ParentTid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.ParentNsTid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.ParentPid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.ParentNsPid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.ChildTid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeInt32(&result.ChildNsTid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeInt32(&result.ChildPid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 7:
+      err = decoder.DecodeInt32(&result.ChildNsPid)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    case 8:
+      err = decoder.DecodeUint64(&result.StartTime)
+      if err != nil {
+        return types.SchedProcessForkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedProcessExecArgs(decoder *Decoder) (types.SchedProcessExecArgs, error) {
-	var result types.SchedProcessExecArgs
-	var err error
+  var result types.SchedProcessExecArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedProcessExecArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedProcessExecArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedProcessExecArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedProcessExecArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Cmdpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint16(&result.InodeMode)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 6:
-			result.InterpreterPathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 7:
-			err = decoder.DecodeUint32(&result.InterpreterDev)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 8:
-			err = decoder.DecodeUint64(&result.InterpreterInode)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 9:
-			err = decoder.DecodeUint64(&result.InterpreterCtime)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 10:
-			result.Argv, err = decoder.ReadArgsArrayFromBuff()
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 11:
-			result.Interp, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 12:
-			err = decoder.DecodeUint16(&result.StdinType)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 13:
-			result.StdinPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 14:
-			err = decoder.DecodeInt32(&result.InvokedFromKernel)
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		case 15:
-			result.Env, err = decoder.ReadArgsArrayFromBuff()
-			if err != nil {
-				return types.SchedProcessExecArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Cmdpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint16(&result.InodeMode)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 6:
+      result.InterpreterPathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 7:
+      err = decoder.DecodeUint32(&result.InterpreterDev)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 8:
+      err = decoder.DecodeUint64(&result.InterpreterInode)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 9:
+      err = decoder.DecodeUint64(&result.InterpreterCtime)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 10:
+      result.Argv, err = decoder.ReadArgsArrayFromBuff()
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 11:
+      result.Interp, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 12:
+      err = decoder.DecodeUint16(&result.StdinType)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 13:
+      result.StdinPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 14:
+      err = decoder.DecodeInt32(&result.InvokedFromKernel)
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    case 15:
+      result.Env, err = decoder.ReadArgsArrayFromBuff()
+      if err != nil {
+        return types.SchedProcessExecArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedProcessExitArgs(decoder *Decoder) (types.SchedProcessExitArgs, error) {
-	var result types.SchedProcessExitArgs
-	var err error
+  var result types.SchedProcessExitArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedProcessExitArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedProcessExitArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedProcessExitArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedProcessExitArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt64(&result.ExitCode)
-			if err != nil {
-				return types.SchedProcessExitArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeBool(&result.ProcessGroupExit)
-			if err != nil {
-				return types.SchedProcessExitArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt64(&result.ExitCode)
+      if err != nil {
+        return types.SchedProcessExitArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeBool(&result.ProcessGroupExit)
+      if err != nil {
+        return types.SchedProcessExitArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSchedSwitchArgs(decoder *Decoder) (types.SchedSwitchArgs, error) {
-	var result types.SchedSwitchArgs
-	var err error
+  var result types.SchedSwitchArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SchedSwitchArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SchedSwitchArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SchedSwitchArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SchedSwitchArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Cpu)
-			if err != nil {
-				return types.SchedSwitchArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.PrevTid)
-			if err != nil {
-				return types.SchedSwitchArgs{}, err
-			}
-		case 2:
-			result.PrevComm, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SchedSwitchArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.NextTid)
-			if err != nil {
-				return types.SchedSwitchArgs{}, err
-			}
-		case 4:
-			result.NextComm, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SchedSwitchArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Cpu)
+      if err != nil {
+        return types.SchedSwitchArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.PrevTid)
+      if err != nil {
+        return types.SchedSwitchArgs{}, err
+      }
+    case 2:
+      result.PrevComm, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SchedSwitchArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.NextTid)
+      if err != nil {
+        return types.SchedSwitchArgs{}, err
+      }
+    case 4:
+      result.NextComm, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SchedSwitchArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseProcessOomKilledArgs(decoder *Decoder) (types.ProcessOomKilledArgs, error) {
-	var result types.ProcessOomKilledArgs
-	var err error
+  var result types.ProcessOomKilledArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ProcessOomKilledArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ProcessOomKilledArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ProcessOomKilledArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ProcessOomKilledArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt64(&result.ExitCode)
-			if err != nil {
-				return types.ProcessOomKilledArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeBool(&result.ProcessGroupExit)
-			if err != nil {
-				return types.ProcessOomKilledArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt64(&result.ExitCode)
+      if err != nil {
+        return types.ProcessOomKilledArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeBool(&result.ProcessGroupExit)
+      if err != nil {
+        return types.ProcessOomKilledArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDoExitArgs(decoder *Decoder) (types.DoExitArgs, error) {
-	return types.DoExitArgs{}, nil
+  return types.DoExitArgs{}, nil
 }
 
 func ParseCapCapableArgs(decoder *Decoder) (types.CapCapableArgs, error) {
-	var result types.CapCapableArgs
-	var err error
+  var result types.CapCapableArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CapCapableArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CapCapableArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CapCapableArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CapCapableArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Cap)
-			if err != nil {
-				return types.CapCapableArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Cap)
+      if err != nil {
+        return types.CapCapableArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseVfsWriteArgs(decoder *Decoder) (types.VfsWriteArgs, error) {
-	var result types.VfsWriteArgs
-	var err error
+  var result types.VfsWriteArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.VfsWriteArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.VfsWriteArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.VfsWriteArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.VfsWriteArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.VfsWriteArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.VfsWriteArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.VfsWriteArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.VfsWriteArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Pos)
-			if err != nil {
-				return types.VfsWriteArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.VfsWriteArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.VfsWriteArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.VfsWriteArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.VfsWriteArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Pos)
+      if err != nil {
+        return types.VfsWriteArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseVfsWritevArgs(decoder *Decoder) (types.VfsWritevArgs, error) {
-	var result types.VfsWritevArgs
-	var err error
+  var result types.VfsWritevArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.VfsWritevArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.VfsWritevArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.VfsWritevArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.VfsWritevArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.VfsWritevArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.VfsWritevArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.VfsWritevArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Vlen)
-			if err != nil {
-				return types.VfsWritevArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Pos)
-			if err != nil {
-				return types.VfsWritevArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.VfsWritevArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.VfsWritevArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.VfsWritevArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Vlen)
+      if err != nil {
+        return types.VfsWritevArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Pos)
+      if err != nil {
+        return types.VfsWritevArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMemProtAlertArgs(decoder *Decoder) (types.MemProtAlertArgs, error) {
-	var result types.MemProtAlertArgs
-	var err error
+  var result types.MemProtAlertArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MemProtAlertArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MemProtAlertArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MemProtAlertArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MemProtAlertArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Alert)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		case 1:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 2:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Prot)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeInt32(&result.PrevProt)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		case 5:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		case 7:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		case 8:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.MemProtAlertArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Alert)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    case 1:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 2:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Prot)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeInt32(&result.PrevProt)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    case 5:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    case 7:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    case 8:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.MemProtAlertArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCommitCredsArgs(decoder *Decoder) (types.CommitCredsArgs, error) {
-	var result types.CommitCredsArgs
-	var err error
+  var result types.CommitCredsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CommitCredsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CommitCredsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CommitCredsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CommitCredsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeSlimCred(&result.OldCred)
-			if err != nil {
-				return types.CommitCredsArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeSlimCred(&result.NewCred)
-			if err != nil {
-				return types.CommitCredsArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeSlimCred(&result.OldCred)
+      if err != nil {
+        return types.CommitCredsArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeSlimCred(&result.NewCred)
+      if err != nil {
+        return types.CommitCredsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSwitchTaskNSArgs(decoder *Decoder) (types.SwitchTaskNSArgs, error) {
-	var result types.SwitchTaskNSArgs
-	var err error
+  var result types.SwitchTaskNSArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SwitchTaskNSArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SwitchTaskNSArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SwitchTaskNSArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SwitchTaskNSArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.SwitchTaskNSArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.NewMnt)
-			if err != nil {
-				return types.SwitchTaskNSArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.NewPid)
-			if err != nil {
-				return types.SwitchTaskNSArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.NewUts)
-			if err != nil {
-				return types.SwitchTaskNSArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint32(&result.NewIpc)
-			if err != nil {
-				return types.SwitchTaskNSArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint32(&result.NewNet)
-			if err != nil {
-				return types.SwitchTaskNSArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeUint32(&result.NewCgroup)
-			if err != nil {
-				return types.SwitchTaskNSArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.SwitchTaskNSArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.NewMnt)
+      if err != nil {
+        return types.SwitchTaskNSArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.NewPid)
+      if err != nil {
+        return types.SwitchTaskNSArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.NewUts)
+      if err != nil {
+        return types.SwitchTaskNSArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint32(&result.NewIpc)
+      if err != nil {
+        return types.SwitchTaskNSArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint32(&result.NewNet)
+      if err != nil {
+        return types.SwitchTaskNSArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeUint32(&result.NewCgroup)
+      if err != nil {
+        return types.SwitchTaskNSArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseMagicWriteArgs(decoder *Decoder) (types.MagicWriteArgs, error) {
-	var result types.MagicWriteArgs
-	var err error
+  var result types.MagicWriteArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.MagicWriteArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.MagicWriteArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.MagicWriteArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.MagicWriteArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.MagicWriteArgs{}, err
-			}
-		case 1:
-			result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.MagicWrite))
-			if err != nil {
-				return types.MagicWriteArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.MagicWriteArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.MagicWriteArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.MagicWriteArgs{}, err
+      }
+    case 1:
+      result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.MagicWrite))
+      if err != nil {
+        return types.MagicWriteArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.MagicWriteArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.MagicWriteArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCgroupAttachTaskArgs(decoder *Decoder) (types.CgroupAttachTaskArgs, error) {
-	var result types.CgroupAttachTaskArgs
-	var err error
+  var result types.CgroupAttachTaskArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CgroupAttachTaskArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CgroupAttachTaskArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CgroupAttachTaskArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CgroupAttachTaskArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.CgroupPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.CgroupAttachTaskArgs{}, err
-			}
-		case 1:
-			result.Comm, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.CgroupAttachTaskArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Pid)
-			if err != nil {
-				return types.CgroupAttachTaskArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.CgroupPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.CgroupAttachTaskArgs{}, err
+      }
+    case 1:
+      result.Comm, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.CgroupAttachTaskArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Pid)
+      if err != nil {
+        return types.CgroupAttachTaskArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCgroupMkdirArgs(decoder *Decoder) (types.CgroupMkdirArgs, error) {
-	var result types.CgroupMkdirArgs
-	var err error
+  var result types.CgroupMkdirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CgroupMkdirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CgroupMkdirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CgroupMkdirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CgroupMkdirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.CgroupId)
-			if err != nil {
-				return types.CgroupMkdirArgs{}, err
-			}
-		case 1:
-			result.CgroupPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.CgroupMkdirArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.HierarchyId)
-			if err != nil {
-				return types.CgroupMkdirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.CgroupId)
+      if err != nil {
+        return types.CgroupMkdirArgs{}, err
+      }
+    case 1:
+      result.CgroupPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.CgroupMkdirArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.HierarchyId)
+      if err != nil {
+        return types.CgroupMkdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCgroupRmdirArgs(decoder *Decoder) (types.CgroupRmdirArgs, error) {
-	var result types.CgroupRmdirArgs
-	var err error
+  var result types.CgroupRmdirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CgroupRmdirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CgroupRmdirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CgroupRmdirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CgroupRmdirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.CgroupRmdirArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.CgroupRmdirArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.CgroupRmdirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.CgroupId)
+      if err != nil {
+        return types.CgroupRmdirArgs{}, err
+      }
+    case 1:
+      result.CgroupPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.CgroupRmdirArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.HierarchyId)
+      if err != nil {
+        return types.CgroupRmdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityFileOpenArgs(decoder *Decoder) (types.SecurityFileOpenArgs, error) {
-	var result types.SecurityFileOpenArgs
-	var err error
+  var result types.SecurityFileOpenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityFileOpenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityFileOpenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityFileOpenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityFileOpenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityFileOpenArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SecurityFileOpenArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.SecurityFileOpenArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.SecurityFileOpenArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.SecurityFileOpenArgs{}, err
-			}
-		case 5:
-			result.SyscallPathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityFileOpenArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityFileOpenArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SecurityFileOpenArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.SecurityFileOpenArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.SecurityFileOpenArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.SecurityFileOpenArgs{}, err
+      }
+    case 5:
+      result.SyscallPathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityFileOpenArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityInodeUnlinkArgs(decoder *Decoder) (types.SecurityInodeUnlinkArgs, error) {
-	var result types.SecurityInodeUnlinkArgs
-	var err error
+  var result types.SecurityInodeUnlinkArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityInodeUnlinkArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityInodeUnlinkArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityInodeUnlinkArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityInodeUnlinkArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityInodeUnlinkArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.SecurityInodeUnlinkArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.SecurityInodeUnlinkArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.SecurityInodeUnlinkArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityInodeUnlinkArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.SecurityInodeUnlinkArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.SecurityInodeUnlinkArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.SecurityInodeUnlinkArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecuritySocketCreateArgs(decoder *Decoder) (types.SecuritySocketCreateArgs, error) {
-	var result types.SecuritySocketCreateArgs
-	var err error
+  var result types.SecuritySocketCreateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecuritySocketCreateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecuritySocketCreateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecuritySocketCreateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecuritySocketCreateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Family)
-			if err != nil {
-				return types.SecuritySocketCreateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.SecuritySocketCreateArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Protocol)
-			if err != nil {
-				return types.SecuritySocketCreateArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Kern)
-			if err != nil {
-				return types.SecuritySocketCreateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Family)
+      if err != nil {
+        return types.SecuritySocketCreateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.SecuritySocketCreateArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Protocol)
+      if err != nil {
+        return types.SecuritySocketCreateArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Kern)
+      if err != nil {
+        return types.SecuritySocketCreateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecuritySocketListenArgs(decoder *Decoder) (types.SecuritySocketListenArgs, error) {
-	var result types.SecuritySocketListenArgs
-	var err error
+  var result types.SecuritySocketListenArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecuritySocketListenArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecuritySocketListenArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecuritySocketListenArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecuritySocketListenArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SecuritySocketListenArgs{}, err
-			}
-		case 1:
-			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SecuritySocketListenArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Backlog)
-			if err != nil {
-				return types.SecuritySocketListenArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SecuritySocketListenArgs{}, err
+      }
+    case 1:
+      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SecuritySocketListenArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Backlog)
+      if err != nil {
+        return types.SecuritySocketListenArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecuritySocketConnectArgs(decoder *Decoder) (types.SecuritySocketConnectArgs, error) {
-	var result types.SecuritySocketConnectArgs
-	var err error
+  var result types.SecuritySocketConnectArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecuritySocketConnectArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecuritySocketConnectArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecuritySocketConnectArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecuritySocketConnectArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SecuritySocketConnectArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.SecuritySocketConnectArgs{}, err
-			}
-		case 2:
-			result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SecuritySocketConnectArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SecuritySocketConnectArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.SecuritySocketConnectArgs{}, err
+      }
+    case 2:
+      result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SecuritySocketConnectArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecuritySocketAcceptArgs(decoder *Decoder) (types.SecuritySocketAcceptArgs, error) {
-	var result types.SecuritySocketAcceptArgs
-	var err error
+  var result types.SecuritySocketAcceptArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecuritySocketAcceptArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecuritySocketAcceptArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecuritySocketAcceptArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecuritySocketAcceptArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SecuritySocketAcceptArgs{}, err
-			}
-		case 1:
-			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SecuritySocketAcceptArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SecuritySocketAcceptArgs{}, err
+      }
+    case 1:
+      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SecuritySocketAcceptArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecuritySocketBindArgs(decoder *Decoder) (types.SecuritySocketBindArgs, error) {
-	var result types.SecuritySocketBindArgs
-	var err error
+  var result types.SecuritySocketBindArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecuritySocketBindArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecuritySocketBindArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecuritySocketBindArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecuritySocketBindArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SecuritySocketBindArgs{}, err
-			}
-		case 1:
-			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SecuritySocketBindArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SecuritySocketBindArgs{}, err
+      }
+    case 1:
+      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SecuritySocketBindArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecuritySocketSetsockoptArgs(decoder *Decoder) (types.SecuritySocketSetsockoptArgs, error) {
-	var result types.SecuritySocketSetsockoptArgs
-	var err error
+  var result types.SecuritySocketSetsockoptArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecuritySocketSetsockoptArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecuritySocketSetsockoptArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecuritySocketSetsockoptArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecuritySocketSetsockoptArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SecuritySocketSetsockoptArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Level)
-			if err != nil {
-				return types.SecuritySocketSetsockoptArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Optname)
-			if err != nil {
-				return types.SecuritySocketSetsockoptArgs{}, err
-			}
-		case 3:
-			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SecuritySocketSetsockoptArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SecuritySocketSetsockoptArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Level)
+      if err != nil {
+        return types.SecuritySocketSetsockoptArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Optname)
+      if err != nil {
+        return types.SecuritySocketSetsockoptArgs{}, err
+      }
+    case 3:
+      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SecuritySocketSetsockoptArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecuritySbMountArgs(decoder *Decoder) (types.SecuritySbMountArgs, error) {
-	var result types.SecuritySbMountArgs
-	var err error
+  var result types.SecuritySbMountArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecuritySbMountArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecuritySbMountArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecuritySbMountArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecuritySbMountArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.DevName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecuritySbMountArgs{}, err
-			}
-		case 1:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecuritySbMountArgs{}, err
-			}
-		case 2:
-			result.Type, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecuritySbMountArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Flags)
-			if err != nil {
-				return types.SecuritySbMountArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.DevName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecuritySbMountArgs{}, err
+      }
+    case 1:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecuritySbMountArgs{}, err
+      }
+    case 2:
+      result.Type, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecuritySbMountArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Flags)
+      if err != nil {
+        return types.SecuritySbMountArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityBPFArgs(decoder *Decoder) (types.SecurityBPFArgs, error) {
-	var result types.SecurityBPFArgs
-	var err error
+  var result types.SecurityBPFArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityBPFArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityBPFArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityBPFArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityBPFArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Cmd)
-			if err != nil {
-				return types.SecurityBPFArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Cmd)
+      if err != nil {
+        return types.SecurityBPFArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityBPFMapArgs(decoder *Decoder) (types.SecurityBPFMapArgs, error) {
-	var result types.SecurityBPFMapArgs
-	var err error
+  var result types.SecurityBPFMapArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityBPFMapArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityBPFMapArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityBPFMapArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityBPFMapArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.MapId)
-			if err != nil {
-				return types.SecurityBPFMapArgs{}, err
-			}
-		case 1:
-			result.MapName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityBPFMapArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.MapId)
+      if err != nil {
+        return types.SecurityBPFMapArgs{}, err
+      }
+    case 1:
+      result.MapName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityBPFMapArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityKernelReadFileArgs(decoder *Decoder) (types.SecurityKernelReadFileArgs, error) {
-	var result types.SecurityKernelReadFileArgs
-	var err error
+  var result types.SecurityKernelReadFileArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityKernelReadFileArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityKernelReadFileArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityKernelReadFileArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityKernelReadFileArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityKernelReadFileArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.SecurityKernelReadFileArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.SecurityKernelReadFileArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.SecurityKernelReadFileArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.SecurityKernelReadFileArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityKernelReadFileArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.SecurityKernelReadFileArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.SecurityKernelReadFileArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.SecurityKernelReadFileArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.SecurityKernelReadFileArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityPostReadFileArgs(decoder *Decoder) (types.SecurityPostReadFileArgs, error) {
-	var result types.SecurityPostReadFileArgs
-	var err error
+  var result types.SecurityPostReadFileArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityPostReadFileArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityPostReadFileArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityPostReadFileArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityPostReadFileArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityPostReadFileArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt64(&result.Size)
-			if err != nil {
-				return types.SecurityPostReadFileArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeInt32(&result.Type)
-			if err != nil {
-				return types.SecurityPostReadFileArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityPostReadFileArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt64(&result.Size)
+      if err != nil {
+        return types.SecurityPostReadFileArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeInt32(&result.Type)
+      if err != nil {
+        return types.SecurityPostReadFileArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityInodeMknodArgs(decoder *Decoder) (types.SecurityInodeMknodArgs, error) {
-	var result types.SecurityInodeMknodArgs
-	var err error
+  var result types.SecurityInodeMknodArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityInodeMknodArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityInodeMknodArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityInodeMknodArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityInodeMknodArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.FileName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityInodeMknodArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint16(&result.Mode)
-			if err != nil {
-				return types.SecurityInodeMknodArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.SecurityInodeMknodArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.FileName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityInodeMknodArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint16(&result.Mode)
+      if err != nil {
+        return types.SecurityInodeMknodArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.SecurityInodeMknodArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityInodeSymlinkEventIdArgs(decoder *Decoder) (types.SecurityInodeSymlinkEventIdArgs, error) {
-	var result types.SecurityInodeSymlinkEventIdArgs
-	var err error
+  var result types.SecurityInodeSymlinkEventIdArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityInodeSymlinkEventIdArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityInodeSymlinkEventIdArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityInodeSymlinkEventIdArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityInodeSymlinkEventIdArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Linkpath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityInodeSymlinkEventIdArgs{}, err
-			}
-		case 1:
-			result.Target, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityInodeSymlinkEventIdArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Linkpath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityInodeSymlinkEventIdArgs{}, err
+      }
+    case 1:
+      result.Target, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityInodeSymlinkEventIdArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityMmapFileArgs(decoder *Decoder) (types.SecurityMmapFileArgs, error) {
-	var result types.SecurityMmapFileArgs
-	var err error
+  var result types.SecurityMmapFileArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityMmapFileArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityMmapFileArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityMmapFileArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityMmapFileArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityMmapFileArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SecurityMmapFileArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.SecurityMmapFileArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.SecurityMmapFileArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.SecurityMmapFileArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.Prot)
-			if err != nil {
-				return types.SecurityMmapFileArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeUint64(&result.MmapFlags)
-			if err != nil {
-				return types.SecurityMmapFileArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityMmapFileArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SecurityMmapFileArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.SecurityMmapFileArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.SecurityMmapFileArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.SecurityMmapFileArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.Prot)
+      if err != nil {
+        return types.SecurityMmapFileArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeUint64(&result.MmapFlags)
+      if err != nil {
+        return types.SecurityMmapFileArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDoMmapArgs(decoder *Decoder) (types.DoMmapArgs, error) {
-	var result types.DoMmapArgs
-	var err error
+  var result types.DoMmapArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DoMmapArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DoMmapArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DoMmapArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DoMmapArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 1:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeUint64(&result.Pgoff)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 7:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 8:
-			err = decoder.DecodeUint64(&result.Prot)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		case 9:
-			err = decoder.DecodeUint64(&result.MmapFlags)
-			if err != nil {
-				return types.DoMmapArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 1:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeUint64(&result.Pgoff)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 7:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 8:
+      err = decoder.DecodeUint64(&result.Prot)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    case 9:
+      err = decoder.DecodeUint64(&result.MmapFlags)
+      if err != nil {
+        return types.DoMmapArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityFileMprotectArgs(decoder *Decoder) (types.SecurityFileMprotectArgs, error) {
-	var result types.SecurityFileMprotectArgs
-	var err error
+  var result types.SecurityFileMprotectArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityFileMprotectArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityFileMprotectArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityFileMprotectArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityFileMprotectArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityFileMprotectArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Prot)
-			if err != nil {
-				return types.SecurityFileMprotectArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.SecurityFileMprotectArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.PrevProt)
-			if err != nil {
-				return types.SecurityFileMprotectArgs{}, err
-			}
-		case 4:
-			var dataAddr uint64
-			err = decoder.DecodeUint64(&dataAddr)
-			if err != nil {
-				return types.SecurityFileMprotectArgs{}, err
-			}
-			result.Addr = uintptr(dataAddr)
-		case 5:
-			err = decoder.DecodeUint64(&result.Len)
-			if err != nil {
-				return types.SecurityFileMprotectArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeInt32(&result.Pkey)
-			if err != nil {
-				return types.SecurityFileMprotectArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityFileMprotectArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Prot)
+      if err != nil {
+        return types.SecurityFileMprotectArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.SecurityFileMprotectArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.PrevProt)
+      if err != nil {
+        return types.SecurityFileMprotectArgs{}, err
+      }
+    case 4:
+      var dataAddr uint64
+      err = decoder.DecodeUint64(&dataAddr)
+      if err != nil {
+        return types.SecurityFileMprotectArgs{}, err
+      }
+      result.Addr = uintptr(dataAddr)
+    case 5:
+      err = decoder.DecodeUint64(&result.Len)
+      if err != nil {
+        return types.SecurityFileMprotectArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeInt32(&result.Pkey)
+      if err != nil {
+        return types.SecurityFileMprotectArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseInitNamespacesArgs(decoder *Decoder) (types.InitNamespacesArgs, error) {
-	var result types.InitNamespacesArgs
-	var err error
+  var result types.InitNamespacesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.InitNamespacesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.InitNamespacesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.InitNamespacesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.InitNamespacesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.Cgroup)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Ipc)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mnt)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint32(&result.Net)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint32(&result.Pid)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint32(&result.PidForChildren)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeUint32(&result.Time)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 7:
-			err = decoder.DecodeUint32(&result.TimeForChildren)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 8:
-			err = decoder.DecodeUint32(&result.User)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		case 9:
-			err = decoder.DecodeUint32(&result.Uts)
-			if err != nil {
-				return types.InitNamespacesArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.Cgroup)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Ipc)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mnt)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint32(&result.Net)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint32(&result.Pid)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint32(&result.PidForChildren)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeUint32(&result.Time)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 7:
+      err = decoder.DecodeUint32(&result.TimeForChildren)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 8:
+      err = decoder.DecodeUint32(&result.User)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    case 9:
+      err = decoder.DecodeUint32(&result.Uts)
+      if err != nil {
+        return types.InitNamespacesArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSocketDupArgs(decoder *Decoder) (types.SocketDupArgs, error) {
-	var result types.SocketDupArgs
-	var err error
+  var result types.SocketDupArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SocketDupArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SocketDupArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SocketDupArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SocketDupArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Oldfd)
-			if err != nil {
-				return types.SocketDupArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Newfd)
-			if err != nil {
-				return types.SocketDupArgs{}, err
-			}
-		case 2:
-			result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SocketDupArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Oldfd)
+      if err != nil {
+        return types.SocketDupArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Newfd)
+      if err != nil {
+        return types.SocketDupArgs{}, err
+      }
+    case 2:
+      result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SocketDupArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseHiddenInodesArgs(decoder *Decoder) (types.HiddenInodesArgs, error) {
-	var result types.HiddenInodesArgs
-	var err error
+  var result types.HiddenInodesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.HiddenInodesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.HiddenInodesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.HiddenInodesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.HiddenInodesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.HiddenProcess, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.HiddenInodesArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.HiddenProcess, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.HiddenInodesArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseKernelWriteArgs(decoder *Decoder) (types.KernelWriteArgs, error) {
-	var result types.KernelWriteArgs
-	var err error
+  var result types.KernelWriteArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KernelWriteArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KernelWriteArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KernelWriteArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KernelWriteArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.KernelWriteArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.KernelWriteArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.KernelWriteArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.KernelWriteArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Pos)
-			if err != nil {
-				return types.KernelWriteArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.KernelWriteArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.KernelWriteArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.KernelWriteArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.KernelWriteArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Pos)
+      if err != nil {
+        return types.KernelWriteArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDirtyPipeSpliceArgs(decoder *Decoder) (types.DirtyPipeSpliceArgs, error) {
-	var result types.DirtyPipeSpliceArgs
-	var err error
+  var result types.DirtyPipeSpliceArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DirtyPipeSpliceArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DirtyPipeSpliceArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DirtyPipeSpliceArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DirtyPipeSpliceArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.InodeIn)
-			if err != nil {
-				return types.DirtyPipeSpliceArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint16(&result.InFileType)
-			if err != nil {
-				return types.DirtyPipeSpliceArgs{}, err
-			}
-		case 2:
-			result.InFilePath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DirtyPipeSpliceArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.ExposedDataStartOffset)
-			if err != nil {
-				return types.DirtyPipeSpliceArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.ExposedDataLen)
-			if err != nil {
-				return types.DirtyPipeSpliceArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.InodeOut)
-			if err != nil {
-				return types.DirtyPipeSpliceArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeUint32(&result.OutPipeLastBufferFlags)
-			if err != nil {
-				return types.DirtyPipeSpliceArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.InodeIn)
+      if err != nil {
+        return types.DirtyPipeSpliceArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint16(&result.InFileType)
+      if err != nil {
+        return types.DirtyPipeSpliceArgs{}, err
+      }
+    case 2:
+      result.InFilePath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DirtyPipeSpliceArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.ExposedDataStartOffset)
+      if err != nil {
+        return types.DirtyPipeSpliceArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.ExposedDataLen)
+      if err != nil {
+        return types.DirtyPipeSpliceArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.InodeOut)
+      if err != nil {
+        return types.DirtyPipeSpliceArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeUint32(&result.OutPipeLastBufferFlags)
+      if err != nil {
+        return types.DirtyPipeSpliceArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseContainerCreateArgs(decoder *Decoder) (types.ContainerCreateArgs, error) {
-	var result types.ContainerCreateArgs
-	var err error
+  var result types.ContainerCreateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ContainerCreateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ContainerCreateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ContainerCreateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ContainerCreateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Runtime, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 1:
-			result.ContainerId, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 3:
-			result.ContainerImage, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 4:
-			result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 5:
-			result.ContainerName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 6:
-			result.PodName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 7:
-			result.PodNamespace, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 8:
-			result.PodUid, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		case 9:
-			err = decoder.DecodeBool(&result.PodSandbox)
-			if err != nil {
-				return types.ContainerCreateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Runtime, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 1:
+      result.ContainerId, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 3:
+      result.ContainerImage, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 4:
+      result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 5:
+      result.ContainerName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 6:
+      result.PodName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 7:
+      result.PodNamespace, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 8:
+      result.PodUid, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    case 9:
+      err = decoder.DecodeBool(&result.PodSandbox)
+      if err != nil {
+        return types.ContainerCreateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseContainerRemoveArgs(decoder *Decoder) (types.ContainerRemoveArgs, error) {
-	var result types.ContainerRemoveArgs
-	var err error
+  var result types.ContainerRemoveArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ContainerRemoveArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ContainerRemoveArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ContainerRemoveArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ContainerRemoveArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Runtime, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerRemoveArgs{}, err
-			}
-		case 1:
-			result.ContainerId, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ContainerRemoveArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Runtime, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerRemoveArgs{}, err
+      }
+    case 1:
+      result.ContainerId, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ContainerRemoveArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseExistingContainerArgs(decoder *Decoder) (types.ExistingContainerArgs, error) {
-	var result types.ExistingContainerArgs
-	var err error
+  var result types.ExistingContainerArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ExistingContainerArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ExistingContainerArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ExistingContainerArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ExistingContainerArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Runtime, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 1:
-			result.ContainerId, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 3:
-			result.ContainerImage, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 4:
-			result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 5:
-			result.ContainerName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 6:
-			result.PodName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 7:
-			result.PodNamespace, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 8:
-			result.PodUid, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		case 9:
-			err = decoder.DecodeBool(&result.PodSandbox)
-			if err != nil {
-				return types.ExistingContainerArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Runtime, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 1:
+      result.ContainerId, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 3:
+      result.ContainerImage, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 4:
+      result.ContainerImageDigest, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 5:
+      result.ContainerName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 6:
+      result.PodName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 7:
+      result.PodNamespace, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 8:
+      result.PodUid, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    case 9:
+      err = decoder.DecodeBool(&result.PodSandbox)
+      if err != nil {
+        return types.ExistingContainerArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseProcCreateArgs(decoder *Decoder) (types.ProcCreateArgs, error) {
-	var result types.ProcCreateArgs
-	var err error
+  var result types.ProcCreateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ProcCreateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ProcCreateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ProcCreateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ProcCreateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ProcCreateArgs{}, err
-			}
-		case 1:
-			var dataProcOpsAddr uint64
-			err = decoder.DecodeUint64(&dataProcOpsAddr)
-			if err != nil {
-				return types.ProcCreateArgs{}, err
-			}
-			result.ProcOpsAddr = uintptr(dataProcOpsAddr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ProcCreateArgs{}, err
+      }
+    case 1:
+      var dataProcOpsAddr uint64
+      err = decoder.DecodeUint64(&dataProcOpsAddr)
+      if err != nil {
+        return types.ProcCreateArgs{}, err
+      }
+      result.ProcOpsAddr = uintptr(dataProcOpsAddr)
+    }
+  }
+  return result, nil
 }
 
 func ParseKprobeAttachArgs(decoder *Decoder) (types.KprobeAttachArgs, error) {
-	var result types.KprobeAttachArgs
-	var err error
+  var result types.KprobeAttachArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KprobeAttachArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KprobeAttachArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KprobeAttachArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KprobeAttachArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.SymbolName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.KprobeAttachArgs{}, err
-			}
-		case 1:
-			var dataPreHandlerAddr uint64
-			err = decoder.DecodeUint64(&dataPreHandlerAddr)
-			if err != nil {
-				return types.KprobeAttachArgs{}, err
-			}
-			result.PreHandlerAddr = uintptr(dataPreHandlerAddr)
-		case 2:
-			var dataPostHandlerAddr uint64
-			err = decoder.DecodeUint64(&dataPostHandlerAddr)
-			if err != nil {
-				return types.KprobeAttachArgs{}, err
-			}
-			result.PostHandlerAddr = uintptr(dataPostHandlerAddr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.SymbolName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.KprobeAttachArgs{}, err
+      }
+    case 1:
+      var dataPreHandlerAddr uint64
+      err = decoder.DecodeUint64(&dataPreHandlerAddr)
+      if err != nil {
+        return types.KprobeAttachArgs{}, err
+      }
+      result.PreHandlerAddr = uintptr(dataPreHandlerAddr)
+    case 2:
+      var dataPostHandlerAddr uint64
+      err = decoder.DecodeUint64(&dataPostHandlerAddr)
+      if err != nil {
+        return types.KprobeAttachArgs{}, err
+      }
+      result.PostHandlerAddr = uintptr(dataPostHandlerAddr)
+    }
+  }
+  return result, nil
 }
 
 func ParseCallUsermodeHelperArgs(decoder *Decoder) (types.CallUsermodeHelperArgs, error) {
-	var result types.CallUsermodeHelperArgs
-	var err error
+  var result types.CallUsermodeHelperArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.CallUsermodeHelperArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.CallUsermodeHelperArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.CallUsermodeHelperArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.CallUsermodeHelperArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.CallUsermodeHelperArgs{}, err
-			}
-		case 1:
-			result.Argv, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.CallUsermodeHelperArgs{}, err
-			}
-		case 2:
-			result.Envp, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.CallUsermodeHelperArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeInt32(&result.Wait)
-			if err != nil {
-				return types.CallUsermodeHelperArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.CallUsermodeHelperArgs{}, err
+      }
+    case 1:
+      result.Argv, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.CallUsermodeHelperArgs{}, err
+      }
+    case 2:
+      result.Envp, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.CallUsermodeHelperArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeInt32(&result.Wait)
+      if err != nil {
+        return types.CallUsermodeHelperArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDebugfsCreateFileArgs(decoder *Decoder) (types.DebugfsCreateFileArgs, error) {
-	var result types.DebugfsCreateFileArgs
-	var err error
+  var result types.DebugfsCreateFileArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DebugfsCreateFileArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DebugfsCreateFileArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DebugfsCreateFileArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DebugfsCreateFileArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.FileName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DebugfsCreateFileArgs{}, err
-			}
-		case 1:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DebugfsCreateFileArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Mode)
-			if err != nil {
-				return types.DebugfsCreateFileArgs{}, err
-			}
-		case 3:
-			var dataProcOpsAddr uint64
-			err = decoder.DecodeUint64(&dataProcOpsAddr)
-			if err != nil {
-				return types.DebugfsCreateFileArgs{}, err
-			}
-			result.ProcOpsAddr = uintptr(dataProcOpsAddr)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.FileName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DebugfsCreateFileArgs{}, err
+      }
+    case 1:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DebugfsCreateFileArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Mode)
+      if err != nil {
+        return types.DebugfsCreateFileArgs{}, err
+      }
+    case 3:
+      var dataProcOpsAddr uint64
+      err = decoder.DecodeUint64(&dataProcOpsAddr)
+      if err != nil {
+        return types.DebugfsCreateFileArgs{}, err
+      }
+      result.ProcOpsAddr = uintptr(dataProcOpsAddr)
+    }
+  }
+  return result, nil
 }
 
 func ParsePrintSyscallTableArgs(decoder *Decoder) (types.PrintSyscallTableArgs, error) {
-	var result types.PrintSyscallTableArgs
-	var err error
+  var result types.PrintSyscallTableArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PrintSyscallTableArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PrintSyscallTableArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PrintSyscallTableArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PrintSyscallTableArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64Array(&result.SyscallsAddresses)
-			if err != nil {
-				return types.PrintSyscallTableArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.CallerContextId)
-			if err != nil {
-				return types.PrintSyscallTableArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64Array(&result.SyscallsAddresses)
+      if err != nil {
+        return types.PrintSyscallTableArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.CallerContextId)
+      if err != nil {
+        return types.PrintSyscallTableArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseHiddenKernelModuleArgs(decoder *Decoder) (types.HiddenKernelModuleArgs, error) {
-	var result types.HiddenKernelModuleArgs
-	var err error
+  var result types.HiddenKernelModuleArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.HiddenKernelModuleArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.HiddenKernelModuleArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.HiddenKernelModuleArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.HiddenKernelModuleArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Address, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.HiddenKernelModuleArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.HiddenKernelModuleArgs{}, err
-			}
-		case 2:
-			result.Srcversion, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.HiddenKernelModuleArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Address, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.HiddenKernelModuleArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.HiddenKernelModuleArgs{}, err
+      }
+    case 2:
+      result.Srcversion, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.HiddenKernelModuleArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseHiddenKernelModuleSeekerArgs(decoder *Decoder) (types.HiddenKernelModuleSeekerArgs, error) {
-	var result types.HiddenKernelModuleSeekerArgs
-	var err error
+  var result types.HiddenKernelModuleSeekerArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.HiddenKernelModuleSeekerArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.HiddenKernelModuleSeekerArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.HiddenKernelModuleSeekerArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.HiddenKernelModuleSeekerArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64(&result.Address)
-			if err != nil {
-				return types.HiddenKernelModuleSeekerArgs{}, err
-			}
-		case 1:
-			result.Name, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
-			if err != nil {
-				return types.HiddenKernelModuleSeekerArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Flags)
-			if err != nil {
-				return types.HiddenKernelModuleSeekerArgs{}, err
-			}
-		case 3:
-			result.Srcversion, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
-			if err != nil {
-				return types.HiddenKernelModuleSeekerArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.Address)
+      if err != nil {
+        return types.HiddenKernelModuleSeekerArgs{}, err
+      }
+    case 1:
+      result.Name, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
+      if err != nil {
+        return types.HiddenKernelModuleSeekerArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Flags)
+      if err != nil {
+        return types.HiddenKernelModuleSeekerArgs{}, err
+      }
+    case 3:
+      result.Srcversion, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.HiddenKernelModuleSeeker))
+      if err != nil {
+        return types.HiddenKernelModuleSeekerArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseHookedSyscallsArgs(decoder *Decoder) (types.HookedSyscallsArgs, error) {
-	var result types.HookedSyscallsArgs
-	var err error
+  var result types.HookedSyscallsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.HookedSyscallsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.HookedSyscallsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.HookedSyscallsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.HookedSyscallsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataCheckSyscalls uint64
-			err = decoder.DecodeUint64(&dataCheckSyscalls)
-			if err != nil {
-				return types.HookedSyscallsArgs{}, err
-			}
-			result.CheckSyscalls = uintptr(dataCheckSyscalls)
-		case 1:
-			var dataHookedSyscalls uint64
-			err = decoder.DecodeUint64(&dataHookedSyscalls)
-			if err != nil {
-				return types.HookedSyscallsArgs{}, err
-			}
-			result.HookedSyscalls = uintptr(dataHookedSyscalls)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataCheckSyscalls uint64
+      err = decoder.DecodeUint64(&dataCheckSyscalls)
+      if err != nil {
+        return types.HookedSyscallsArgs{}, err
+      }
+      result.CheckSyscalls = uintptr(dataCheckSyscalls)
+    case 1:
+      var dataHookedSyscalls uint64
+      err = decoder.DecodeUint64(&dataHookedSyscalls)
+      if err != nil {
+        return types.HookedSyscallsArgs{}, err
+      }
+      result.HookedSyscalls = uintptr(dataHookedSyscalls)
+    }
+  }
+  return result, nil
 }
 
 func ParseDebugfsCreateDirArgs(decoder *Decoder) (types.DebugfsCreateDirArgs, error) {
-	var result types.DebugfsCreateDirArgs
-	var err error
+  var result types.DebugfsCreateDirArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DebugfsCreateDirArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DebugfsCreateDirArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DebugfsCreateDirArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DebugfsCreateDirArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DebugfsCreateDirArgs{}, err
-			}
-		case 1:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DebugfsCreateDirArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DebugfsCreateDirArgs{}, err
+      }
+    case 1:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DebugfsCreateDirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDeviceAddArgs(decoder *Decoder) (types.DeviceAddArgs, error) {
-	var result types.DeviceAddArgs
-	var err error
+  var result types.DeviceAddArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DeviceAddArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DeviceAddArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DeviceAddArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DeviceAddArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DeviceAddArgs{}, err
-			}
-		case 1:
-			result.ParentName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DeviceAddArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DeviceAddArgs{}, err
+      }
+    case 1:
+      result.ParentName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DeviceAddArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseRegisterChrdevArgs(decoder *Decoder) (types.RegisterChrdevArgs, error) {
-	var result types.RegisterChrdevArgs
-	var err error
+  var result types.RegisterChrdevArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.RegisterChrdevArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.RegisterChrdevArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.RegisterChrdevArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.RegisterChrdevArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.RequestedMajorNumber)
-			if err != nil {
-				return types.RegisterChrdevArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.GrantedMajorNumber)
-			if err != nil {
-				return types.RegisterChrdevArgs{}, err
-			}
-		case 2:
-			result.CharDeviceName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.RegisterChrdevArgs{}, err
-			}
-		case 3:
-			var dataCharDeviceFops uint64
-			err = decoder.DecodeUint64(&dataCharDeviceFops)
-			if err != nil {
-				return types.RegisterChrdevArgs{}, err
-			}
-			result.CharDeviceFops = uintptr(dataCharDeviceFops)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.RequestedMajorNumber)
+      if err != nil {
+        return types.RegisterChrdevArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.GrantedMajorNumber)
+      if err != nil {
+        return types.RegisterChrdevArgs{}, err
+      }
+    case 2:
+      result.CharDeviceName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.RegisterChrdevArgs{}, err
+      }
+    case 3:
+      var dataCharDeviceFops uint64
+      err = decoder.DecodeUint64(&dataCharDeviceFops)
+      if err != nil {
+        return types.RegisterChrdevArgs{}, err
+      }
+      result.CharDeviceFops = uintptr(dataCharDeviceFops)
+    }
+  }
+  return result, nil
 }
 
 func ParseSharedObjectLoadedArgs(decoder *Decoder) (types.SharedObjectLoadedArgs, error) {
-	var result types.SharedObjectLoadedArgs
-	var err error
+  var result types.SharedObjectLoadedArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SharedObjectLoadedArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SharedObjectLoadedArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SharedObjectLoadedArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SharedObjectLoadedArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SharedObjectLoadedArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeInt32(&result.Flags)
-			if err != nil {
-				return types.SharedObjectLoadedArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.SharedObjectLoadedArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.SharedObjectLoadedArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Ctime)
-			if err != nil {
-				return types.SharedObjectLoadedArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SharedObjectLoadedArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeInt32(&result.Flags)
+      if err != nil {
+        return types.SharedObjectLoadedArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.SharedObjectLoadedArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.SharedObjectLoadedArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Ctime)
+      if err != nil {
+        return types.SharedObjectLoadedArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSymbolsLoadedArgs(decoder *Decoder) (types.SymbolsLoadedArgs, error) {
-	var result types.SymbolsLoadedArgs
-	var err error
+  var result types.SymbolsLoadedArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SymbolsLoadedArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SymbolsLoadedArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SymbolsLoadedArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SymbolsLoadedArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.LibraryPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SymbolsLoadedArgs{}, err
-			}
-		case 1:
-			result.Symbols, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.SymbolsLoadedArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.LibraryPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SymbolsLoadedArgs{}, err
+      }
+    case 1:
+      result.Symbols, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.SymbolsLoadedArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSymbolsCollisionArgs(decoder *Decoder) (types.SymbolsCollisionArgs, error) {
-	var result types.SymbolsCollisionArgs
-	var err error
+  var result types.SymbolsCollisionArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SymbolsCollisionArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SymbolsCollisionArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SymbolsCollisionArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SymbolsCollisionArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.LoadedPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SymbolsCollisionArgs{}, err
-			}
-		case 1:
-			result.CollisionPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SymbolsCollisionArgs{}, err
-			}
-		case 2:
-			result.Symbols, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.SymbolsCollisionArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.LoadedPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SymbolsCollisionArgs{}, err
+      }
+    case 1:
+      result.CollisionPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SymbolsCollisionArgs{}, err
+      }
+    case 2:
+      result.Symbols, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.SymbolsCollisionArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCaptureFileWriteArgs(decoder *Decoder) (types.CaptureFileWriteArgs, error) {
-	return types.CaptureFileWriteArgs{}, nil
+  return types.CaptureFileWriteArgs{}, nil
 }
 
 func ParseCaptureFileReadArgs(decoder *Decoder) (types.CaptureFileReadArgs, error) {
-	return types.CaptureFileReadArgs{}, nil
+  return types.CaptureFileReadArgs{}, nil
 }
 
 func ParseCaptureExecArgs(decoder *Decoder) (types.CaptureExecArgs, error) {
-	return types.CaptureExecArgs{}, nil
+  return types.CaptureExecArgs{}, nil
 }
 
 func ParseCaptureModuleArgs(decoder *Decoder) (types.CaptureModuleArgs, error) {
-	return types.CaptureModuleArgs{}, nil
+  return types.CaptureModuleArgs{}, nil
 }
 
 func ParseCaptureMemArgs(decoder *Decoder) (types.CaptureMemArgs, error) {
-	return types.CaptureMemArgs{}, nil
+  return types.CaptureMemArgs{}, nil
 }
 
 func ParseCaptureBpfArgs(decoder *Decoder) (types.CaptureBpfArgs, error) {
-	return types.CaptureBpfArgs{}, nil
+  return types.CaptureBpfArgs{}, nil
 }
 
 func ParseDoInitModuleArgs(decoder *Decoder) (types.DoInitModuleArgs, error) {
-	var result types.DoInitModuleArgs
-	var err error
+  var result types.DoInitModuleArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DoInitModuleArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DoInitModuleArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DoInitModuleArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DoInitModuleArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DoInitModuleArgs{}, err
-			}
-		case 1:
-			result.Version, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DoInitModuleArgs{}, err
-			}
-		case 2:
-			result.SrcVersion, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DoInitModuleArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DoInitModuleArgs{}, err
+      }
+    case 1:
+      result.Version, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DoInitModuleArgs{}, err
+      }
+    case 2:
+      result.SrcVersion, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DoInitModuleArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseModuleLoadArgs(decoder *Decoder) (types.ModuleLoadArgs, error) {
-	var result types.ModuleLoadArgs
-	var err error
+  var result types.ModuleLoadArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ModuleLoadArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ModuleLoadArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ModuleLoadArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ModuleLoadArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ModuleLoadArgs{}, err
-			}
-		case 1:
-			result.Version, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ModuleLoadArgs{}, err
-			}
-		case 2:
-			result.SrcVersion, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ModuleLoadArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ModuleLoadArgs{}, err
+      }
+    case 1:
+      result.Version, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ModuleLoadArgs{}, err
+      }
+    case 2:
+      result.SrcVersion, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ModuleLoadArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseModuleFreeArgs(decoder *Decoder) (types.ModuleFreeArgs, error) {
-	var result types.ModuleFreeArgs
-	var err error
+  var result types.ModuleFreeArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ModuleFreeArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ModuleFreeArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ModuleFreeArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ModuleFreeArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Name, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ModuleFreeArgs{}, err
-			}
-		case 1:
-			result.Version, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ModuleFreeArgs{}, err
-			}
-		case 2:
-			result.SrcVersion, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ModuleFreeArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Name, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ModuleFreeArgs{}, err
+      }
+    case 1:
+      result.Version, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ModuleFreeArgs{}, err
+      }
+    case 2:
+      result.SrcVersion, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ModuleFreeArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSocketAcceptArgs(decoder *Decoder) (types.SocketAcceptArgs, error) {
-	var result types.SocketAcceptArgs
-	var err error
+  var result types.SocketAcceptArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SocketAcceptArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SocketAcceptArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SocketAcceptArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SocketAcceptArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sockfd)
-			if err != nil {
-				return types.SocketAcceptArgs{}, err
-			}
-		case 1:
-			result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SocketAcceptArgs{}, err
-			}
-		case 2:
-			result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
-			if err != nil {
-				return types.SocketAcceptArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sockfd)
+      if err != nil {
+        return types.SocketAcceptArgs{}, err
+      }
+    case 1:
+      result.LocalAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SocketAcceptArgs{}, err
+      }
+    case 2:
+      result.RemoteAddr, err = decoder.ReadSockaddrFromBuff()
+      if err != nil {
+        return types.SocketAcceptArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseLoadElfPhdrsArgs(decoder *Decoder) (types.LoadElfPhdrsArgs, error) {
-	var result types.LoadElfPhdrsArgs
-	var err error
+  var result types.LoadElfPhdrsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.LoadElfPhdrsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.LoadElfPhdrsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.LoadElfPhdrsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.LoadElfPhdrsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.LoadElfPhdrsArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.LoadElfPhdrsArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.LoadElfPhdrsArgs{}, err
-			}
-		}
-	}
-	return result, nil
-}
-
-func ParseHookedProcFopsArgs(decoder *Decoder) (types.HookedProcFopsArgs, error) {
-	var result types.HookedProcFopsArgs
-	var err error
-
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.HookedProcFopsArgs{}, err
-	}
-
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.HookedProcFopsArgs{}, err
-		}
-
-		switch currArg {
-		case 0:
-			var dataHookedFopsPointers uint64
-			err = decoder.DecodeUint64(&dataHookedFopsPointers)
-			if err != nil {
-				return types.HookedProcFopsArgs{}, err
-			}
-			result.HookedFopsPointers = uintptr(dataHookedFopsPointers)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.LoadElfPhdrsArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.LoadElfPhdrsArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.LoadElfPhdrsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParsePrintNetSeqOpsArgs(decoder *Decoder) (types.PrintNetSeqOpsArgs, error) {
-	var result types.PrintNetSeqOpsArgs
-	var err error
+  var result types.PrintNetSeqOpsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PrintNetSeqOpsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PrintNetSeqOpsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PrintNetSeqOpsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PrintNetSeqOpsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint64Array(&result.NetSeqOps)
-			if err != nil {
-				return types.PrintNetSeqOpsArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.CallerContextId)
-			if err != nil {
-				return types.PrintNetSeqOpsArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64Array(&result.NetSeqOps)
+      if err != nil {
+        return types.PrintNetSeqOpsArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.CallerContextId)
+      if err != nil {
+        return types.PrintNetSeqOpsArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseHookedSeqOpsArgs(decoder *Decoder) (types.HookedSeqOpsArgs, error) {
-	var result types.HookedSeqOpsArgs
-	var err error
+  var result types.HookedSeqOpsArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.HookedSeqOpsArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.HookedSeqOpsArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.HookedSeqOpsArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.HookedSeqOpsArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataHookedSeqOps uint64
-			err = decoder.DecodeUint64(&dataHookedSeqOps)
-			if err != nil {
-				return types.HookedSeqOpsArgs{}, err
-			}
-			result.HookedSeqOps = uintptr(dataHookedSeqOps)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataHookedSeqOps uint64
+      err = decoder.DecodeUint64(&dataHookedSeqOps)
+      if err != nil {
+        return types.HookedSeqOpsArgs{}, err
+      }
+      result.HookedSeqOps = uintptr(dataHookedSeqOps)
+    }
+  }
+  return result, nil
 }
 
 func ParseTaskRenameArgs(decoder *Decoder) (types.TaskRenameArgs, error) {
-	var result types.TaskRenameArgs
-	var err error
+  var result types.TaskRenameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.TaskRenameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.TaskRenameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.TaskRenameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.TaskRenameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.OldName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.TaskRenameArgs{}, err
-			}
-		case 1:
-			result.NewName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.TaskRenameArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.OldName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.TaskRenameArgs{}, err
+      }
+    case 1:
+      result.NewName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.TaskRenameArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseSecurityInodeRenameArgs(decoder *Decoder) (types.SecurityInodeRenameArgs, error) {
-	var result types.SecurityInodeRenameArgs
-	var err error
+  var result types.SecurityInodeRenameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SecurityInodeRenameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SecurityInodeRenameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SecurityInodeRenameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SecurityInodeRenameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.OldPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityInodeRenameArgs{}, err
-			}
-		case 1:
-			result.NewPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.SecurityInodeRenameArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.OldPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityInodeRenameArgs{}, err
+      }
+    case 1:
+      result.NewPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SecurityInodeRenameArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDoSigactionArgs(decoder *Decoder) (types.DoSigactionArgs, error) {
-	var result types.DoSigactionArgs
-	var err error
+  var result types.DoSigactionArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DoSigactionArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DoSigactionArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DoSigactionArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DoSigactionArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.Sig)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeBool(&result.IsSaInitialized)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.SaFlags)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.SaMask)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint8(&result.SaHandleMethod)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 5:
-			var dataSaHandler uint64
-			err = decoder.DecodeUint64(&dataSaHandler)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-			result.SaHandler = uintptr(dataSaHandler)
-		case 6:
-			err = decoder.DecodeBool(&result.IsOldSaInitialized)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 7:
-			err = decoder.DecodeUint64(&result.OldSaFlags)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 8:
-			err = decoder.DecodeUint64(&result.OldSaMask)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 9:
-			err = decoder.DecodeUint8(&result.OldSaHandleMethod)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-		case 10:
-			var dataOldSaHandler uint64
-			err = decoder.DecodeUint64(&dataOldSaHandler)
-			if err != nil {
-				return types.DoSigactionArgs{}, err
-			}
-			result.OldSaHandler = uintptr(dataOldSaHandler)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.Sig)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeBool(&result.IsSaInitialized)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.SaFlags)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.SaMask)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint8(&result.SaHandleMethod)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 5:
+      var dataSaHandler uint64
+      err = decoder.DecodeUint64(&dataSaHandler)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+      result.SaHandler = uintptr(dataSaHandler)
+    case 6:
+      err = decoder.DecodeBool(&result.IsOldSaInitialized)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 7:
+      err = decoder.DecodeUint64(&result.OldSaFlags)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 8:
+      err = decoder.DecodeUint64(&result.OldSaMask)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 9:
+      err = decoder.DecodeUint8(&result.OldSaHandleMethod)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+    case 10:
+      var dataOldSaHandler uint64
+      err = decoder.DecodeUint64(&dataOldSaHandler)
+      if err != nil {
+        return types.DoSigactionArgs{}, err
+      }
+      result.OldSaHandler = uintptr(dataOldSaHandler)
+    }
+  }
+  return result, nil
 }
 
 func ParseBpfAttachArgs(decoder *Decoder) (types.BpfAttachArgs, error) {
-	var result types.BpfAttachArgs
-	var err error
+  var result types.BpfAttachArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.BpfAttachArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.BpfAttachArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.BpfAttachArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.BpfAttachArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeInt32(&result.ProgType)
-			if err != nil {
-				return types.BpfAttachArgs{}, err
-			}
-		case 1:
-			result.ProgName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.BpfAttachArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.ProgId)
-			if err != nil {
-				return types.BpfAttachArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64Array(&result.ProgHelpers)
-			if err != nil {
-				return types.BpfAttachArgs{}, err
-			}
-		case 4:
-			result.SymbolName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.BpfAttachArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint64(&result.SymbolAddr)
-			if err != nil {
-				return types.BpfAttachArgs{}, err
-			}
-		case 6:
-			err = decoder.DecodeInt32(&result.AttachType)
-			if err != nil {
-				return types.BpfAttachArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeInt32(&result.ProgType)
+      if err != nil {
+        return types.BpfAttachArgs{}, err
+      }
+    case 1:
+      result.ProgName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.BpfAttachArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.ProgId)
+      if err != nil {
+        return types.BpfAttachArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64Array(&result.ProgHelpers)
+      if err != nil {
+        return types.BpfAttachArgs{}, err
+      }
+    case 4:
+      result.SymbolName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.BpfAttachArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint64(&result.SymbolAddr)
+      if err != nil {
+        return types.BpfAttachArgs{}, err
+      }
+    case 6:
+      err = decoder.DecodeInt32(&result.AttachType)
+      if err != nil {
+        return types.BpfAttachArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseKallsymsLookupNameArgs(decoder *Decoder) (types.KallsymsLookupNameArgs, error) {
-	var result types.KallsymsLookupNameArgs
-	var err error
+  var result types.KallsymsLookupNameArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.KallsymsLookupNameArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.KallsymsLookupNameArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.KallsymsLookupNameArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.KallsymsLookupNameArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.SymbolName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.KallsymsLookupNameArgs{}, err
-			}
-		case 1:
-			var dataSymbolAddress uint64
-			err = decoder.DecodeUint64(&dataSymbolAddress)
-			if err != nil {
-				return types.KallsymsLookupNameArgs{}, err
-			}
-			result.SymbolAddress = uintptr(dataSymbolAddress)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.SymbolName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.KallsymsLookupNameArgs{}, err
+      }
+    case 1:
+      var dataSymbolAddress uint64
+      err = decoder.DecodeUint64(&dataSymbolAddress)
+      if err != nil {
+        return types.KallsymsLookupNameArgs{}, err
+      }
+      result.SymbolAddress = uintptr(dataSymbolAddress)
+    }
+  }
+  return result, nil
 }
 
 func ParsePrintMemDumpArgs(decoder *Decoder) (types.PrintMemDumpArgs, error) {
-	var result types.PrintMemDumpArgs
-	var err error
+  var result types.PrintMemDumpArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.PrintMemDumpArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.PrintMemDumpArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.PrintMemDumpArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.PrintMemDumpArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.PrintMemDump))
-			if err != nil {
-				return types.PrintMemDumpArgs{}, err
-			}
-		case 1:
-			var dataAddress uint64
-			err = decoder.DecodeUint64(&dataAddress)
-			if err != nil {
-				return types.PrintMemDumpArgs{}, err
-			}
-			result.Address = uintptr(dataAddress)
-		case 2:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.PrintMemDumpArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.CallerContextId)
-			if err != nil {
-				return types.PrintMemDumpArgs{}, err
-			}
-		case 4:
-			result.Arch, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.PrintMemDumpArgs{}, err
-			}
-		case 5:
-			result.SymbolName, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.PrintMemDumpArgs{}, err
-			}
-		case 6:
-			result.SymbolOwner, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.PrintMemDumpArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Bytes, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.PrintMemDump))
+      if err != nil {
+        return types.PrintMemDumpArgs{}, err
+      }
+    case 1:
+      var dataAddress uint64
+      err = decoder.DecodeUint64(&dataAddress)
+      if err != nil {
+        return types.PrintMemDumpArgs{}, err
+      }
+      result.Address = uintptr(dataAddress)
+    case 2:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.PrintMemDumpArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.CallerContextId)
+      if err != nil {
+        return types.PrintMemDumpArgs{}, err
+      }
+    case 4:
+      result.Arch, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.PrintMemDumpArgs{}, err
+      }
+    case 5:
+      result.SymbolName, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.PrintMemDumpArgs{}, err
+      }
+    case 6:
+      result.SymbolOwner, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.PrintMemDumpArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseVfsReadArgs(decoder *Decoder) (types.VfsReadArgs, error) {
-	var result types.VfsReadArgs
-	var err error
+  var result types.VfsReadArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.VfsReadArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.VfsReadArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.VfsReadArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.VfsReadArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.VfsReadArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.VfsReadArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.VfsReadArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Count)
-			if err != nil {
-				return types.VfsReadArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Pos)
-			if err != nil {
-				return types.VfsReadArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.VfsReadArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.VfsReadArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.VfsReadArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Count)
+      if err != nil {
+        return types.VfsReadArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Pos)
+      if err != nil {
+        return types.VfsReadArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseVfsReadvArgs(decoder *Decoder) (types.VfsReadvArgs, error) {
-	var result types.VfsReadvArgs
-	var err error
+  var result types.VfsReadvArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.VfsReadvArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.VfsReadvArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.VfsReadvArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.VfsReadvArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.VfsReadvArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.VfsReadvArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.VfsReadvArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Vlen)
-			if err != nil {
-				return types.VfsReadvArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Pos)
-			if err != nil {
-				return types.VfsReadvArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.VfsReadvArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.VfsReadvArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.VfsReadvArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Vlen)
+      if err != nil {
+        return types.VfsReadvArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Pos)
+      if err != nil {
+        return types.VfsReadvArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseVfsUtimesArgs(decoder *Decoder) (types.VfsUtimesArgs, error) {
-	var result types.VfsUtimesArgs
-	var err error
+  var result types.VfsUtimesArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.VfsUtimesArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.VfsUtimesArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.VfsUtimesArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.VfsUtimesArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.VfsUtimesArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.VfsUtimesArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.VfsUtimesArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Atime)
-			if err != nil {
-				return types.VfsUtimesArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.Mtime)
-			if err != nil {
-				return types.VfsUtimesArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.VfsUtimesArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.VfsUtimesArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.VfsUtimesArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Atime)
+      if err != nil {
+        return types.VfsUtimesArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.Mtime)
+      if err != nil {
+        return types.VfsUtimesArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseDoTruncateArgs(decoder *Decoder) (types.DoTruncateArgs, error) {
-	var result types.DoTruncateArgs
-	var err error
+  var result types.DoTruncateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.DoTruncateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.DoTruncateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.DoTruncateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.DoTruncateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.DoTruncateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.DoTruncateArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.DoTruncateArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.Length)
-			if err != nil {
-				return types.DoTruncateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.DoTruncateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.DoTruncateArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.DoTruncateArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.Length)
+      if err != nil {
+        return types.DoTruncateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseFileModificationArgs(decoder *Decoder) (types.FileModificationArgs, error) {
-	var result types.FileModificationArgs
-	var err error
+  var result types.FileModificationArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.FileModificationArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.FileModificationArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.FileModificationArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.FileModificationArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.FilePath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.FileModificationArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.FileModificationArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.FileModificationArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.OldCtime)
-			if err != nil {
-				return types.FileModificationArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.NewCtime)
-			if err != nil {
-				return types.FileModificationArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.FilePath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.FileModificationArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.FileModificationArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.FileModificationArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.OldCtime)
+      if err != nil {
+        return types.FileModificationArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.NewCtime)
+      if err != nil {
+        return types.FileModificationArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseInotifyWatchArgs(decoder *Decoder) (types.InotifyWatchArgs, error) {
-	var result types.InotifyWatchArgs
-	var err error
+  var result types.InotifyWatchArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.InotifyWatchArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.InotifyWatchArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.InotifyWatchArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.InotifyWatchArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Pathname, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.InotifyWatchArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint64(&result.Inode)
-			if err != nil {
-				return types.InotifyWatchArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.Dev)
-			if err != nil {
-				return types.InotifyWatchArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Pathname, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.InotifyWatchArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint64(&result.Inode)
+      if err != nil {
+        return types.InotifyWatchArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.Dev)
+      if err != nil {
+        return types.InotifyWatchArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseProcessExecuteFailedArgs(decoder *Decoder) (types.ProcessExecuteFailedArgs, error) {
-	var result types.ProcessExecuteFailedArgs
-	var err error
+  var result types.ProcessExecuteFailedArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.ProcessExecuteFailedArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.ProcessExecuteFailedArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.ProcessExecuteFailedArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.ProcessExecuteFailedArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Path, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 1:
-			result.BinaryPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint32(&result.BinaryDeviceId)
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint64(&result.BinaryInodeNumber)
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 4:
-			err = decoder.DecodeUint64(&result.BinaryCtime)
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 5:
-			err = decoder.DecodeUint16(&result.BinaryInodeMode)
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 6:
-			result.InterpreterPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 7:
-			err = decoder.DecodeUint16(&result.StdinType)
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 8:
-			result.StdinPath, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 9:
-			err = decoder.DecodeInt32(&result.KernelInvoked)
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 10:
-			result.BinaryArguments, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		case 11:
-			result.Environment, err = decoder.ReadStringArrayFromBuff()
-			if err != nil {
-				return types.ProcessExecuteFailedArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Path, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 1:
+      result.BinaryPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.BinaryDeviceId)
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint64(&result.BinaryInodeNumber)
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 4:
+      err = decoder.DecodeUint64(&result.BinaryCtime)
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 5:
+      err = decoder.DecodeUint16(&result.BinaryInodeMode)
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 6:
+      result.InterpreterPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 7:
+      err = decoder.DecodeUint16(&result.StdinType)
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 8:
+      result.StdinPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 9:
+      err = decoder.DecodeInt32(&result.KernelInvoked)
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 10:
+      result.BinaryArguments, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    case 11:
+      result.Environment, err = decoder.ReadStringArrayFromBuff()
+      if err != nil {
+        return types.ProcessExecuteFailedArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketBaseArgs(decoder *Decoder) (types.NetPacketBaseArgs, error) {
-	return types.NetPacketBaseArgs{}, nil
+  return types.NetPacketBaseArgs{}, nil
 }
 
 func ParseNetPacketIPBaseArgs(decoder *Decoder) (types.NetPacketIPBaseArgs, error) {
-	var result types.NetPacketIPBaseArgs
-	var err error
+  var result types.NetPacketIPBaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketIPBaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketIPBaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketIPBaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketIPBaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketIPBase))
-			if err != nil {
-				return types.NetPacketIPBaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketIPBase))
+      if err != nil {
+        return types.NetPacketIPBaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketIPv4Args(decoder *Decoder) (types.NetPacketIPv4Args, error) {
-	var result types.NetPacketIPv4Args
-	var err error
+  var result types.NetPacketIPv4Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketIPv4Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketIPv4Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketIPv4Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketIPv4Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketIPv4Args{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketIPv4Args{}, err
-			}
-		case 2:
-			var dataProtoIpv4 uint64
-			err = decoder.DecodeUint64(&dataProtoIpv4)
-			if err != nil {
-				return types.NetPacketIPv4Args{}, err
-			}
-			result.ProtoIpv4 = uintptr(dataProtoIpv4)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketIPv4Args{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketIPv4Args{}, err
+      }
+    case 2:
+      var dataProtoIpv4 uint64
+      err = decoder.DecodeUint64(&dataProtoIpv4)
+      if err != nil {
+        return types.NetPacketIPv4Args{}, err
+      }
+      result.ProtoIpv4 = uintptr(dataProtoIpv4)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketIPv6Args(decoder *Decoder) (types.NetPacketIPv6Args, error) {
-	var result types.NetPacketIPv6Args
-	var err error
+  var result types.NetPacketIPv6Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketIPv6Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketIPv6Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketIPv6Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketIPv6Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketIPv6Args{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketIPv6Args{}, err
-			}
-		case 2:
-			var dataProtoIpv6 uint64
-			err = decoder.DecodeUint64(&dataProtoIpv6)
-			if err != nil {
-				return types.NetPacketIPv6Args{}, err
-			}
-			result.ProtoIpv6 = uintptr(dataProtoIpv6)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketIPv6Args{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketIPv6Args{}, err
+      }
+    case 2:
+      var dataProtoIpv6 uint64
+      err = decoder.DecodeUint64(&dataProtoIpv6)
+      if err != nil {
+        return types.NetPacketIPv6Args{}, err
+      }
+      result.ProtoIpv6 = uintptr(dataProtoIpv6)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketTCPBaseArgs(decoder *Decoder) (types.NetPacketTCPBaseArgs, error) {
-	var result types.NetPacketTCPBaseArgs
-	var err error
+  var result types.NetPacketTCPBaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketTCPBaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketTCPBaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketTCPBaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketTCPBaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketTCPBase))
-			if err != nil {
-				return types.NetPacketTCPBaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketTCPBase))
+      if err != nil {
+        return types.NetPacketTCPBaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketTCPArgs(decoder *Decoder) (types.NetPacketTCPArgs, error) {
-	var result types.NetPacketTCPArgs
-	var err error
+  var result types.NetPacketTCPArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketTCPArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketTCPArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketTCPArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketTCPArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketTCPArgs{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketTCPArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint16(&result.SrcPort)
-			if err != nil {
-				return types.NetPacketTCPArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint16(&result.DstPort)
-			if err != nil {
-				return types.NetPacketTCPArgs{}, err
-			}
-		case 4:
-			var dataProtoTcp uint64
-			err = decoder.DecodeUint64(&dataProtoTcp)
-			if err != nil {
-				return types.NetPacketTCPArgs{}, err
-			}
-			result.ProtoTcp = uintptr(dataProtoTcp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketTCPArgs{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketTCPArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint16(&result.SrcPort)
+      if err != nil {
+        return types.NetPacketTCPArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint16(&result.DstPort)
+      if err != nil {
+        return types.NetPacketTCPArgs{}, err
+      }
+    case 4:
+      var dataProtoTcp uint64
+      err = decoder.DecodeUint64(&dataProtoTcp)
+      if err != nil {
+        return types.NetPacketTCPArgs{}, err
+      }
+      result.ProtoTcp = uintptr(dataProtoTcp)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketUDPBaseArgs(decoder *Decoder) (types.NetPacketUDPBaseArgs, error) {
-	var result types.NetPacketUDPBaseArgs
-	var err error
+  var result types.NetPacketUDPBaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketUDPBaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketUDPBaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketUDPBaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketUDPBaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketUDPBase))
-			if err != nil {
-				return types.NetPacketUDPBaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketUDPBase))
+      if err != nil {
+        return types.NetPacketUDPBaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketUDPArgs(decoder *Decoder) (types.NetPacketUDPArgs, error) {
-	var result types.NetPacketUDPArgs
-	var err error
+  var result types.NetPacketUDPArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketUDPArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketUDPArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketUDPArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketUDPArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketUDPArgs{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketUDPArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint16(&result.SrcPort)
-			if err != nil {
-				return types.NetPacketUDPArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint16(&result.DstPort)
-			if err != nil {
-				return types.NetPacketUDPArgs{}, err
-			}
-		case 4:
-			var dataProtoUdp uint64
-			err = decoder.DecodeUint64(&dataProtoUdp)
-			if err != nil {
-				return types.NetPacketUDPArgs{}, err
-			}
-			result.ProtoUdp = uintptr(dataProtoUdp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketUDPArgs{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketUDPArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint16(&result.SrcPort)
+      if err != nil {
+        return types.NetPacketUDPArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint16(&result.DstPort)
+      if err != nil {
+        return types.NetPacketUDPArgs{}, err
+      }
+    case 4:
+      var dataProtoUdp uint64
+      err = decoder.DecodeUint64(&dataProtoUdp)
+      if err != nil {
+        return types.NetPacketUDPArgs{}, err
+      }
+      result.ProtoUdp = uintptr(dataProtoUdp)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketICMPBaseArgs(decoder *Decoder) (types.NetPacketICMPBaseArgs, error) {
-	var result types.NetPacketICMPBaseArgs
-	var err error
+  var result types.NetPacketICMPBaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketICMPBaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketICMPBaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketICMPBaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketICMPBaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPBase))
-			if err != nil {
-				return types.NetPacketICMPBaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPBase))
+      if err != nil {
+        return types.NetPacketICMPBaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketICMPArgs(decoder *Decoder) (types.NetPacketICMPArgs, error) {
-	var result types.NetPacketICMPArgs
-	var err error
+  var result types.NetPacketICMPArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketICMPArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketICMPArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketICMPArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketICMPArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketICMPArgs{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketICMPArgs{}, err
-			}
-		case 2:
-			var dataProtoIcmp uint64
-			err = decoder.DecodeUint64(&dataProtoIcmp)
-			if err != nil {
-				return types.NetPacketICMPArgs{}, err
-			}
-			result.ProtoIcmp = uintptr(dataProtoIcmp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketICMPArgs{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketICMPArgs{}, err
+      }
+    case 2:
+      var dataProtoIcmp uint64
+      err = decoder.DecodeUint64(&dataProtoIcmp)
+      if err != nil {
+        return types.NetPacketICMPArgs{}, err
+      }
+      result.ProtoIcmp = uintptr(dataProtoIcmp)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketICMPv6BaseArgs(decoder *Decoder) (types.NetPacketICMPv6BaseArgs, error) {
-	var result types.NetPacketICMPv6BaseArgs
-	var err error
+  var result types.NetPacketICMPv6BaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketICMPv6BaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketICMPv6BaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketICMPv6BaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketICMPv6BaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPv6Base))
-			if err != nil {
-				return types.NetPacketICMPv6BaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketICMPv6Base))
+      if err != nil {
+        return types.NetPacketICMPv6BaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketICMPv6Args(decoder *Decoder) (types.NetPacketICMPv6Args, error) {
-	var result types.NetPacketICMPv6Args
-	var err error
+  var result types.NetPacketICMPv6Args
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketICMPv6Args{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketICMPv6Args{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketICMPv6Args{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketICMPv6Args{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketICMPv6Args{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketICMPv6Args{}, err
-			}
-		case 2:
-			var dataProtoIcmpv6 uint64
-			err = decoder.DecodeUint64(&dataProtoIcmpv6)
-			if err != nil {
-				return types.NetPacketICMPv6Args{}, err
-			}
-			result.ProtoIcmpv6 = uintptr(dataProtoIcmpv6)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketICMPv6Args{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketICMPv6Args{}, err
+      }
+    case 2:
+      var dataProtoIcmpv6 uint64
+      err = decoder.DecodeUint64(&dataProtoIcmpv6)
+      if err != nil {
+        return types.NetPacketICMPv6Args{}, err
+      }
+      result.ProtoIcmpv6 = uintptr(dataProtoIcmpv6)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketDNSBaseArgs(decoder *Decoder) (types.NetPacketDNSBaseArgs, error) {
-	var result types.NetPacketDNSBaseArgs
-	var err error
+  var result types.NetPacketDNSBaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketDNSBaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketDNSBaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketDNSBaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketDNSBaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketDNSBase))
-			if err != nil {
-				return types.NetPacketDNSBaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketDNSBase))
+      if err != nil {
+        return types.NetPacketDNSBaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketDNSArgs(decoder *Decoder) (types.NetPacketDNSArgs, error) {
-	var result types.NetPacketDNSArgs
-	var err error
+  var result types.NetPacketDNSArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketDNSArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketDNSArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketDNSArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketDNSArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketDNSArgs{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketDNSArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint16(&result.SrcPort)
-			if err != nil {
-				return types.NetPacketDNSArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint16(&result.DstPort)
-			if err != nil {
-				return types.NetPacketDNSArgs{}, err
-			}
-		case 4:
-			var dataProtoDns uint64
-			err = decoder.DecodeUint64(&dataProtoDns)
-			if err != nil {
-				return types.NetPacketDNSArgs{}, err
-			}
-			result.ProtoDns = uintptr(dataProtoDns)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketDNSArgs{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketDNSArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint16(&result.SrcPort)
+      if err != nil {
+        return types.NetPacketDNSArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint16(&result.DstPort)
+      if err != nil {
+        return types.NetPacketDNSArgs{}, err
+      }
+    case 4:
+      var dataProtoDns uint64
+      err = decoder.DecodeUint64(&dataProtoDns)
+      if err != nil {
+        return types.NetPacketDNSArgs{}, err
+      }
+      result.ProtoDns = uintptr(dataProtoDns)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketDNSRequestArgs(decoder *Decoder) (types.NetPacketDNSRequestArgs, error) {
-	var result types.NetPacketDNSRequestArgs
-	var err error
+  var result types.NetPacketDNSRequestArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketDNSRequestArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketDNSRequestArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketDNSRequestArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketDNSRequestArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataMetadata uint64
-			err = decoder.DecodeUint64(&dataMetadata)
-			if err != nil {
-				return types.NetPacketDNSRequestArgs{}, err
-			}
-			result.Metadata = uintptr(dataMetadata)
-		case 1:
-			var dataDnsQuestions uint64
-			err = decoder.DecodeUint64(&dataDnsQuestions)
-			if err != nil {
-				return types.NetPacketDNSRequestArgs{}, err
-			}
-			result.DnsQuestions = uintptr(dataDnsQuestions)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataMetadata uint64
+      err = decoder.DecodeUint64(&dataMetadata)
+      if err != nil {
+        return types.NetPacketDNSRequestArgs{}, err
+      }
+      result.Metadata = uintptr(dataMetadata)
+    case 1:
+      var dataDnsQuestions uint64
+      err = decoder.DecodeUint64(&dataDnsQuestions)
+      if err != nil {
+        return types.NetPacketDNSRequestArgs{}, err
+      }
+      result.DnsQuestions = uintptr(dataDnsQuestions)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketDNSResponseArgs(decoder *Decoder) (types.NetPacketDNSResponseArgs, error) {
-	var result types.NetPacketDNSResponseArgs
-	var err error
+  var result types.NetPacketDNSResponseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketDNSResponseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketDNSResponseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketDNSResponseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketDNSResponseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataMetadata uint64
-			err = decoder.DecodeUint64(&dataMetadata)
-			if err != nil {
-				return types.NetPacketDNSResponseArgs{}, err
-			}
-			result.Metadata = uintptr(dataMetadata)
-		case 1:
-			var dataDnsResponse uint64
-			err = decoder.DecodeUint64(&dataDnsResponse)
-			if err != nil {
-				return types.NetPacketDNSResponseArgs{}, err
-			}
-			result.DnsResponse = uintptr(dataDnsResponse)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataMetadata uint64
+      err = decoder.DecodeUint64(&dataMetadata)
+      if err != nil {
+        return types.NetPacketDNSResponseArgs{}, err
+      }
+      result.Metadata = uintptr(dataMetadata)
+    case 1:
+      var dataDnsResponse uint64
+      err = decoder.DecodeUint64(&dataDnsResponse)
+      if err != nil {
+        return types.NetPacketDNSResponseArgs{}, err
+      }
+      result.DnsResponse = uintptr(dataDnsResponse)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketHTTPBaseArgs(decoder *Decoder) (types.NetPacketHTTPBaseArgs, error) {
-	var result types.NetPacketHTTPBaseArgs
-	var err error
+  var result types.NetPacketHTTPBaseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketHTTPBaseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketHTTPBaseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketHTTPBaseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketHTTPBaseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketHTTPBase))
-			if err != nil {
-				return types.NetPacketHTTPBaseArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketHTTPBase))
+      if err != nil {
+        return types.NetPacketHTTPBaseArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketHTTPArgs(decoder *Decoder) (types.NetPacketHTTPArgs, error) {
-	var result types.NetPacketHTTPArgs
-	var err error
+  var result types.NetPacketHTTPArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketHTTPArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketHTTPArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketHTTPArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketHTTPArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Src, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketHTTPArgs{}, err
-			}
-		case 1:
-			result.Dst, err = decoder.ReadStringFromBuff()
-			if err != nil {
-				return types.NetPacketHTTPArgs{}, err
-			}
-		case 2:
-			err = decoder.DecodeUint16(&result.SrcPort)
-			if err != nil {
-				return types.NetPacketHTTPArgs{}, err
-			}
-		case 3:
-			err = decoder.DecodeUint16(&result.DstPort)
-			if err != nil {
-				return types.NetPacketHTTPArgs{}, err
-			}
-		case 4:
-			var dataProtoHttp uint64
-			err = decoder.DecodeUint64(&dataProtoHttp)
-			if err != nil {
-				return types.NetPacketHTTPArgs{}, err
-			}
-			result.ProtoHttp = uintptr(dataProtoHttp)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Src, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketHTTPArgs{}, err
+      }
+    case 1:
+      result.Dst, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.NetPacketHTTPArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint16(&result.SrcPort)
+      if err != nil {
+        return types.NetPacketHTTPArgs{}, err
+      }
+    case 3:
+      err = decoder.DecodeUint16(&result.DstPort)
+      if err != nil {
+        return types.NetPacketHTTPArgs{}, err
+      }
+    case 4:
+      var dataProtoHttp uint64
+      err = decoder.DecodeUint64(&dataProtoHttp)
+      if err != nil {
+        return types.NetPacketHTTPArgs{}, err
+      }
+      result.ProtoHttp = uintptr(dataProtoHttp)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketHTTPRequestArgs(decoder *Decoder) (types.NetPacketHTTPRequestArgs, error) {
-	var result types.NetPacketHTTPRequestArgs
-	var err error
+  var result types.NetPacketHTTPRequestArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketHTTPRequestArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketHTTPRequestArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketHTTPRequestArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketHTTPRequestArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataMetadata uint64
-			err = decoder.DecodeUint64(&dataMetadata)
-			if err != nil {
-				return types.NetPacketHTTPRequestArgs{}, err
-			}
-			result.Metadata = uintptr(dataMetadata)
-		case 1:
-			var dataHttpRequest uint64
-			err = decoder.DecodeUint64(&dataHttpRequest)
-			if err != nil {
-				return types.NetPacketHTTPRequestArgs{}, err
-			}
-			result.HttpRequest = uintptr(dataHttpRequest)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataMetadata uint64
+      err = decoder.DecodeUint64(&dataMetadata)
+      if err != nil {
+        return types.NetPacketHTTPRequestArgs{}, err
+      }
+      result.Metadata = uintptr(dataMetadata)
+    case 1:
+      var dataHttpRequest uint64
+      err = decoder.DecodeUint64(&dataHttpRequest)
+      if err != nil {
+        return types.NetPacketHTTPRequestArgs{}, err
+      }
+      result.HttpRequest = uintptr(dataHttpRequest)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketHTTPResponseArgs(decoder *Decoder) (types.NetPacketHTTPResponseArgs, error) {
-	var result types.NetPacketHTTPResponseArgs
-	var err error
+  var result types.NetPacketHTTPResponseArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketHTTPResponseArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketHTTPResponseArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketHTTPResponseArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketHTTPResponseArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			var dataMetadata uint64
-			err = decoder.DecodeUint64(&dataMetadata)
-			if err != nil {
-				return types.NetPacketHTTPResponseArgs{}, err
-			}
-			result.Metadata = uintptr(dataMetadata)
-		case 1:
-			var dataHttpResponse uint64
-			err = decoder.DecodeUint64(&dataHttpResponse)
-			if err != nil {
-				return types.NetPacketHTTPResponseArgs{}, err
-			}
-			result.HttpResponse = uintptr(dataHttpResponse)
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      var dataMetadata uint64
+      err = decoder.DecodeUint64(&dataMetadata)
+      if err != nil {
+        return types.NetPacketHTTPResponseArgs{}, err
+      }
+      result.Metadata = uintptr(dataMetadata)
+    case 1:
+      var dataHttpResponse uint64
+      err = decoder.DecodeUint64(&dataHttpResponse)
+      if err != nil {
+        return types.NetPacketHTTPResponseArgs{}, err
+      }
+      result.HttpResponse = uintptr(dataHttpResponse)
+    }
+  }
+  return result, nil
 }
 
 func ParseNetPacketCaptureArgs(decoder *Decoder) (types.NetPacketCaptureArgs, error) {
-	var result types.NetPacketCaptureArgs
-	var err error
+  var result types.NetPacketCaptureArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.NetPacketCaptureArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.NetPacketCaptureArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.NetPacketCaptureArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.NetPacketCaptureArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketCapture))
-			if err != nil {
-				return types.NetPacketCaptureArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      result.Payload, err = decoder.ReadMaxByteSliceFromBuff(eventMaxByteSliceBufferSize(events.NetPacketCapture))
+      if err != nil {
+        return types.NetPacketCaptureArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseCaptureNetPacketArgs(decoder *Decoder) (types.CaptureNetPacketArgs, error) {
-	return types.CaptureNetPacketArgs{}, nil
+  return types.CaptureNetPacketArgs{}, nil
 }
 
 func ParseSockSetStateArgs(decoder *Decoder) (types.SockSetStateArgs, error) {
-	var result types.SockSetStateArgs
-	var err error
+  var result types.SockSetStateArgs
+  var err error
 
-	var numArgs uint8
-	err = decoder.DecodeUint8(&numArgs)
-	if err != nil {
-		return types.SockSetStateArgs{}, err
-	}
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SockSetStateArgs{}, err
+  }
 
-	for arg := 0; arg < int(numArgs); arg++ {
-		var currArg uint8
-		err = decoder.DecodeUint8(&currArg)
-		if err != nil {
-			return types.SockSetStateArgs{}, err
-		}
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SockSetStateArgs{}, err
+    }
 
-		switch currArg {
-		case 0:
-			err = decoder.DecodeUint32(&result.OldState)
-			if err != nil {
-				return types.SockSetStateArgs{}, err
-			}
-		case 1:
-			err = decoder.DecodeUint32(&result.NewState)
-			if err != nil {
-				return types.SockSetStateArgs{}, err
-			}
-		case 2:
-			result.Tuple, err = decoder.ReadAddrTuple()
-			if err != nil {
-				return types.SockSetStateArgs{}, err
-			}
-		}
-	}
-	return result, nil
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint32(&result.OldState)
+      if err != nil {
+        return types.SockSetStateArgs{}, err
+      }
+    case 1:
+      err = decoder.DecodeUint32(&result.NewState)
+      if err != nil {
+        return types.SockSetStateArgs{}, err
+      }
+    case 2:
+      result.Tuple, err = decoder.ReadAddrTuple()
+      if err != nil {
+        return types.SockSetStateArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseTrackSyscallStatsArgs(decoder *Decoder) (types.TrackSyscallStatsArgs, error) {
-	return types.TrackSyscallStatsArgs{}, nil
+  return types.TrackSyscallStatsArgs{}, nil
 }
 
 func ParseTestEventArgs(decoder *Decoder) (types.TestEventArgs, error) {
-	return types.TestEventArgs{}, nil
+  return types.TestEventArgs{}, nil
+}
+
+func ParseSignalCgroupMkdirArgs(decoder *Decoder) (types.SignalCgroupMkdirArgs, error) {
+  var result types.SignalCgroupMkdirArgs
+  var err error
+
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SignalCgroupMkdirArgs{}, err
+  }
+
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SignalCgroupMkdirArgs{}, err
+    }
+
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.CgroupId)
+      if err != nil {
+        return types.SignalCgroupMkdirArgs{}, err
+      }
+    case 1:
+      result.CgroupPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SignalCgroupMkdirArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.HierarchyId)
+      if err != nil {
+        return types.SignalCgroupMkdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
+}
+
+func ParseSignalCgroupRmdirArgs(decoder *Decoder) (types.SignalCgroupRmdirArgs, error) {
+  var result types.SignalCgroupRmdirArgs
+  var err error
+
+  var numArgs uint8
+  err = decoder.DecodeUint8(&numArgs)
+  if err != nil {
+    return types.SignalCgroupRmdirArgs{}, err
+  }
+
+  for arg := 0; arg < int(numArgs); arg++ {
+    var currArg uint8
+    err = decoder.DecodeUint8(&currArg)
+    if err != nil {
+      return types.SignalCgroupRmdirArgs{}, err
+    }
+
+    switch currArg {
+    case 0:
+      err = decoder.DecodeUint64(&result.CgroupId)
+      if err != nil {
+        return types.SignalCgroupRmdirArgs{}, err
+      }
+    case 1:
+      result.CgroupPath, err = decoder.ReadStringFromBuff()
+      if err != nil {
+        return types.SignalCgroupRmdirArgs{}, err
+      }
+    case 2:
+      err = decoder.DecodeUint32(&result.HierarchyId)
+      if err != nil {
+        return types.SignalCgroupRmdirArgs{}, err
+      }
+    }
+  }
+  return result, nil
 }
 
 func ParseArgs(decoder *Decoder, event events.ID) (types.Args, error) {
-	switch event {
-	case events.Read:
-		return ParseReadArgs(decoder)
-	case events.Write:
-		return ParseWriteArgs(decoder)
-	case events.Open:
-		return ParseOpenArgs(decoder)
-	case events.Close:
-		return ParseCloseArgs(decoder)
-	case events.Stat:
-		return ParseStatArgs(decoder)
-	case events.Fstat:
-		return ParseFstatArgs(decoder)
-	case events.Lstat:
-		return ParseLstatArgs(decoder)
-	case events.Poll:
-		return ParsePollArgs(decoder)
-	case events.Lseek:
-		return ParseLseekArgs(decoder)
-	case events.Mmap:
-		return ParseMmapArgs(decoder)
-	case events.Mprotect:
-		return ParseMprotectArgs(decoder)
-	case events.Munmap:
-		return ParseMunmapArgs(decoder)
-	case events.Brk:
-		return ParseBrkArgs(decoder)
-	case events.RtSigaction:
-		return ParseRtSigactionArgs(decoder)
-	case events.RtSigprocmask:
-		return ParseRtSigprocmaskArgs(decoder)
-	case events.RtSigreturn:
-		return ParseRtSigreturnArgs(decoder)
-	case events.Ioctl:
-		return ParseIoctlArgs(decoder)
-	case events.Pread64:
-		return ParsePread64Args(decoder)
-	case events.Pwrite64:
-		return ParsePwrite64Args(decoder)
-	case events.Readv:
-		return ParseReadvArgs(decoder)
-	case events.Writev:
-		return ParseWritevArgs(decoder)
-	case events.Access:
-		return ParseAccessArgs(decoder)
-	case events.Pipe:
-		return ParsePipeArgs(decoder)
-	case events.Select:
-		return ParseSelectArgs(decoder)
-	case events.SchedYield:
-		return ParseSchedYieldArgs(decoder)
-	case events.Mremap:
-		return ParseMremapArgs(decoder)
-	case events.Msync:
-		return ParseMsyncArgs(decoder)
-	case events.Mincore:
-		return ParseMincoreArgs(decoder)
-	case events.Madvise:
-		return ParseMadviseArgs(decoder)
-	case events.Shmget:
-		return ParseShmgetArgs(decoder)
-	case events.Shmat:
-		return ParseShmatArgs(decoder)
-	case events.Shmctl:
-		return ParseShmctlArgs(decoder)
-	case events.Dup:
-		return ParseDupArgs(decoder)
-	case events.Dup2:
-		return ParseDup2Args(decoder)
-	case events.Pause:
-		return ParsePauseArgs(decoder)
-	case events.Nanosleep:
-		return ParseNanosleepArgs(decoder)
-	case events.Getitimer:
-		return ParseGetitimerArgs(decoder)
-	case events.Alarm:
-		return ParseAlarmArgs(decoder)
-	case events.Setitimer:
-		return ParseSetitimerArgs(decoder)
-	case events.Getpid:
-		return ParseGetpidArgs(decoder)
-	case events.Sendfile:
-		return ParseSendfileArgs(decoder)
-	case events.Socket:
-		return ParseSocketArgs(decoder)
-	case events.Connect:
-		return ParseConnectArgs(decoder)
-	case events.Accept:
-		return ParseAcceptArgs(decoder)
-	case events.Sendto:
-		return ParseSendtoArgs(decoder)
-	case events.Recvfrom:
-		return ParseRecvfromArgs(decoder)
-	case events.Sendmsg:
-		return ParseSendmsgArgs(decoder)
-	case events.Recvmsg:
-		return ParseRecvmsgArgs(decoder)
-	case events.Shutdown:
-		return ParseShutdownArgs(decoder)
-	case events.Bind:
-		return ParseBindArgs(decoder)
-	case events.Listen:
-		return ParseListenArgs(decoder)
-	case events.Getsockname:
-		return ParseGetsocknameArgs(decoder)
-	case events.Getpeername:
-		return ParseGetpeernameArgs(decoder)
-	case events.Socketpair:
-		return ParseSocketpairArgs(decoder)
-	case events.Setsockopt:
-		return ParseSetsockoptArgs(decoder)
-	case events.Getsockopt:
-		return ParseGetsockoptArgs(decoder)
-	case events.Clone:
-		return ParseCloneArgs(decoder)
-	case events.Fork:
-		return ParseForkArgs(decoder)
-	case events.Vfork:
-		return ParseVforkArgs(decoder)
-	case events.Execve:
-		return ParseExecveArgs(decoder)
-	case events.Exit:
-		return ParseExitArgs(decoder)
-	case events.Wait4:
-		return ParseWait4Args(decoder)
-	case events.Kill:
-		return ParseKillArgs(decoder)
-	case events.Uname:
-		return ParseUnameArgs(decoder)
-	case events.Semget:
-		return ParseSemgetArgs(decoder)
-	case events.Semop:
-		return ParseSemopArgs(decoder)
-	case events.Semctl:
-		return ParseSemctlArgs(decoder)
-	case events.Shmdt:
-		return ParseShmdtArgs(decoder)
-	case events.Msgget:
-		return ParseMsggetArgs(decoder)
-	case events.Msgsnd:
-		return ParseMsgsndArgs(decoder)
-	case events.Msgrcv:
-		return ParseMsgrcvArgs(decoder)
-	case events.Msgctl:
-		return ParseMsgctlArgs(decoder)
-	case events.Fcntl:
-		return ParseFcntlArgs(decoder)
-	case events.Flock:
-		return ParseFlockArgs(decoder)
-	case events.Fsync:
-		return ParseFsyncArgs(decoder)
-	case events.Fdatasync:
-		return ParseFdatasyncArgs(decoder)
-	case events.Truncate:
-		return ParseTruncateArgs(decoder)
-	case events.Ftruncate:
-		return ParseFtruncateArgs(decoder)
-	case events.Getdents:
-		return ParseGetdentsArgs(decoder)
-	case events.Getcwd:
-		return ParseGetcwdArgs(decoder)
-	case events.Chdir:
-		return ParseChdirArgs(decoder)
-	case events.Fchdir:
-		return ParseFchdirArgs(decoder)
-	case events.Rename:
-		return ParseRenameArgs(decoder)
-	case events.Mkdir:
-		return ParseMkdirArgs(decoder)
-	case events.Rmdir:
-		return ParseRmdirArgs(decoder)
-	case events.Creat:
-		return ParseCreatArgs(decoder)
-	case events.Link:
-		return ParseLinkArgs(decoder)
-	case events.Unlink:
-		return ParseUnlinkArgs(decoder)
-	case events.Symlink:
-		return ParseSymlinkArgs(decoder)
-	case events.Readlink:
-		return ParseReadlinkArgs(decoder)
-	case events.Chmod:
-		return ParseChmodArgs(decoder)
-	case events.Fchmod:
-		return ParseFchmodArgs(decoder)
-	case events.Chown:
-		return ParseChownArgs(decoder)
-	case events.Fchown:
-		return ParseFchownArgs(decoder)
-	case events.Lchown:
-		return ParseLchownArgs(decoder)
-	case events.Umask:
-		return ParseUmaskArgs(decoder)
-	case events.Gettimeofday:
-		return ParseGettimeofdayArgs(decoder)
-	case events.Getrlimit:
-		return ParseGetrlimitArgs(decoder)
-	case events.Getrusage:
-		return ParseGetrusageArgs(decoder)
-	case events.Sysinfo:
-		return ParseSysinfoArgs(decoder)
-	case events.Times:
-		return ParseTimesArgs(decoder)
-	case events.Ptrace:
-		return ParsePtraceArgs(decoder)
-	case events.Getuid:
-		return ParseGetuidArgs(decoder)
-	case events.Syslog:
-		return ParseSyslogArgs(decoder)
-	case events.Getgid:
-		return ParseGetgidArgs(decoder)
-	case events.Setuid:
-		return ParseSetuidArgs(decoder)
-	case events.Setgid:
-		return ParseSetgidArgs(decoder)
-	case events.Geteuid:
-		return ParseGeteuidArgs(decoder)
-	case events.Getegid:
-		return ParseGetegidArgs(decoder)
-	case events.Setpgid:
-		return ParseSetpgidArgs(decoder)
-	case events.Getppid:
-		return ParseGetppidArgs(decoder)
-	case events.Getpgrp:
-		return ParseGetpgrpArgs(decoder)
-	case events.Setsid:
-		return ParseSetsidArgs(decoder)
-	case events.Setreuid:
-		return ParseSetreuidArgs(decoder)
-	case events.Setregid:
-		return ParseSetregidArgs(decoder)
-	case events.Getgroups:
-		return ParseGetgroupsArgs(decoder)
-	case events.Setgroups:
-		return ParseSetgroupsArgs(decoder)
-	case events.Setresuid:
-		return ParseSetresuidArgs(decoder)
-	case events.Getresuid:
-		return ParseGetresuidArgs(decoder)
-	case events.Setresgid:
-		return ParseSetresgidArgs(decoder)
-	case events.Getresgid:
-		return ParseGetresgidArgs(decoder)
-	case events.Getpgid:
-		return ParseGetpgidArgs(decoder)
-	case events.Setfsuid:
-		return ParseSetfsuidArgs(decoder)
-	case events.Setfsgid:
-		return ParseSetfsgidArgs(decoder)
-	case events.Getsid:
-		return ParseGetsidArgs(decoder)
-	case events.Capget:
-		return ParseCapgetArgs(decoder)
-	case events.Capset:
-		return ParseCapsetArgs(decoder)
-	case events.RtSigpending:
-		return ParseRtSigpendingArgs(decoder)
-	case events.RtSigtimedwait:
-		return ParseRtSigtimedwaitArgs(decoder)
-	case events.RtSigqueueinfo:
-		return ParseRtSigqueueinfoArgs(decoder)
-	case events.RtSigsuspend:
-		return ParseRtSigsuspendArgs(decoder)
-	case events.Sigaltstack:
-		return ParseSigaltstackArgs(decoder)
-	case events.Utime:
-		return ParseUtimeArgs(decoder)
-	case events.Mknod:
-		return ParseMknodArgs(decoder)
-	case events.Uselib:
-		return ParseUselibArgs(decoder)
-	case events.Personality:
-		return ParsePersonalityArgs(decoder)
-	case events.Ustat:
-		return ParseUstatArgs(decoder)
-	case events.Statfs:
-		return ParseStatfsArgs(decoder)
-	case events.Fstatfs:
-		return ParseFstatfsArgs(decoder)
-	case events.Sysfs:
-		return ParseSysfsArgs(decoder)
-	case events.Getpriority:
-		return ParseGetpriorityArgs(decoder)
-	case events.Setpriority:
-		return ParseSetpriorityArgs(decoder)
-	case events.SchedSetparam:
-		return ParseSchedSetparamArgs(decoder)
-	case events.SchedGetparam:
-		return ParseSchedGetparamArgs(decoder)
-	case events.SchedSetscheduler:
-		return ParseSchedSetschedulerArgs(decoder)
-	case events.SchedGetscheduler:
-		return ParseSchedGetschedulerArgs(decoder)
-	case events.SchedGetPriorityMax:
-		return ParseSchedGetPriorityMaxArgs(decoder)
-	case events.SchedGetPriorityMin:
-		return ParseSchedGetPriorityMinArgs(decoder)
-	case events.SchedRrGetInterval:
-		return ParseSchedRrGetIntervalArgs(decoder)
-	case events.Mlock:
-		return ParseMlockArgs(decoder)
-	case events.Munlock:
-		return ParseMunlockArgs(decoder)
-	case events.Mlockall:
-		return ParseMlockallArgs(decoder)
-	case events.Munlockall:
-		return ParseMunlockallArgs(decoder)
-	case events.Vhangup:
-		return ParseVhangupArgs(decoder)
-	case events.ModifyLdt:
-		return ParseModifyLdtArgs(decoder)
-	case events.PivotRoot:
-		return ParsePivotRootArgs(decoder)
-	case events.Sysctl:
-		return ParseSysctlArgs(decoder)
-	case events.Prctl:
-		return ParsePrctlArgs(decoder)
-	case events.ArchPrctl:
-		return ParseArchPrctlArgs(decoder)
-	case events.Adjtimex:
-		return ParseAdjtimexArgs(decoder)
-	case events.Setrlimit:
-		return ParseSetrlimitArgs(decoder)
-	case events.Chroot:
-		return ParseChrootArgs(decoder)
-	case events.Sync:
-		return ParseSyncArgs(decoder)
-	case events.Acct:
-		return ParseAcctArgs(decoder)
-	case events.Settimeofday:
-		return ParseSettimeofdayArgs(decoder)
-	case events.Mount:
-		return ParseMountArgs(decoder)
-	case events.Umount2:
-		return ParseUmount2Args(decoder)
-	case events.Swapon:
-		return ParseSwaponArgs(decoder)
-	case events.Swapoff:
-		return ParseSwapoffArgs(decoder)
-	case events.Reboot:
-		return ParseRebootArgs(decoder)
-	case events.Sethostname:
-		return ParseSethostnameArgs(decoder)
-	case events.Setdomainname:
-		return ParseSetdomainnameArgs(decoder)
-	case events.Iopl:
-		return ParseIoplArgs(decoder)
-	case events.Ioperm:
-		return ParseIopermArgs(decoder)
-	case events.CreateModule:
-		return ParseCreateModuleArgs(decoder)
-	case events.InitModule:
-		return ParseInitModuleArgs(decoder)
-	case events.DeleteModule:
-		return ParseDeleteModuleArgs(decoder)
-	case events.GetKernelSyms:
-		return ParseGetKernelSymsArgs(decoder)
-	case events.QueryModule:
-		return ParseQueryModuleArgs(decoder)
-	case events.Quotactl:
-		return ParseQuotactlArgs(decoder)
-	case events.Nfsservctl:
-		return ParseNfsservctlArgs(decoder)
-	case events.Getpmsg:
-		return ParseGetpmsgArgs(decoder)
-	case events.Putpmsg:
-		return ParsePutpmsgArgs(decoder)
-	case events.Afs:
-		return ParseAfsArgs(decoder)
-	case events.Tuxcall:
-		return ParseTuxcallArgs(decoder)
-	case events.Security:
-		return ParseSecurityArgs(decoder)
-	case events.Gettid:
-		return ParseGettidArgs(decoder)
-	case events.Readahead:
-		return ParseReadaheadArgs(decoder)
-	case events.Setxattr:
-		return ParseSetxattrArgs(decoder)
-	case events.Lsetxattr:
-		return ParseLsetxattrArgs(decoder)
-	case events.Fsetxattr:
-		return ParseFsetxattrArgs(decoder)
-	case events.Getxattr:
-		return ParseGetxattrArgs(decoder)
-	case events.Lgetxattr:
-		return ParseLgetxattrArgs(decoder)
-	case events.Fgetxattr:
-		return ParseFgetxattrArgs(decoder)
-	case events.Listxattr:
-		return ParseListxattrArgs(decoder)
-	case events.Llistxattr:
-		return ParseLlistxattrArgs(decoder)
-	case events.Flistxattr:
-		return ParseFlistxattrArgs(decoder)
-	case events.Removexattr:
-		return ParseRemovexattrArgs(decoder)
-	case events.Lremovexattr:
-		return ParseLremovexattrArgs(decoder)
-	case events.Fremovexattr:
-		return ParseFremovexattrArgs(decoder)
-	case events.Tkill:
-		return ParseTkillArgs(decoder)
-	case events.Time:
-		return ParseTimeArgs(decoder)
-	case events.Futex:
-		return ParseFutexArgs(decoder)
-	case events.SchedSetaffinity:
-		return ParseSchedSetaffinityArgs(decoder)
-	case events.SchedGetaffinity:
-		return ParseSchedGetaffinityArgs(decoder)
-	case events.SetThreadArea:
-		return ParseSetThreadAreaArgs(decoder)
-	case events.IoSetup:
-		return ParseIoSetupArgs(decoder)
-	case events.IoDestroy:
-		return ParseIoDestroyArgs(decoder)
-	case events.IoGetevents:
-		return ParseIoGeteventsArgs(decoder)
-	case events.IoSubmit:
-		return ParseIoSubmitArgs(decoder)
-	case events.IoCancel:
-		return ParseIoCancelArgs(decoder)
-	case events.GetThreadArea:
-		return ParseGetThreadAreaArgs(decoder)
-	case events.LookupDcookie:
-		return ParseLookupDcookieArgs(decoder)
-	case events.EpollCreate:
-		return ParseEpollCreateArgs(decoder)
-	case events.EpollCtlOld:
-		return ParseEpollCtlOldArgs(decoder)
-	case events.EpollWaitOld:
-		return ParseEpollWaitOldArgs(decoder)
-	case events.RemapFilePages:
-		return ParseRemapFilePagesArgs(decoder)
-	case events.Getdents64:
-		return ParseGetdents64Args(decoder)
-	case events.SetTidAddress:
-		return ParseSetTidAddressArgs(decoder)
-	case events.RestartSyscall:
-		return ParseRestartSyscallArgs(decoder)
-	case events.Semtimedop:
-		return ParseSemtimedopArgs(decoder)
-	case events.Fadvise64:
-		return ParseFadvise64Args(decoder)
-	case events.TimerCreate:
-		return ParseTimerCreateArgs(decoder)
-	case events.TimerSettime:
-		return ParseTimerSettimeArgs(decoder)
-	case events.TimerGettime:
-		return ParseTimerGettimeArgs(decoder)
-	case events.TimerGetoverrun:
-		return ParseTimerGetoverrunArgs(decoder)
-	case events.TimerDelete:
-		return ParseTimerDeleteArgs(decoder)
-	case events.ClockSettime:
-		return ParseClockSettimeArgs(decoder)
-	case events.ClockGettime:
-		return ParseClockGettimeArgs(decoder)
-	case events.ClockGetres:
-		return ParseClockGetresArgs(decoder)
-	case events.ClockNanosleep:
-		return ParseClockNanosleepArgs(decoder)
-	case events.ExitGroup:
-		return ParseExitGroupArgs(decoder)
-	case events.EpollWait:
-		return ParseEpollWaitArgs(decoder)
-	case events.EpollCtl:
-		return ParseEpollCtlArgs(decoder)
-	case events.Tgkill:
-		return ParseTgkillArgs(decoder)
-	case events.Utimes:
-		return ParseUtimesArgs(decoder)
-	case events.Vserver:
-		return ParseVserverArgs(decoder)
-	case events.Mbind:
-		return ParseMbindArgs(decoder)
-	case events.SetMempolicy:
-		return ParseSetMempolicyArgs(decoder)
-	case events.GetMempolicy:
-		return ParseGetMempolicyArgs(decoder)
-	case events.MqOpen:
-		return ParseMqOpenArgs(decoder)
-	case events.MqUnlink:
-		return ParseMqUnlinkArgs(decoder)
-	case events.MqTimedsend:
-		return ParseMqTimedsendArgs(decoder)
-	case events.MqTimedreceive:
-		return ParseMqTimedreceiveArgs(decoder)
-	case events.MqNotify:
-		return ParseMqNotifyArgs(decoder)
-	case events.MqGetsetattr:
-		return ParseMqGetsetattrArgs(decoder)
-	case events.KexecLoad:
-		return ParseKexecLoadArgs(decoder)
-	case events.Waitid:
-		return ParseWaitidArgs(decoder)
-	case events.AddKey:
-		return ParseAddKeyArgs(decoder)
-	case events.RequestKey:
-		return ParseRequestKeyArgs(decoder)
-	case events.Keyctl:
-		return ParseKeyctlArgs(decoder)
-	case events.IoprioSet:
-		return ParseIoprioSetArgs(decoder)
-	case events.IoprioGet:
-		return ParseIoprioGetArgs(decoder)
-	case events.InotifyInit:
-		return ParseInotifyInitArgs(decoder)
-	case events.InotifyAddWatch:
-		return ParseInotifyAddWatchArgs(decoder)
-	case events.InotifyRmWatch:
-		return ParseInotifyRmWatchArgs(decoder)
-	case events.MigratePages:
-		return ParseMigratePagesArgs(decoder)
-	case events.Openat:
-		return ParseOpenatArgs(decoder)
-	case events.Mkdirat:
-		return ParseMkdiratArgs(decoder)
-	case events.Mknodat:
-		return ParseMknodatArgs(decoder)
-	case events.Fchownat:
-		return ParseFchownatArgs(decoder)
-	case events.Futimesat:
-		return ParseFutimesatArgs(decoder)
-	case events.Newfstatat:
-		return ParseNewfstatatArgs(decoder)
-	case events.Unlinkat:
-		return ParseUnlinkatArgs(decoder)
-	case events.Renameat:
-		return ParseRenameatArgs(decoder)
-	case events.Linkat:
-		return ParseLinkatArgs(decoder)
-	case events.Symlinkat:
-		return ParseSymlinkatArgs(decoder)
-	case events.Readlinkat:
-		return ParseReadlinkatArgs(decoder)
-	case events.Fchmodat:
-		return ParseFchmodatArgs(decoder)
-	case events.Faccessat:
-		return ParseFaccessatArgs(decoder)
-	case events.Pselect6:
-		return ParsePselect6Args(decoder)
-	case events.Ppoll:
-		return ParsePpollArgs(decoder)
-	case events.Unshare:
-		return ParseUnshareArgs(decoder)
-	case events.SetRobustList:
-		return ParseSetRobustListArgs(decoder)
-	case events.GetRobustList:
-		return ParseGetRobustListArgs(decoder)
-	case events.Splice:
-		return ParseSpliceArgs(decoder)
-	case events.Tee:
-		return ParseTeeArgs(decoder)
-	case events.SyncFileRange:
-		return ParseSyncFileRangeArgs(decoder)
-	case events.Vmsplice:
-		return ParseVmspliceArgs(decoder)
-	case events.MovePages:
-		return ParseMovePagesArgs(decoder)
-	case events.Utimensat:
-		return ParseUtimensatArgs(decoder)
-	case events.EpollPwait:
-		return ParseEpollPwaitArgs(decoder)
-	case events.Signalfd:
-		return ParseSignalfdArgs(decoder)
-	case events.TimerfdCreate:
-		return ParseTimerfdCreateArgs(decoder)
-	case events.Eventfd:
-		return ParseEventfdArgs(decoder)
-	case events.Fallocate:
-		return ParseFallocateArgs(decoder)
-	case events.TimerfdSettime:
-		return ParseTimerfdSettimeArgs(decoder)
-	case events.TimerfdGettime:
-		return ParseTimerfdGettimeArgs(decoder)
-	case events.Accept4:
-		return ParseAccept4Args(decoder)
-	case events.Signalfd4:
-		return ParseSignalfd4Args(decoder)
-	case events.Eventfd2:
-		return ParseEventfd2Args(decoder)
-	case events.EpollCreate1:
-		return ParseEpollCreate1Args(decoder)
-	case events.Dup3:
-		return ParseDup3Args(decoder)
-	case events.Pipe2:
-		return ParsePipe2Args(decoder)
-	case events.InotifyInit1:
-		return ParseInotifyInit1Args(decoder)
-	case events.Preadv:
-		return ParsePreadvArgs(decoder)
-	case events.Pwritev:
-		return ParsePwritevArgs(decoder)
-	case events.RtTgsigqueueinfo:
-		return ParseRtTgsigqueueinfoArgs(decoder)
-	case events.PerfEventOpen:
-		return ParsePerfEventOpenArgs(decoder)
-	case events.Recvmmsg:
-		return ParseRecvmmsgArgs(decoder)
-	case events.FanotifyInit:
-		return ParseFanotifyInitArgs(decoder)
-	case events.FanotifyMark:
-		return ParseFanotifyMarkArgs(decoder)
-	case events.Prlimit64:
-		return ParsePrlimit64Args(decoder)
-	case events.NameToHandleAt:
-		return ParseNameToHandleAtArgs(decoder)
-	case events.OpenByHandleAt:
-		return ParseOpenByHandleAtArgs(decoder)
-	case events.ClockAdjtime:
-		return ParseClockAdjtimeArgs(decoder)
-	case events.Syncfs:
-		return ParseSyncfsArgs(decoder)
-	case events.Sendmmsg:
-		return ParseSendmmsgArgs(decoder)
-	case events.Setns:
-		return ParseSetnsArgs(decoder)
-	case events.Getcpu:
-		return ParseGetcpuArgs(decoder)
-	case events.ProcessVmReadv:
-		return ParseProcessVmReadvArgs(decoder)
-	case events.ProcessVmWritev:
-		return ParseProcessVmWritevArgs(decoder)
-	case events.Kcmp:
-		return ParseKcmpArgs(decoder)
-	case events.FinitModule:
-		return ParseFinitModuleArgs(decoder)
-	case events.SchedSetattr:
-		return ParseSchedSetattrArgs(decoder)
-	case events.SchedGetattr:
-		return ParseSchedGetattrArgs(decoder)
-	case events.Renameat2:
-		return ParseRenameat2Args(decoder)
-	case events.Seccomp:
-		return ParseSeccompArgs(decoder)
-	case events.Getrandom:
-		return ParseGetrandomArgs(decoder)
-	case events.MemfdCreate:
-		return ParseMemfdCreateArgs(decoder)
-	case events.KexecFileLoad:
-		return ParseKexecFileLoadArgs(decoder)
-	case events.Bpf:
-		return ParseBpfArgs(decoder)
-	case events.Execveat:
-		return ParseExecveatArgs(decoder)
-	case events.Userfaultfd:
-		return ParseUserfaultfdArgs(decoder)
-	case events.Membarrier:
-		return ParseMembarrierArgs(decoder)
-	case events.Mlock2:
-		return ParseMlock2Args(decoder)
-	case events.CopyFileRange:
-		return ParseCopyFileRangeArgs(decoder)
-	case events.Preadv2:
-		return ParsePreadv2Args(decoder)
-	case events.Pwritev2:
-		return ParsePwritev2Args(decoder)
-	case events.PkeyMprotect:
-		return ParsePkeyMprotectArgs(decoder)
-	case events.PkeyAlloc:
-		return ParsePkeyAllocArgs(decoder)
-	case events.PkeyFree:
-		return ParsePkeyFreeArgs(decoder)
-	case events.Statx:
-		return ParseStatxArgs(decoder)
-	case events.IoPgetevents:
-		return ParseIoPgeteventsArgs(decoder)
-	case events.Rseq:
-		return ParseRseqArgs(decoder)
-	case events.PidfdSendSignal:
-		return ParsePidfdSendSignalArgs(decoder)
-	case events.IoUringSetup:
-		return ParseIoUringSetupArgs(decoder)
-	case events.IoUringEnter:
-		return ParseIoUringEnterArgs(decoder)
-	case events.IoUringRegister:
-		return ParseIoUringRegisterArgs(decoder)
-	case events.OpenTree:
-		return ParseOpenTreeArgs(decoder)
-	case events.MoveMount:
-		return ParseMoveMountArgs(decoder)
-	case events.Fsopen:
-		return ParseFsopenArgs(decoder)
-	case events.Fsconfig:
-		return ParseFsconfigArgs(decoder)
-	case events.Fsmount:
-		return ParseFsmountArgs(decoder)
-	case events.Fspick:
-		return ParseFspickArgs(decoder)
-	case events.PidfdOpen:
-		return ParsePidfdOpenArgs(decoder)
-	case events.Clone3:
-		return ParseClone3Args(decoder)
-	case events.CloseRange:
-		return ParseCloseRangeArgs(decoder)
-	case events.Openat2:
-		return ParseOpenat2Args(decoder)
-	case events.PidfdGetfd:
-		return ParsePidfdGetfdArgs(decoder)
-	case events.Faccessat2:
-		return ParseFaccessat2Args(decoder)
-	case events.ProcessMadvise:
-		return ParseProcessMadviseArgs(decoder)
-	case events.EpollPwait2:
-		return ParseEpollPwait2Args(decoder)
-	case events.MountSetatt:
-		return ParseMountSetattArgs(decoder)
-	case events.QuotactlFd:
-		return ParseQuotactlFdArgs(decoder)
-	case events.LandlockCreateRuleset:
-		return ParseLandlockCreateRulesetArgs(decoder)
-	case events.LandlockAddRule:
-		return ParseLandlockAddRuleArgs(decoder)
-	case events.LandloclRestrictSet:
-		return ParseLandloclRestrictSetArgs(decoder)
-	case events.MemfdSecret:
-		return ParseMemfdSecretArgs(decoder)
-	case events.ProcessMrelease:
-		return ParseProcessMreleaseArgs(decoder)
-	case events.Waitpid:
-		return ParseWaitpidArgs(decoder)
-	case events.Oldfstat:
-		return ParseOldfstatArgs(decoder)
-	case events.Break:
-		return ParseBreakArgs(decoder)
-	case events.Oldstat:
-		return ParseOldstatArgs(decoder)
-	case events.Umount:
-		return ParseUmountArgs(decoder)
-	case events.Stime:
-		return ParseStimeArgs(decoder)
-	case events.Stty:
-		return ParseSttyArgs(decoder)
-	case events.Gtty:
-		return ParseGttyArgs(decoder)
-	case events.Nice:
-		return ParseNiceArgs(decoder)
-	case events.Ftime:
-		return ParseFtimeArgs(decoder)
-	case events.Prof:
-		return ParseProfArgs(decoder)
-	case events.Signal:
-		return ParseSignalArgs(decoder)
-	case events.Lock:
-		return ParseLockArgs(decoder)
-	case events.Mpx:
-		return ParseMpxArgs(decoder)
-	case events.Ulimit:
-		return ParseUlimitArgs(decoder)
-	case events.Oldolduname:
-		return ParseOldoldunameArgs(decoder)
-	case events.Sigaction:
-		return ParseSigactionArgs(decoder)
-	case events.Sgetmask:
-		return ParseSgetmaskArgs(decoder)
-	case events.Ssetmask:
-		return ParseSsetmaskArgs(decoder)
-	case events.Sigsuspend:
-		return ParseSigsuspendArgs(decoder)
-	case events.Sigpending:
-		return ParseSigpendingArgs(decoder)
-	case events.Oldlstat:
-		return ParseOldlstatArgs(decoder)
-	case events.Readdir:
-		return ParseReaddirArgs(decoder)
-	case events.Profil:
-		return ParseProfilArgs(decoder)
-	case events.Socketcall:
-		return ParseSocketcallArgs(decoder)
-	case events.Olduname:
-		return ParseOldunameArgs(decoder)
-	case events.Idle:
-		return ParseIdleArgs(decoder)
-	case events.Vm86old:
-		return ParseVm86oldArgs(decoder)
-	case events.Ipc:
-		return ParseIpcArgs(decoder)
-	case events.Sigreturn:
-		return ParseSigreturnArgs(decoder)
-	case events.Sigprocmask:
-		return ParseSigprocmaskArgs(decoder)
-	case events.Bdflush:
-		return ParseBdflushArgs(decoder)
-	case events.Afs_syscall:
-		return ParseAfs_syscallArgs(decoder)
-	case events.Llseek:
-		return ParseLlseekArgs(decoder)
-	case events.OldSelect:
-		return ParseOldSelectArgs(decoder)
-	case events.Vm86:
-		return ParseVm86Args(decoder)
-	case events.OldGetrlimit:
-		return ParseOldGetrlimitArgs(decoder)
-	case events.Mmap2:
-		return ParseMmap2Args(decoder)
-	case events.Truncate64:
-		return ParseTruncate64Args(decoder)
-	case events.Ftruncate64:
-		return ParseFtruncate64Args(decoder)
-	case events.Stat64:
-		return ParseStat64Args(decoder)
-	case events.Lstat64:
-		return ParseLstat64Args(decoder)
-	case events.Fstat64:
-		return ParseFstat64Args(decoder)
-	case events.Lchown16:
-		return ParseLchown16Args(decoder)
-	case events.Getuid16:
-		return ParseGetuid16Args(decoder)
-	case events.Getgid16:
-		return ParseGetgid16Args(decoder)
-	case events.Geteuid16:
-		return ParseGeteuid16Args(decoder)
-	case events.Getegid16:
-		return ParseGetegid16Args(decoder)
-	case events.Setreuid16:
-		return ParseSetreuid16Args(decoder)
-	case events.Setregid16:
-		return ParseSetregid16Args(decoder)
-	case events.Getgroups16:
-		return ParseGetgroups16Args(decoder)
-	case events.Setgroups16:
-		return ParseSetgroups16Args(decoder)
-	case events.Fchown16:
-		return ParseFchown16Args(decoder)
-	case events.Setresuid16:
-		return ParseSetresuid16Args(decoder)
-	case events.Getresuid16:
-		return ParseGetresuid16Args(decoder)
-	case events.Setresgid16:
-		return ParseSetresgid16Args(decoder)
-	case events.Getresgid16:
-		return ParseGetresgid16Args(decoder)
-	case events.Chown16:
-		return ParseChown16Args(decoder)
-	case events.Setuid16:
-		return ParseSetuid16Args(decoder)
-	case events.Setgid16:
-		return ParseSetgid16Args(decoder)
-	case events.Setfsuid16:
-		return ParseSetfsuid16Args(decoder)
-	case events.Setfsgid16:
-		return ParseSetfsgid16Args(decoder)
-	case events.Fcntl64:
-		return ParseFcntl64Args(decoder)
-	case events.Sendfile32:
-		return ParseSendfile32Args(decoder)
-	case events.Statfs64:
-		return ParseStatfs64Args(decoder)
-	case events.Fstatfs64:
-		return ParseFstatfs64Args(decoder)
-	case events.Fadvise64_64:
-		return ParseFadvise64_64Args(decoder)
-	case events.ClockGettime32:
-		return ParseClockGettime32Args(decoder)
-	case events.ClockSettime32:
-		return ParseClockSettime32Args(decoder)
-	case events.ClockAdjtime64:
-		return ParseClockAdjtime64Args(decoder)
-	case events.ClockGetresTime32:
-		return ParseClockGetresTime32Args(decoder)
-	case events.ClockNanosleepTime32:
-		return ParseClockNanosleepTime32Args(decoder)
-	case events.TimerGettime32:
-		return ParseTimerGettime32Args(decoder)
-	case events.TimerSettime32:
-		return ParseTimerSettime32Args(decoder)
-	case events.TimerfdGettime32:
-		return ParseTimerfdGettime32Args(decoder)
-	case events.TimerfdSettime32:
-		return ParseTimerfdSettime32Args(decoder)
-	case events.UtimensatTime32:
-		return ParseUtimensatTime32Args(decoder)
-	case events.Pselect6Time32:
-		return ParsePselect6Time32Args(decoder)
-	case events.PpollTime32:
-		return ParsePpollTime32Args(decoder)
-	case events.IoPgeteventsTime32:
-		return ParseIoPgeteventsTime32Args(decoder)
-	case events.RecvmmsgTime32:
-		return ParseRecvmmsgTime32Args(decoder)
-	case events.MqTimedsendTime32:
-		return ParseMqTimedsendTime32Args(decoder)
-	case events.MqTimedreceiveTime32:
-		return ParseMqTimedreceiveTime32Args(decoder)
-	case events.RtSigtimedwaitTime32:
-		return ParseRtSigtimedwaitTime32Args(decoder)
-	case events.FutexTime32:
-		return ParseFutexTime32Args(decoder)
-	case events.SchedRrGetInterval32:
-		return ParseSchedRrGetInterval32Args(decoder)
-	case events.SysEnter:
-		return ParseSysEnterArgs(decoder)
-	case events.SysExit:
-		return ParseSysExitArgs(decoder)
-	case events.SchedProcessFork:
-		return ParseSchedProcessForkArgs(decoder)
-	case events.SchedProcessExec:
-		return ParseSchedProcessExecArgs(decoder)
-	case events.SchedProcessExit:
-		return ParseSchedProcessExitArgs(decoder)
-	case events.SchedSwitch:
-		return ParseSchedSwitchArgs(decoder)
-	case events.ProcessOomKilled:
-		return ParseProcessOomKilledArgs(decoder)
-	case events.DoExit:
-		return ParseDoExitArgs(decoder)
-	case events.CapCapable:
-		return ParseCapCapableArgs(decoder)
-	case events.VfsWrite:
-		return ParseVfsWriteArgs(decoder)
-	case events.VfsWritev:
-		return ParseVfsWritevArgs(decoder)
-	case events.MemProtAlert:
-		return ParseMemProtAlertArgs(decoder)
-	case events.CommitCreds:
-		return ParseCommitCredsArgs(decoder)
-	case events.SwitchTaskNS:
-		return ParseSwitchTaskNSArgs(decoder)
-	case events.MagicWrite:
-		return ParseMagicWriteArgs(decoder)
-	case events.CgroupAttachTask:
-		return ParseCgroupAttachTaskArgs(decoder)
-	case events.CgroupMkdir:
-		return ParseCgroupMkdirArgs(decoder)
-	case events.CgroupRmdir:
-		return ParseCgroupRmdirArgs(decoder)
-	case events.SecurityFileOpen:
-		return ParseSecurityFileOpenArgs(decoder)
-	case events.SecurityInodeUnlink:
-		return ParseSecurityInodeUnlinkArgs(decoder)
-	case events.SecuritySocketCreate:
-		return ParseSecuritySocketCreateArgs(decoder)
-	case events.SecuritySocketListen:
-		return ParseSecuritySocketListenArgs(decoder)
-	case events.SecuritySocketConnect:
-		return ParseSecuritySocketConnectArgs(decoder)
-	case events.SecuritySocketAccept:
-		return ParseSecuritySocketAcceptArgs(decoder)
-	case events.SecuritySocketBind:
-		return ParseSecuritySocketBindArgs(decoder)
-	case events.SecuritySocketSetsockopt:
-		return ParseSecuritySocketSetsockoptArgs(decoder)
-	case events.SecuritySbMount:
-		return ParseSecuritySbMountArgs(decoder)
-	case events.SecurityBPF:
-		return ParseSecurityBPFArgs(decoder)
-	case events.SecurityBPFMap:
-		return ParseSecurityBPFMapArgs(decoder)
-	case events.SecurityKernelReadFile:
-		return ParseSecurityKernelReadFileArgs(decoder)
-	case events.SecurityPostReadFile:
-		return ParseSecurityPostReadFileArgs(decoder)
-	case events.SecurityInodeMknod:
-		return ParseSecurityInodeMknodArgs(decoder)
-	case events.SecurityInodeSymlinkEventId:
-		return ParseSecurityInodeSymlinkEventIdArgs(decoder)
-	case events.SecurityMmapFile:
-		return ParseSecurityMmapFileArgs(decoder)
-	case events.DoMmap:
-		return ParseDoMmapArgs(decoder)
-	case events.SecurityFileMprotect:
-		return ParseSecurityFileMprotectArgs(decoder)
-	case events.InitNamespaces:
-		return ParseInitNamespacesArgs(decoder)
-	case events.SocketDup:
-		return ParseSocketDupArgs(decoder)
-	case events.HiddenInodes:
-		return ParseHiddenInodesArgs(decoder)
-	case events.KernelWrite:
-		return ParseKernelWriteArgs(decoder)
-	case events.DirtyPipeSplice:
-		return ParseDirtyPipeSpliceArgs(decoder)
-	case events.ContainerCreate:
-		return ParseContainerCreateArgs(decoder)
-	case events.ContainerRemove:
-		return ParseContainerRemoveArgs(decoder)
-	case events.ExistingContainer:
-		return ParseExistingContainerArgs(decoder)
-	case events.ProcCreate:
-		return ParseProcCreateArgs(decoder)
-	case events.KprobeAttach:
-		return ParseKprobeAttachArgs(decoder)
-	case events.CallUsermodeHelper:
-		return ParseCallUsermodeHelperArgs(decoder)
-	case events.DebugfsCreateFile:
-		return ParseDebugfsCreateFileArgs(decoder)
-	case events.PrintSyscallTable:
-		return ParsePrintSyscallTableArgs(decoder)
-	case events.HiddenKernelModule:
-		return ParseHiddenKernelModuleArgs(decoder)
-	case events.HiddenKernelModuleSeeker:
-		return ParseHiddenKernelModuleSeekerArgs(decoder)
-	case events.HookedSyscalls:
-		return ParseHookedSyscallsArgs(decoder)
-	case events.DebugfsCreateDir:
-		return ParseDebugfsCreateDirArgs(decoder)
-	case events.DeviceAdd:
-		return ParseDeviceAddArgs(decoder)
-	case events.RegisterChrdev:
-		return ParseRegisterChrdevArgs(decoder)
-	case events.SharedObjectLoaded:
-		return ParseSharedObjectLoadedArgs(decoder)
-	case events.SymbolsLoaded:
-		return ParseSymbolsLoadedArgs(decoder)
-	case events.SymbolsCollision:
-		return ParseSymbolsCollisionArgs(decoder)
-	case events.CaptureFileWrite:
-		return ParseCaptureFileWriteArgs(decoder)
-	case events.CaptureFileRead:
-		return ParseCaptureFileReadArgs(decoder)
-	case events.CaptureExec:
-		return ParseCaptureExecArgs(decoder)
-	case events.CaptureModule:
-		return ParseCaptureModuleArgs(decoder)
-	case events.CaptureMem:
-		return ParseCaptureMemArgs(decoder)
-	case events.CaptureBpf:
-		return ParseCaptureBpfArgs(decoder)
-	case events.DoInitModule:
-		return ParseDoInitModuleArgs(decoder)
-	case events.ModuleLoad:
-		return ParseModuleLoadArgs(decoder)
-	case events.ModuleFree:
-		return ParseModuleFreeArgs(decoder)
-	case events.SocketAccept:
-		return ParseSocketAcceptArgs(decoder)
-	case events.LoadElfPhdrs:
-		return ParseLoadElfPhdrsArgs(decoder)
-	case events.HookedProcFops:
-		return ParseHookedProcFopsArgs(decoder)
-	case events.PrintNetSeqOps:
-		return ParsePrintNetSeqOpsArgs(decoder)
-	case events.HookedSeqOps:
-		return ParseHookedSeqOpsArgs(decoder)
-	case events.TaskRename:
-		return ParseTaskRenameArgs(decoder)
-	case events.SecurityInodeRename:
-		return ParseSecurityInodeRenameArgs(decoder)
-	case events.DoSigaction:
-		return ParseDoSigactionArgs(decoder)
-	case events.BpfAttach:
-		return ParseBpfAttachArgs(decoder)
-	case events.KallsymsLookupName:
-		return ParseKallsymsLookupNameArgs(decoder)
-	case events.PrintMemDump:
-		return ParsePrintMemDumpArgs(decoder)
-	case events.VfsRead:
-		return ParseVfsReadArgs(decoder)
-	case events.VfsReadv:
-		return ParseVfsReadvArgs(decoder)
-	case events.VfsUtimes:
-		return ParseVfsUtimesArgs(decoder)
-	case events.DoTruncate:
-		return ParseDoTruncateArgs(decoder)
-	case events.FileModification:
-		return ParseFileModificationArgs(decoder)
-	case events.InotifyWatch:
-		return ParseInotifyWatchArgs(decoder)
-	case events.ProcessExecuteFailed:
-		return ParseProcessExecuteFailedArgs(decoder)
-	case events.NetPacketBase:
-		return ParseNetPacketBaseArgs(decoder)
-	case events.NetPacketIPBase:
-		return ParseNetPacketIPBaseArgs(decoder)
-	case events.NetPacketIPv4:
-		return ParseNetPacketIPv4Args(decoder)
-	case events.NetPacketIPv6:
-		return ParseNetPacketIPv6Args(decoder)
-	case events.NetPacketTCPBase:
-		return ParseNetPacketTCPBaseArgs(decoder)
-	case events.NetPacketTCP:
-		return ParseNetPacketTCPArgs(decoder)
-	case events.NetPacketUDPBase:
-		return ParseNetPacketUDPBaseArgs(decoder)
-	case events.NetPacketUDP:
-		return ParseNetPacketUDPArgs(decoder)
-	case events.NetPacketICMPBase:
-		return ParseNetPacketICMPBaseArgs(decoder)
-	case events.NetPacketICMP:
-		return ParseNetPacketICMPArgs(decoder)
-	case events.NetPacketICMPv6Base:
-		return ParseNetPacketICMPv6BaseArgs(decoder)
-	case events.NetPacketICMPv6:
-		return ParseNetPacketICMPv6Args(decoder)
-	case events.NetPacketDNSBase:
-		return ParseNetPacketDNSBaseArgs(decoder)
-	case events.NetPacketDNS:
-		return ParseNetPacketDNSArgs(decoder)
-	case events.NetPacketDNSRequest:
-		return ParseNetPacketDNSRequestArgs(decoder)
-	case events.NetPacketDNSResponse:
-		return ParseNetPacketDNSResponseArgs(decoder)
-	case events.NetPacketHTTPBase:
-		return ParseNetPacketHTTPBaseArgs(decoder)
-	case events.NetPacketHTTP:
-		return ParseNetPacketHTTPArgs(decoder)
-	case events.NetPacketHTTPRequest:
-		return ParseNetPacketHTTPRequestArgs(decoder)
-	case events.NetPacketHTTPResponse:
-		return ParseNetPacketHTTPResponseArgs(decoder)
-	case events.NetPacketCapture:
-		return ParseNetPacketCaptureArgs(decoder)
-	case events.CaptureNetPacket:
-		return ParseCaptureNetPacketArgs(decoder)
-	case events.SockSetState:
-		return ParseSockSetStateArgs(decoder)
-	case events.TrackSyscallStats:
-		return ParseTrackSyscallStatsArgs(decoder)
-	case events.TestEvent:
-		return ParseTestEventArgs(decoder)
-	}
+  switch event {
+  case events.Read:
+    return ParseReadArgs(decoder)
+  case events.Write:
+    return ParseWriteArgs(decoder)
+  case events.Open:
+    return ParseOpenArgs(decoder)
+  case events.Close:
+    return ParseCloseArgs(decoder)
+  case events.Stat:
+    return ParseStatArgs(decoder)
+  case events.Fstat:
+    return ParseFstatArgs(decoder)
+  case events.Lstat:
+    return ParseLstatArgs(decoder)
+  case events.Poll:
+    return ParsePollArgs(decoder)
+  case events.Lseek:
+    return ParseLseekArgs(decoder)
+  case events.Mmap:
+    return ParseMmapArgs(decoder)
+  case events.Mprotect:
+    return ParseMprotectArgs(decoder)
+  case events.Munmap:
+    return ParseMunmapArgs(decoder)
+  case events.Brk:
+    return ParseBrkArgs(decoder)
+  case events.RtSigaction:
+    return ParseRtSigactionArgs(decoder)
+  case events.RtSigprocmask:
+    return ParseRtSigprocmaskArgs(decoder)
+  case events.RtSigreturn:
+    return ParseRtSigreturnArgs(decoder)
+  case events.Ioctl:
+    return ParseIoctlArgs(decoder)
+  case events.Pread64:
+    return ParsePread64Args(decoder)
+  case events.Pwrite64:
+    return ParsePwrite64Args(decoder)
+  case events.Readv:
+    return ParseReadvArgs(decoder)
+  case events.Writev:
+    return ParseWritevArgs(decoder)
+  case events.Access:
+    return ParseAccessArgs(decoder)
+  case events.Pipe:
+    return ParsePipeArgs(decoder)
+  case events.Select:
+    return ParseSelectArgs(decoder)
+  case events.SchedYield:
+    return ParseSchedYieldArgs(decoder)
+  case events.Mremap:
+    return ParseMremapArgs(decoder)
+  case events.Msync:
+    return ParseMsyncArgs(decoder)
+  case events.Mincore:
+    return ParseMincoreArgs(decoder)
+  case events.Madvise:
+    return ParseMadviseArgs(decoder)
+  case events.Shmget:
+    return ParseShmgetArgs(decoder)
+  case events.Shmat:
+    return ParseShmatArgs(decoder)
+  case events.Shmctl:
+    return ParseShmctlArgs(decoder)
+  case events.Dup:
+    return ParseDupArgs(decoder)
+  case events.Dup2:
+    return ParseDup2Args(decoder)
+  case events.Pause:
+    return ParsePauseArgs(decoder)
+  case events.Nanosleep:
+    return ParseNanosleepArgs(decoder)
+  case events.Getitimer:
+    return ParseGetitimerArgs(decoder)
+  case events.Alarm:
+    return ParseAlarmArgs(decoder)
+  case events.Setitimer:
+    return ParseSetitimerArgs(decoder)
+  case events.Getpid:
+    return ParseGetpidArgs(decoder)
+  case events.Sendfile:
+    return ParseSendfileArgs(decoder)
+  case events.Socket:
+    return ParseSocketArgs(decoder)
+  case events.Connect:
+    return ParseConnectArgs(decoder)
+  case events.Accept:
+    return ParseAcceptArgs(decoder)
+  case events.Sendto:
+    return ParseSendtoArgs(decoder)
+  case events.Recvfrom:
+    return ParseRecvfromArgs(decoder)
+  case events.Sendmsg:
+    return ParseSendmsgArgs(decoder)
+  case events.Recvmsg:
+    return ParseRecvmsgArgs(decoder)
+  case events.Shutdown:
+    return ParseShutdownArgs(decoder)
+  case events.Bind:
+    return ParseBindArgs(decoder)
+  case events.Listen:
+    return ParseListenArgs(decoder)
+  case events.Getsockname:
+    return ParseGetsocknameArgs(decoder)
+  case events.Getpeername:
+    return ParseGetpeernameArgs(decoder)
+  case events.Socketpair:
+    return ParseSocketpairArgs(decoder)
+  case events.Setsockopt:
+    return ParseSetsockoptArgs(decoder)
+  case events.Getsockopt:
+    return ParseGetsockoptArgs(decoder)
+  case events.Clone:
+    return ParseCloneArgs(decoder)
+  case events.Fork:
+    return ParseForkArgs(decoder)
+  case events.Vfork:
+    return ParseVforkArgs(decoder)
+  case events.Execve:
+    return ParseExecveArgs(decoder)
+  case events.Exit:
+    return ParseExitArgs(decoder)
+  case events.Wait4:
+    return ParseWait4Args(decoder)
+  case events.Kill:
+    return ParseKillArgs(decoder)
+  case events.Uname:
+    return ParseUnameArgs(decoder)
+  case events.Semget:
+    return ParseSemgetArgs(decoder)
+  case events.Semop:
+    return ParseSemopArgs(decoder)
+  case events.Semctl:
+    return ParseSemctlArgs(decoder)
+  case events.Shmdt:
+    return ParseShmdtArgs(decoder)
+  case events.Msgget:
+    return ParseMsggetArgs(decoder)
+  case events.Msgsnd:
+    return ParseMsgsndArgs(decoder)
+  case events.Msgrcv:
+    return ParseMsgrcvArgs(decoder)
+  case events.Msgctl:
+    return ParseMsgctlArgs(decoder)
+  case events.Fcntl:
+    return ParseFcntlArgs(decoder)
+  case events.Flock:
+    return ParseFlockArgs(decoder)
+  case events.Fsync:
+    return ParseFsyncArgs(decoder)
+  case events.Fdatasync:
+    return ParseFdatasyncArgs(decoder)
+  case events.Truncate:
+    return ParseTruncateArgs(decoder)
+  case events.Ftruncate:
+    return ParseFtruncateArgs(decoder)
+  case events.Getdents:
+    return ParseGetdentsArgs(decoder)
+  case events.Getcwd:
+    return ParseGetcwdArgs(decoder)
+  case events.Chdir:
+    return ParseChdirArgs(decoder)
+  case events.Fchdir:
+    return ParseFchdirArgs(decoder)
+  case events.Rename:
+    return ParseRenameArgs(decoder)
+  case events.Mkdir:
+    return ParseMkdirArgs(decoder)
+  case events.Rmdir:
+    return ParseRmdirArgs(decoder)
+  case events.Creat:
+    return ParseCreatArgs(decoder)
+  case events.Link:
+    return ParseLinkArgs(decoder)
+  case events.Unlink:
+    return ParseUnlinkArgs(decoder)
+  case events.Symlink:
+    return ParseSymlinkArgs(decoder)
+  case events.Readlink:
+    return ParseReadlinkArgs(decoder)
+  case events.Chmod:
+    return ParseChmodArgs(decoder)
+  case events.Fchmod:
+    return ParseFchmodArgs(decoder)
+  case events.Chown:
+    return ParseChownArgs(decoder)
+  case events.Fchown:
+    return ParseFchownArgs(decoder)
+  case events.Lchown:
+    return ParseLchownArgs(decoder)
+  case events.Umask:
+    return ParseUmaskArgs(decoder)
+  case events.Gettimeofday:
+    return ParseGettimeofdayArgs(decoder)
+  case events.Getrlimit:
+    return ParseGetrlimitArgs(decoder)
+  case events.Getrusage:
+    return ParseGetrusageArgs(decoder)
+  case events.Sysinfo:
+    return ParseSysinfoArgs(decoder)
+  case events.Times:
+    return ParseTimesArgs(decoder)
+  case events.Ptrace:
+    return ParsePtraceArgs(decoder)
+  case events.Getuid:
+    return ParseGetuidArgs(decoder)
+  case events.Syslog:
+    return ParseSyslogArgs(decoder)
+  case events.Getgid:
+    return ParseGetgidArgs(decoder)
+  case events.Setuid:
+    return ParseSetuidArgs(decoder)
+  case events.Setgid:
+    return ParseSetgidArgs(decoder)
+  case events.Geteuid:
+    return ParseGeteuidArgs(decoder)
+  case events.Getegid:
+    return ParseGetegidArgs(decoder)
+  case events.Setpgid:
+    return ParseSetpgidArgs(decoder)
+  case events.Getppid:
+    return ParseGetppidArgs(decoder)
+  case events.Getpgrp:
+    return ParseGetpgrpArgs(decoder)
+  case events.Setsid:
+    return ParseSetsidArgs(decoder)
+  case events.Setreuid:
+    return ParseSetreuidArgs(decoder)
+  case events.Setregid:
+    return ParseSetregidArgs(decoder)
+  case events.Getgroups:
+    return ParseGetgroupsArgs(decoder)
+  case events.Setgroups:
+    return ParseSetgroupsArgs(decoder)
+  case events.Setresuid:
+    return ParseSetresuidArgs(decoder)
+  case events.Getresuid:
+    return ParseGetresuidArgs(decoder)
+  case events.Setresgid:
+    return ParseSetresgidArgs(decoder)
+  case events.Getresgid:
+    return ParseGetresgidArgs(decoder)
+  case events.Getpgid:
+    return ParseGetpgidArgs(decoder)
+  case events.Setfsuid:
+    return ParseSetfsuidArgs(decoder)
+  case events.Setfsgid:
+    return ParseSetfsgidArgs(decoder)
+  case events.Getsid:
+    return ParseGetsidArgs(decoder)
+  case events.Capget:
+    return ParseCapgetArgs(decoder)
+  case events.Capset:
+    return ParseCapsetArgs(decoder)
+  case events.RtSigpending:
+    return ParseRtSigpendingArgs(decoder)
+  case events.RtSigtimedwait:
+    return ParseRtSigtimedwaitArgs(decoder)
+  case events.RtSigqueueinfo:
+    return ParseRtSigqueueinfoArgs(decoder)
+  case events.RtSigsuspend:
+    return ParseRtSigsuspendArgs(decoder)
+  case events.Sigaltstack:
+    return ParseSigaltstackArgs(decoder)
+  case events.Utime:
+    return ParseUtimeArgs(decoder)
+  case events.Mknod:
+    return ParseMknodArgs(decoder)
+  case events.Uselib:
+    return ParseUselibArgs(decoder)
+  case events.Personality:
+    return ParsePersonalityArgs(decoder)
+  case events.Ustat:
+    return ParseUstatArgs(decoder)
+  case events.Statfs:
+    return ParseStatfsArgs(decoder)
+  case events.Fstatfs:
+    return ParseFstatfsArgs(decoder)
+  case events.Sysfs:
+    return ParseSysfsArgs(decoder)
+  case events.Getpriority:
+    return ParseGetpriorityArgs(decoder)
+  case events.Setpriority:
+    return ParseSetpriorityArgs(decoder)
+  case events.SchedSetparam:
+    return ParseSchedSetparamArgs(decoder)
+  case events.SchedGetparam:
+    return ParseSchedGetparamArgs(decoder)
+  case events.SchedSetscheduler:
+    return ParseSchedSetschedulerArgs(decoder)
+  case events.SchedGetscheduler:
+    return ParseSchedGetschedulerArgs(decoder)
+  case events.SchedGetPriorityMax:
+    return ParseSchedGetPriorityMaxArgs(decoder)
+  case events.SchedGetPriorityMin:
+    return ParseSchedGetPriorityMinArgs(decoder)
+  case events.SchedRrGetInterval:
+    return ParseSchedRrGetIntervalArgs(decoder)
+  case events.Mlock:
+    return ParseMlockArgs(decoder)
+  case events.Munlock:
+    return ParseMunlockArgs(decoder)
+  case events.Mlockall:
+    return ParseMlockallArgs(decoder)
+  case events.Munlockall:
+    return ParseMunlockallArgs(decoder)
+  case events.Vhangup:
+    return ParseVhangupArgs(decoder)
+  case events.ModifyLdt:
+    return ParseModifyLdtArgs(decoder)
+  case events.PivotRoot:
+    return ParsePivotRootArgs(decoder)
+  case events.Sysctl:
+    return ParseSysctlArgs(decoder)
+  case events.Prctl:
+    return ParsePrctlArgs(decoder)
+  case events.ArchPrctl:
+    return ParseArchPrctlArgs(decoder)
+  case events.Adjtimex:
+    return ParseAdjtimexArgs(decoder)
+  case events.Setrlimit:
+    return ParseSetrlimitArgs(decoder)
+  case events.Chroot:
+    return ParseChrootArgs(decoder)
+  case events.Sync:
+    return ParseSyncArgs(decoder)
+  case events.Acct:
+    return ParseAcctArgs(decoder)
+  case events.Settimeofday:
+    return ParseSettimeofdayArgs(decoder)
+  case events.Mount:
+    return ParseMountArgs(decoder)
+  case events.Umount2:
+    return ParseUmount2Args(decoder)
+  case events.Swapon:
+    return ParseSwaponArgs(decoder)
+  case events.Swapoff:
+    return ParseSwapoffArgs(decoder)
+  case events.Reboot:
+    return ParseRebootArgs(decoder)
+  case events.Sethostname:
+    return ParseSethostnameArgs(decoder)
+  case events.Setdomainname:
+    return ParseSetdomainnameArgs(decoder)
+  case events.Iopl:
+    return ParseIoplArgs(decoder)
+  case events.Ioperm:
+    return ParseIopermArgs(decoder)
+  case events.CreateModule:
+    return ParseCreateModuleArgs(decoder)
+  case events.InitModule:
+    return ParseInitModuleArgs(decoder)
+  case events.DeleteModule:
+    return ParseDeleteModuleArgs(decoder)
+  case events.GetKernelSyms:
+    return ParseGetKernelSymsArgs(decoder)
+  case events.QueryModule:
+    return ParseQueryModuleArgs(decoder)
+  case events.Quotactl:
+    return ParseQuotactlArgs(decoder)
+  case events.Nfsservctl:
+    return ParseNfsservctlArgs(decoder)
+  case events.Getpmsg:
+    return ParseGetpmsgArgs(decoder)
+  case events.Putpmsg:
+    return ParsePutpmsgArgs(decoder)
+  case events.Afs:
+    return ParseAfsArgs(decoder)
+  case events.Tuxcall:
+    return ParseTuxcallArgs(decoder)
+  case events.Security:
+    return ParseSecurityArgs(decoder)
+  case events.Gettid:
+    return ParseGettidArgs(decoder)
+  case events.Readahead:
+    return ParseReadaheadArgs(decoder)
+  case events.Setxattr:
+    return ParseSetxattrArgs(decoder)
+  case events.Lsetxattr:
+    return ParseLsetxattrArgs(decoder)
+  case events.Fsetxattr:
+    return ParseFsetxattrArgs(decoder)
+  case events.Getxattr:
+    return ParseGetxattrArgs(decoder)
+  case events.Lgetxattr:
+    return ParseLgetxattrArgs(decoder)
+  case events.Fgetxattr:
+    return ParseFgetxattrArgs(decoder)
+  case events.Listxattr:
+    return ParseListxattrArgs(decoder)
+  case events.Llistxattr:
+    return ParseLlistxattrArgs(decoder)
+  case events.Flistxattr:
+    return ParseFlistxattrArgs(decoder)
+  case events.Removexattr:
+    return ParseRemovexattrArgs(decoder)
+  case events.Lremovexattr:
+    return ParseLremovexattrArgs(decoder)
+  case events.Fremovexattr:
+    return ParseFremovexattrArgs(decoder)
+  case events.Tkill:
+    return ParseTkillArgs(decoder)
+  case events.Time:
+    return ParseTimeArgs(decoder)
+  case events.Futex:
+    return ParseFutexArgs(decoder)
+  case events.SchedSetaffinity:
+    return ParseSchedSetaffinityArgs(decoder)
+  case events.SchedGetaffinity:
+    return ParseSchedGetaffinityArgs(decoder)
+  case events.SetThreadArea:
+    return ParseSetThreadAreaArgs(decoder)
+  case events.IoSetup:
+    return ParseIoSetupArgs(decoder)
+  case events.IoDestroy:
+    return ParseIoDestroyArgs(decoder)
+  case events.IoGetevents:
+    return ParseIoGeteventsArgs(decoder)
+  case events.IoSubmit:
+    return ParseIoSubmitArgs(decoder)
+  case events.IoCancel:
+    return ParseIoCancelArgs(decoder)
+  case events.GetThreadArea:
+    return ParseGetThreadAreaArgs(decoder)
+  case events.LookupDcookie:
+    return ParseLookupDcookieArgs(decoder)
+  case events.EpollCreate:
+    return ParseEpollCreateArgs(decoder)
+  case events.EpollCtlOld:
+    return ParseEpollCtlOldArgs(decoder)
+  case events.EpollWaitOld:
+    return ParseEpollWaitOldArgs(decoder)
+  case events.RemapFilePages:
+    return ParseRemapFilePagesArgs(decoder)
+  case events.Getdents64:
+    return ParseGetdents64Args(decoder)
+  case events.SetTidAddress:
+    return ParseSetTidAddressArgs(decoder)
+  case events.RestartSyscall:
+    return ParseRestartSyscallArgs(decoder)
+  case events.Semtimedop:
+    return ParseSemtimedopArgs(decoder)
+  case events.Fadvise64:
+    return ParseFadvise64Args(decoder)
+  case events.TimerCreate:
+    return ParseTimerCreateArgs(decoder)
+  case events.TimerSettime:
+    return ParseTimerSettimeArgs(decoder)
+  case events.TimerGettime:
+    return ParseTimerGettimeArgs(decoder)
+  case events.TimerGetoverrun:
+    return ParseTimerGetoverrunArgs(decoder)
+  case events.TimerDelete:
+    return ParseTimerDeleteArgs(decoder)
+  case events.ClockSettime:
+    return ParseClockSettimeArgs(decoder)
+  case events.ClockGettime:
+    return ParseClockGettimeArgs(decoder)
+  case events.ClockGetres:
+    return ParseClockGetresArgs(decoder)
+  case events.ClockNanosleep:
+    return ParseClockNanosleepArgs(decoder)
+  case events.ExitGroup:
+    return ParseExitGroupArgs(decoder)
+  case events.EpollWait:
+    return ParseEpollWaitArgs(decoder)
+  case events.EpollCtl:
+    return ParseEpollCtlArgs(decoder)
+  case events.Tgkill:
+    return ParseTgkillArgs(decoder)
+  case events.Utimes:
+    return ParseUtimesArgs(decoder)
+  case events.Vserver:
+    return ParseVserverArgs(decoder)
+  case events.Mbind:
+    return ParseMbindArgs(decoder)
+  case events.SetMempolicy:
+    return ParseSetMempolicyArgs(decoder)
+  case events.GetMempolicy:
+    return ParseGetMempolicyArgs(decoder)
+  case events.MqOpen:
+    return ParseMqOpenArgs(decoder)
+  case events.MqUnlink:
+    return ParseMqUnlinkArgs(decoder)
+  case events.MqTimedsend:
+    return ParseMqTimedsendArgs(decoder)
+  case events.MqTimedreceive:
+    return ParseMqTimedreceiveArgs(decoder)
+  case events.MqNotify:
+    return ParseMqNotifyArgs(decoder)
+  case events.MqGetsetattr:
+    return ParseMqGetsetattrArgs(decoder)
+  case events.KexecLoad:
+    return ParseKexecLoadArgs(decoder)
+  case events.Waitid:
+    return ParseWaitidArgs(decoder)
+  case events.AddKey:
+    return ParseAddKeyArgs(decoder)
+  case events.RequestKey:
+    return ParseRequestKeyArgs(decoder)
+  case events.Keyctl:
+    return ParseKeyctlArgs(decoder)
+  case events.IoprioSet:
+    return ParseIoprioSetArgs(decoder)
+  case events.IoprioGet:
+    return ParseIoprioGetArgs(decoder)
+  case events.InotifyInit:
+    return ParseInotifyInitArgs(decoder)
+  case events.InotifyAddWatch:
+    return ParseInotifyAddWatchArgs(decoder)
+  case events.InotifyRmWatch:
+    return ParseInotifyRmWatchArgs(decoder)
+  case events.MigratePages:
+    return ParseMigratePagesArgs(decoder)
+  case events.Openat:
+    return ParseOpenatArgs(decoder)
+  case events.Mkdirat:
+    return ParseMkdiratArgs(decoder)
+  case events.Mknodat:
+    return ParseMknodatArgs(decoder)
+  case events.Fchownat:
+    return ParseFchownatArgs(decoder)
+  case events.Futimesat:
+    return ParseFutimesatArgs(decoder)
+  case events.Newfstatat:
+    return ParseNewfstatatArgs(decoder)
+  case events.Unlinkat:
+    return ParseUnlinkatArgs(decoder)
+  case events.Renameat:
+    return ParseRenameatArgs(decoder)
+  case events.Linkat:
+    return ParseLinkatArgs(decoder)
+  case events.Symlinkat:
+    return ParseSymlinkatArgs(decoder)
+  case events.Readlinkat:
+    return ParseReadlinkatArgs(decoder)
+  case events.Fchmodat:
+    return ParseFchmodatArgs(decoder)
+  case events.Faccessat:
+    return ParseFaccessatArgs(decoder)
+  case events.Pselect6:
+    return ParsePselect6Args(decoder)
+  case events.Ppoll:
+    return ParsePpollArgs(decoder)
+  case events.Unshare:
+    return ParseUnshareArgs(decoder)
+  case events.SetRobustList:
+    return ParseSetRobustListArgs(decoder)
+  case events.GetRobustList:
+    return ParseGetRobustListArgs(decoder)
+  case events.Splice:
+    return ParseSpliceArgs(decoder)
+  case events.Tee:
+    return ParseTeeArgs(decoder)
+  case events.SyncFileRange:
+    return ParseSyncFileRangeArgs(decoder)
+  case events.Vmsplice:
+    return ParseVmspliceArgs(decoder)
+  case events.MovePages:
+    return ParseMovePagesArgs(decoder)
+  case events.Utimensat:
+    return ParseUtimensatArgs(decoder)
+  case events.EpollPwait:
+    return ParseEpollPwaitArgs(decoder)
+  case events.Signalfd:
+    return ParseSignalfdArgs(decoder)
+  case events.TimerfdCreate:
+    return ParseTimerfdCreateArgs(decoder)
+  case events.Eventfd:
+    return ParseEventfdArgs(decoder)
+  case events.Fallocate:
+    return ParseFallocateArgs(decoder)
+  case events.TimerfdSettime:
+    return ParseTimerfdSettimeArgs(decoder)
+  case events.TimerfdGettime:
+    return ParseTimerfdGettimeArgs(decoder)
+  case events.Accept4:
+    return ParseAccept4Args(decoder)
+  case events.Signalfd4:
+    return ParseSignalfd4Args(decoder)
+  case events.Eventfd2:
+    return ParseEventfd2Args(decoder)
+  case events.EpollCreate1:
+    return ParseEpollCreate1Args(decoder)
+  case events.Dup3:
+    return ParseDup3Args(decoder)
+  case events.Pipe2:
+    return ParsePipe2Args(decoder)
+  case events.InotifyInit1:
+    return ParseInotifyInit1Args(decoder)
+  case events.Preadv:
+    return ParsePreadvArgs(decoder)
+  case events.Pwritev:
+    return ParsePwritevArgs(decoder)
+  case events.RtTgsigqueueinfo:
+    return ParseRtTgsigqueueinfoArgs(decoder)
+  case events.PerfEventOpen:
+    return ParsePerfEventOpenArgs(decoder)
+  case events.Recvmmsg:
+    return ParseRecvmmsgArgs(decoder)
+  case events.FanotifyInit:
+    return ParseFanotifyInitArgs(decoder)
+  case events.FanotifyMark:
+    return ParseFanotifyMarkArgs(decoder)
+  case events.Prlimit64:
+    return ParsePrlimit64Args(decoder)
+  case events.NameToHandleAt:
+    return ParseNameToHandleAtArgs(decoder)
+  case events.OpenByHandleAt:
+    return ParseOpenByHandleAtArgs(decoder)
+  case events.ClockAdjtime:
+    return ParseClockAdjtimeArgs(decoder)
+  case events.Syncfs:
+    return ParseSyncfsArgs(decoder)
+  case events.Sendmmsg:
+    return ParseSendmmsgArgs(decoder)
+  case events.Setns:
+    return ParseSetnsArgs(decoder)
+  case events.Getcpu:
+    return ParseGetcpuArgs(decoder)
+  case events.ProcessVmReadv:
+    return ParseProcessVmReadvArgs(decoder)
+  case events.ProcessVmWritev:
+    return ParseProcessVmWritevArgs(decoder)
+  case events.Kcmp:
+    return ParseKcmpArgs(decoder)
+  case events.FinitModule:
+    return ParseFinitModuleArgs(decoder)
+  case events.SchedSetattr:
+    return ParseSchedSetattrArgs(decoder)
+  case events.SchedGetattr:
+    return ParseSchedGetattrArgs(decoder)
+  case events.Renameat2:
+    return ParseRenameat2Args(decoder)
+  case events.Seccomp:
+    return ParseSeccompArgs(decoder)
+  case events.Getrandom:
+    return ParseGetrandomArgs(decoder)
+  case events.MemfdCreate:
+    return ParseMemfdCreateArgs(decoder)
+  case events.KexecFileLoad:
+    return ParseKexecFileLoadArgs(decoder)
+  case events.Bpf:
+    return ParseBpfArgs(decoder)
+  case events.Execveat:
+    return ParseExecveatArgs(decoder)
+  case events.Userfaultfd:
+    return ParseUserfaultfdArgs(decoder)
+  case events.Membarrier:
+    return ParseMembarrierArgs(decoder)
+  case events.Mlock2:
+    return ParseMlock2Args(decoder)
+  case events.CopyFileRange:
+    return ParseCopyFileRangeArgs(decoder)
+  case events.Preadv2:
+    return ParsePreadv2Args(decoder)
+  case events.Pwritev2:
+    return ParsePwritev2Args(decoder)
+  case events.PkeyMprotect:
+    return ParsePkeyMprotectArgs(decoder)
+  case events.PkeyAlloc:
+    return ParsePkeyAllocArgs(decoder)
+  case events.PkeyFree:
+    return ParsePkeyFreeArgs(decoder)
+  case events.Statx:
+    return ParseStatxArgs(decoder)
+  case events.IoPgetevents:
+    return ParseIoPgeteventsArgs(decoder)
+  case events.Rseq:
+    return ParseRseqArgs(decoder)
+  case events.PidfdSendSignal:
+    return ParsePidfdSendSignalArgs(decoder)
+  case events.IoUringSetup:
+    return ParseIoUringSetupArgs(decoder)
+  case events.IoUringEnter:
+    return ParseIoUringEnterArgs(decoder)
+  case events.IoUringRegister:
+    return ParseIoUringRegisterArgs(decoder)
+  case events.OpenTree:
+    return ParseOpenTreeArgs(decoder)
+  case events.MoveMount:
+    return ParseMoveMountArgs(decoder)
+  case events.Fsopen:
+    return ParseFsopenArgs(decoder)
+  case events.Fsconfig:
+    return ParseFsconfigArgs(decoder)
+  case events.Fsmount:
+    return ParseFsmountArgs(decoder)
+  case events.Fspick:
+    return ParseFspickArgs(decoder)
+  case events.PidfdOpen:
+    return ParsePidfdOpenArgs(decoder)
+  case events.Clone3:
+    return ParseClone3Args(decoder)
+  case events.CloseRange:
+    return ParseCloseRangeArgs(decoder)
+  case events.Openat2:
+    return ParseOpenat2Args(decoder)
+  case events.PidfdGetfd:
+    return ParsePidfdGetfdArgs(decoder)
+  case events.Faccessat2:
+    return ParseFaccessat2Args(decoder)
+  case events.ProcessMadvise:
+    return ParseProcessMadviseArgs(decoder)
+  case events.EpollPwait2:
+    return ParseEpollPwait2Args(decoder)
+  case events.MountSetatt:
+    return ParseMountSetattArgs(decoder)
+  case events.QuotactlFd:
+    return ParseQuotactlFdArgs(decoder)
+  case events.LandlockCreateRuleset:
+    return ParseLandlockCreateRulesetArgs(decoder)
+  case events.LandlockAddRule:
+    return ParseLandlockAddRuleArgs(decoder)
+  case events.LandloclRestrictSet:
+    return ParseLandloclRestrictSetArgs(decoder)
+  case events.MemfdSecret:
+    return ParseMemfdSecretArgs(decoder)
+  case events.ProcessMrelease:
+    return ParseProcessMreleaseArgs(decoder)
+  case events.Waitpid:
+    return ParseWaitpidArgs(decoder)
+  case events.Oldfstat:
+    return ParseOldfstatArgs(decoder)
+  case events.Break:
+    return ParseBreakArgs(decoder)
+  case events.Oldstat:
+    return ParseOldstatArgs(decoder)
+  case events.Umount:
+    return ParseUmountArgs(decoder)
+  case events.Stime:
+    return ParseStimeArgs(decoder)
+  case events.Stty:
+    return ParseSttyArgs(decoder)
+  case events.Gtty:
+    return ParseGttyArgs(decoder)
+  case events.Nice:
+    return ParseNiceArgs(decoder)
+  case events.Ftime:
+    return ParseFtimeArgs(decoder)
+  case events.Prof:
+    return ParseProfArgs(decoder)
+  case events.Signal:
+    return ParseSignalArgs(decoder)
+  case events.Lock:
+    return ParseLockArgs(decoder)
+  case events.Mpx:
+    return ParseMpxArgs(decoder)
+  case events.Ulimit:
+    return ParseUlimitArgs(decoder)
+  case events.Oldolduname:
+    return ParseOldoldunameArgs(decoder)
+  case events.Sigaction:
+    return ParseSigactionArgs(decoder)
+  case events.Sgetmask:
+    return ParseSgetmaskArgs(decoder)
+  case events.Ssetmask:
+    return ParseSsetmaskArgs(decoder)
+  case events.Sigsuspend:
+    return ParseSigsuspendArgs(decoder)
+  case events.Sigpending:
+    return ParseSigpendingArgs(decoder)
+  case events.Oldlstat:
+    return ParseOldlstatArgs(decoder)
+  case events.Readdir:
+    return ParseReaddirArgs(decoder)
+  case events.Profil:
+    return ParseProfilArgs(decoder)
+  case events.Socketcall:
+    return ParseSocketcallArgs(decoder)
+  case events.Olduname:
+    return ParseOldunameArgs(decoder)
+  case events.Idle:
+    return ParseIdleArgs(decoder)
+  case events.Vm86old:
+    return ParseVm86oldArgs(decoder)
+  case events.Ipc:
+    return ParseIpcArgs(decoder)
+  case events.Sigreturn:
+    return ParseSigreturnArgs(decoder)
+  case events.Sigprocmask:
+    return ParseSigprocmaskArgs(decoder)
+  case events.Bdflush:
+    return ParseBdflushArgs(decoder)
+  case events.Afs_syscall:
+    return ParseAfs_syscallArgs(decoder)
+  case events.Llseek:
+    return ParseLlseekArgs(decoder)
+  case events.OldSelect:
+    return ParseOldSelectArgs(decoder)
+  case events.Vm86:
+    return ParseVm86Args(decoder)
+  case events.OldGetrlimit:
+    return ParseOldGetrlimitArgs(decoder)
+  case events.Mmap2:
+    return ParseMmap2Args(decoder)
+  case events.Truncate64:
+    return ParseTruncate64Args(decoder)
+  case events.Ftruncate64:
+    return ParseFtruncate64Args(decoder)
+  case events.Stat64:
+    return ParseStat64Args(decoder)
+  case events.Lstat64:
+    return ParseLstat64Args(decoder)
+  case events.Fstat64:
+    return ParseFstat64Args(decoder)
+  case events.Lchown16:
+    return ParseLchown16Args(decoder)
+  case events.Getuid16:
+    return ParseGetuid16Args(decoder)
+  case events.Getgid16:
+    return ParseGetgid16Args(decoder)
+  case events.Geteuid16:
+    return ParseGeteuid16Args(decoder)
+  case events.Getegid16:
+    return ParseGetegid16Args(decoder)
+  case events.Setreuid16:
+    return ParseSetreuid16Args(decoder)
+  case events.Setregid16:
+    return ParseSetregid16Args(decoder)
+  case events.Getgroups16:
+    return ParseGetgroups16Args(decoder)
+  case events.Setgroups16:
+    return ParseSetgroups16Args(decoder)
+  case events.Fchown16:
+    return ParseFchown16Args(decoder)
+  case events.Setresuid16:
+    return ParseSetresuid16Args(decoder)
+  case events.Getresuid16:
+    return ParseGetresuid16Args(decoder)
+  case events.Setresgid16:
+    return ParseSetresgid16Args(decoder)
+  case events.Getresgid16:
+    return ParseGetresgid16Args(decoder)
+  case events.Chown16:
+    return ParseChown16Args(decoder)
+  case events.Setuid16:
+    return ParseSetuid16Args(decoder)
+  case events.Setgid16:
+    return ParseSetgid16Args(decoder)
+  case events.Setfsuid16:
+    return ParseSetfsuid16Args(decoder)
+  case events.Setfsgid16:
+    return ParseSetfsgid16Args(decoder)
+  case events.Fcntl64:
+    return ParseFcntl64Args(decoder)
+  case events.Sendfile32:
+    return ParseSendfile32Args(decoder)
+  case events.Statfs64:
+    return ParseStatfs64Args(decoder)
+  case events.Fstatfs64:
+    return ParseFstatfs64Args(decoder)
+  case events.Fadvise64_64:
+    return ParseFadvise64_64Args(decoder)
+  case events.ClockGettime32:
+    return ParseClockGettime32Args(decoder)
+  case events.ClockSettime32:
+    return ParseClockSettime32Args(decoder)
+  case events.ClockAdjtime64:
+    return ParseClockAdjtime64Args(decoder)
+  case events.ClockGetresTime32:
+    return ParseClockGetresTime32Args(decoder)
+  case events.ClockNanosleepTime32:
+    return ParseClockNanosleepTime32Args(decoder)
+  case events.TimerGettime32:
+    return ParseTimerGettime32Args(decoder)
+  case events.TimerSettime32:
+    return ParseTimerSettime32Args(decoder)
+  case events.TimerfdGettime32:
+    return ParseTimerfdGettime32Args(decoder)
+  case events.TimerfdSettime32:
+    return ParseTimerfdSettime32Args(decoder)
+  case events.UtimensatTime32:
+    return ParseUtimensatTime32Args(decoder)
+  case events.Pselect6Time32:
+    return ParsePselect6Time32Args(decoder)
+  case events.PpollTime32:
+    return ParsePpollTime32Args(decoder)
+  case events.IoPgeteventsTime32:
+    return ParseIoPgeteventsTime32Args(decoder)
+  case events.RecvmmsgTime32:
+    return ParseRecvmmsgTime32Args(decoder)
+  case events.MqTimedsendTime32:
+    return ParseMqTimedsendTime32Args(decoder)
+  case events.MqTimedreceiveTime32:
+    return ParseMqTimedreceiveTime32Args(decoder)
+  case events.RtSigtimedwaitTime32:
+    return ParseRtSigtimedwaitTime32Args(decoder)
+  case events.FutexTime32:
+    return ParseFutexTime32Args(decoder)
+  case events.SchedRrGetInterval32:
+    return ParseSchedRrGetInterval32Args(decoder)
+  case events.SysEnter:
+    return ParseSysEnterArgs(decoder)
+  case events.SysExit:
+    return ParseSysExitArgs(decoder)
+  case events.SchedProcessFork:
+    return ParseSchedProcessForkArgs(decoder)
+  case events.SchedProcessExec:
+    return ParseSchedProcessExecArgs(decoder)
+  case events.SchedProcessExit:
+    return ParseSchedProcessExitArgs(decoder)
+  case events.SchedSwitch:
+    return ParseSchedSwitchArgs(decoder)
+  case events.ProcessOomKilled:
+    return ParseProcessOomKilledArgs(decoder)
+  case events.DoExit:
+    return ParseDoExitArgs(decoder)
+  case events.CapCapable:
+    return ParseCapCapableArgs(decoder)
+  case events.VfsWrite:
+    return ParseVfsWriteArgs(decoder)
+  case events.VfsWritev:
+    return ParseVfsWritevArgs(decoder)
+  case events.MemProtAlert:
+    return ParseMemProtAlertArgs(decoder)
+  case events.CommitCreds:
+    return ParseCommitCredsArgs(decoder)
+  case events.SwitchTaskNS:
+    return ParseSwitchTaskNSArgs(decoder)
+  case events.MagicWrite:
+    return ParseMagicWriteArgs(decoder)
+  case events.CgroupAttachTask:
+    return ParseCgroupAttachTaskArgs(decoder)
+  case events.CgroupMkdir:
+    return ParseCgroupMkdirArgs(decoder)
+  case events.CgroupRmdir:
+    return ParseCgroupRmdirArgs(decoder)
+  case events.SecurityFileOpen:
+    return ParseSecurityFileOpenArgs(decoder)
+  case events.SecurityInodeUnlink:
+    return ParseSecurityInodeUnlinkArgs(decoder)
+  case events.SecuritySocketCreate:
+    return ParseSecuritySocketCreateArgs(decoder)
+  case events.SecuritySocketListen:
+    return ParseSecuritySocketListenArgs(decoder)
+  case events.SecuritySocketConnect:
+    return ParseSecuritySocketConnectArgs(decoder)
+  case events.SecuritySocketAccept:
+    return ParseSecuritySocketAcceptArgs(decoder)
+  case events.SecuritySocketBind:
+    return ParseSecuritySocketBindArgs(decoder)
+  case events.SecuritySocketSetsockopt:
+    return ParseSecuritySocketSetsockoptArgs(decoder)
+  case events.SecuritySbMount:
+    return ParseSecuritySbMountArgs(decoder)
+  case events.SecurityBPF:
+    return ParseSecurityBPFArgs(decoder)
+  case events.SecurityBPFMap:
+    return ParseSecurityBPFMapArgs(decoder)
+  case events.SecurityKernelReadFile:
+    return ParseSecurityKernelReadFileArgs(decoder)
+  case events.SecurityPostReadFile:
+    return ParseSecurityPostReadFileArgs(decoder)
+  case events.SecurityInodeMknod:
+    return ParseSecurityInodeMknodArgs(decoder)
+  case events.SecurityInodeSymlinkEventId:
+    return ParseSecurityInodeSymlinkEventIdArgs(decoder)
+  case events.SecurityMmapFile:
+    return ParseSecurityMmapFileArgs(decoder)
+  case events.DoMmap:
+    return ParseDoMmapArgs(decoder)
+  case events.SecurityFileMprotect:
+    return ParseSecurityFileMprotectArgs(decoder)
+  case events.InitNamespaces:
+    return ParseInitNamespacesArgs(decoder)
+  case events.SocketDup:
+    return ParseSocketDupArgs(decoder)
+  case events.HiddenInodes:
+    return ParseHiddenInodesArgs(decoder)
+  case events.KernelWrite:
+    return ParseKernelWriteArgs(decoder)
+  case events.DirtyPipeSplice:
+    return ParseDirtyPipeSpliceArgs(decoder)
+  case events.ContainerCreate:
+    return ParseContainerCreateArgs(decoder)
+  case events.ContainerRemove:
+    return ParseContainerRemoveArgs(decoder)
+  case events.ExistingContainer:
+    return ParseExistingContainerArgs(decoder)
+  case events.ProcCreate:
+    return ParseProcCreateArgs(decoder)
+  case events.KprobeAttach:
+    return ParseKprobeAttachArgs(decoder)
+  case events.CallUsermodeHelper:
+    return ParseCallUsermodeHelperArgs(decoder)
+  case events.DebugfsCreateFile:
+    return ParseDebugfsCreateFileArgs(decoder)
+  case events.PrintSyscallTable:
+    return ParsePrintSyscallTableArgs(decoder)
+  case events.HiddenKernelModule:
+    return ParseHiddenKernelModuleArgs(decoder)
+  case events.HiddenKernelModuleSeeker:
+    return ParseHiddenKernelModuleSeekerArgs(decoder)
+  case events.HookedSyscalls:
+    return ParseHookedSyscallsArgs(decoder)
+  case events.DebugfsCreateDir:
+    return ParseDebugfsCreateDirArgs(decoder)
+  case events.DeviceAdd:
+    return ParseDeviceAddArgs(decoder)
+  case events.RegisterChrdev:
+    return ParseRegisterChrdevArgs(decoder)
+  case events.SharedObjectLoaded:
+    return ParseSharedObjectLoadedArgs(decoder)
+  case events.SymbolsLoaded:
+    return ParseSymbolsLoadedArgs(decoder)
+  case events.SymbolsCollision:
+    return ParseSymbolsCollisionArgs(decoder)
+  case events.CaptureFileWrite:
+    return ParseCaptureFileWriteArgs(decoder)
+  case events.CaptureFileRead:
+    return ParseCaptureFileReadArgs(decoder)
+  case events.CaptureExec:
+    return ParseCaptureExecArgs(decoder)
+  case events.CaptureModule:
+    return ParseCaptureModuleArgs(decoder)
+  case events.CaptureMem:
+    return ParseCaptureMemArgs(decoder)
+  case events.CaptureBpf:
+    return ParseCaptureBpfArgs(decoder)
+  case events.DoInitModule:
+    return ParseDoInitModuleArgs(decoder)
+  case events.ModuleLoad:
+    return ParseModuleLoadArgs(decoder)
+  case events.ModuleFree:
+    return ParseModuleFreeArgs(decoder)
+  case events.SocketAccept:
+    return ParseSocketAcceptArgs(decoder)
+  case events.LoadElfPhdrs:
+    return ParseLoadElfPhdrsArgs(decoder)
+  case events.PrintNetSeqOps:
+    return ParsePrintNetSeqOpsArgs(decoder)
+  case events.HookedSeqOps:
+    return ParseHookedSeqOpsArgs(decoder)
+  case events.TaskRename:
+    return ParseTaskRenameArgs(decoder)
+  case events.SecurityInodeRename:
+    return ParseSecurityInodeRenameArgs(decoder)
+  case events.DoSigaction:
+    return ParseDoSigactionArgs(decoder)
+  case events.BpfAttach:
+    return ParseBpfAttachArgs(decoder)
+  case events.KallsymsLookupName:
+    return ParseKallsymsLookupNameArgs(decoder)
+  case events.PrintMemDump:
+    return ParsePrintMemDumpArgs(decoder)
+  case events.VfsRead:
+    return ParseVfsReadArgs(decoder)
+  case events.VfsReadv:
+    return ParseVfsReadvArgs(decoder)
+  case events.VfsUtimes:
+    return ParseVfsUtimesArgs(decoder)
+  case events.DoTruncate:
+    return ParseDoTruncateArgs(decoder)
+  case events.FileModification:
+    return ParseFileModificationArgs(decoder)
+  case events.InotifyWatch:
+    return ParseInotifyWatchArgs(decoder)
+  case events.ProcessExecuteFailed:
+    return ParseProcessExecuteFailedArgs(decoder)
+  case events.NetPacketBase:
+    return ParseNetPacketBaseArgs(decoder)
+  case events.NetPacketIPBase:
+    return ParseNetPacketIPBaseArgs(decoder)
+  case events.NetPacketIPv4:
+    return ParseNetPacketIPv4Args(decoder)
+  case events.NetPacketIPv6:
+    return ParseNetPacketIPv6Args(decoder)
+  case events.NetPacketTCPBase:
+    return ParseNetPacketTCPBaseArgs(decoder)
+  case events.NetPacketTCP:
+    return ParseNetPacketTCPArgs(decoder)
+  case events.NetPacketUDPBase:
+    return ParseNetPacketUDPBaseArgs(decoder)
+  case events.NetPacketUDP:
+    return ParseNetPacketUDPArgs(decoder)
+  case events.NetPacketICMPBase:
+    return ParseNetPacketICMPBaseArgs(decoder)
+  case events.NetPacketICMP:
+    return ParseNetPacketICMPArgs(decoder)
+  case events.NetPacketICMPv6Base:
+    return ParseNetPacketICMPv6BaseArgs(decoder)
+  case events.NetPacketICMPv6:
+    return ParseNetPacketICMPv6Args(decoder)
+  case events.NetPacketDNSBase:
+    return ParseNetPacketDNSBaseArgs(decoder)
+  case events.NetPacketDNS:
+    return ParseNetPacketDNSArgs(decoder)
+  case events.NetPacketDNSRequest:
+    return ParseNetPacketDNSRequestArgs(decoder)
+  case events.NetPacketDNSResponse:
+    return ParseNetPacketDNSResponseArgs(decoder)
+  case events.NetPacketHTTPBase:
+    return ParseNetPacketHTTPBaseArgs(decoder)
+  case events.NetPacketHTTP:
+    return ParseNetPacketHTTPArgs(decoder)
+  case events.NetPacketHTTPRequest:
+    return ParseNetPacketHTTPRequestArgs(decoder)
+  case events.NetPacketHTTPResponse:
+    return ParseNetPacketHTTPResponseArgs(decoder)
+  case events.NetPacketCapture:
+    return ParseNetPacketCaptureArgs(decoder)
+  case events.CaptureNetPacket:
+    return ParseCaptureNetPacketArgs(decoder)
+  case events.SockSetState:
+    return ParseSockSetStateArgs(decoder)
+  case events.TrackSyscallStats:
+    return ParseTrackSyscallStatsArgs(decoder)
+  case events.TestEvent:
+    return ParseTestEventArgs(decoder)
+  case events.SignalCgroupMkdir:
+    return ParseSignalCgroupMkdirArgs(decoder)
+  case events.SignalCgroupRmdir:
+    return ParseSignalCgroupRmdirArgs(decoder)
+  }
 
-	return nil, ErrUnknownArgsType
+  return nil, ErrUnknownArgsType
 }

--- a/pkg/ebpftracer/decoder/decoder.go
+++ b/pkg/ebpftracer/decoder/decoder.go
@@ -50,6 +50,19 @@ func (decoder *Decoder) ReadAmountBytes() int {
 	return decoder.cursor
 }
 
+func (decoder *Decoder) DecodeSignalContext(ctx *types.SignalContext) error {
+	offset := decoder.cursor
+	if len(decoder.buffer[offset:]) < ctx.GetSizeBytes() {
+		return fmt.Errorf("signal context buffer size [%d] smaller than %d", len(decoder.buffer[offset:]), ctx.GetSizeBytes())
+	}
+
+	ctx.EventID = events.ID(binary.LittleEndian.Uint32(decoder.buffer[offset : offset+4]))
+
+	decoder.cursor += ctx.GetSizeBytes()
+
+	return nil
+}
+
 // DecodeContext translates data from the decoder buffer, starting from the decoder cursor, to bufferdecoder.eventContext struct.
 func (decoder *Decoder) DecodeContext(ctx *types.EventContext) error {
 	offset := decoder.cursor
@@ -77,9 +90,9 @@ func (decoder *Decoder) DecodeContext(ctx *types.EventContext) error {
 	_ = copy(ctx.UtsName[:], decoder.buffer[offset+80:offset+96])
 	ctx.Flags = binary.LittleEndian.Uint32(decoder.buffer[offset+96 : offset+100])
 	// task_context end
-  // 4 bytes padding
+	// 4 bytes padding
 
-	ctx.EventID = events.ID(int32(binary.LittleEndian.Uint32(decoder.buffer[offset+104 : offset+108])))
+	ctx.EventID = events.ID(binary.LittleEndian.Uint32(decoder.buffer[offset+104 : offset+108]))
 	ctx.Syscall = int32(binary.LittleEndian.Uint32(decoder.buffer[offset+108 : offset+112]))
 	ctx.MatchedPolicies = binary.LittleEndian.Uint64(decoder.buffer[offset+112 : offset+120])
 	ctx.Retval = int64(binary.LittleEndian.Uint64(decoder.buffer[offset+120 : offset+128]))

--- a/pkg/ebpftracer/decoder/decoder_test.go
+++ b/pkg/ebpftracer/decoder/decoder_test.go
@@ -52,6 +52,28 @@ func TestDecodeContext(t *testing.T) {
 	assert.Equal(t, int(ctxExpected.GetSizeBytes()), cursorAfter-cursorBefore)
 }
 
+func TestDecodeSignalContext(t *testing.T) {
+	buf := new(bytes.Buffer)
+	ctxExpected := types.SignalContext{
+		EventID: 100,
+	}
+	err := binary.Write(buf, binary.LittleEndian, ctxExpected)
+	assert.Equal(t, nil, err)
+	var ctxObtained types.SignalContext
+	rawData := buf.Bytes()
+	d := NewEventDecoder(log, rawData)
+	cursorBefore := d.cursor
+	err = d.DecodeSignalContext(&ctxObtained)
+	cursorAfter := d.cursor
+
+	// checking no error
+	assert.Equal(t, nil, err)
+	// checking decoding succeeded correctly
+	assert.Equal(t, ctxExpected, ctxObtained)
+	// checking decoder cursor on buffer moved appropriately
+	assert.Equal(t, int(ctxExpected.GetSizeBytes()), cursorAfter-cursorBefore)
+}
+
 func TestDecodeUint8(t *testing.T) {
 	buf := new(bytes.Buffer)
 	var expected uint8 = 42

--- a/pkg/ebpftracer/events.go
+++ b/pkg/ebpftracer/events.go
@@ -5562,9 +5562,9 @@ func newEventsDefinitionSet(objs *tracerObjects) map[events.ID]definition {
 			},
 			sets: []string{"lsm_hooks", "proc", "proc_life"},
 			params: []argMeta{
-				{Type: "const char*", Name: "pathname"},
-				{Type: "dev_t", Name: "dev"},
-				{Type: "unsigned long", Name: "inode"},
+				{Type: "u64", Name: "cgroup_id"},
+				{Type: "const char*", Name: "cgroup_path"},
+				{Type: "u32", Name: "hierarchy_id"},
 			},
 		},
 		events.SecurityFileOpen: {
@@ -7275,6 +7275,43 @@ func newEventsDefinitionSet(objs *tracerObjects) map[events.ID]definition {
 			name:     "test_event",
 			internal: true,
 			syscall:  false,
+		},
+		//
+		// Begin of Signal Events (Control Plane)
+		//
+		events.SignalCgroupMkdir: {
+			ID:       events.SignalCgroupMkdir,
+			id32Bit:  events.Sys32Undefined,
+			name:     "signal_cgroup_mkdir",
+			internal: true,
+			dependencies: dependencies{
+				probes: []EventProbe{
+					{handle: SignalCgroupMkdir, required: true},
+				},
+			},
+			sets: []string{"signal"},
+			params: []argMeta{
+				{Type: "u64", Name: "cgroup_id"},
+				{Type: "const char*", Name: "cgroup_path"},
+				{Type: "u32", Name: "hierarchy_id"},
+			},
+		},
+		events.SignalCgroupRmdir: {
+			ID:       events.SignalCgroupRmdir,
+			id32Bit:  events.Sys32Undefined,
+			name:     "signal_cgroup_rmdir",
+			internal: true,
+			dependencies: dependencies{
+				probes: []EventProbe{
+					{handle: SignalCgroupRmdir, required: true},
+				},
+			},
+			sets: []string{"signal"},
+			params: []argMeta{
+				{Type: "u64", Name: "cgroup_id"},
+				{Type: "const char*", Name: "cgroup_path"},
+				{Type: "u32", Name: "hierarchy_id"},
+			},
 		},
 	}
 }

--- a/pkg/ebpftracer/events/events.go
+++ b/pkg/ebpftracer/events/events.go
@@ -6,7 +6,7 @@ const (
 	Unsupported    ID = 10000
 )
 
-type ID int32
+type ID uint32
 
 // NOTE: Events should match defined values in ebpf code.
 
@@ -140,6 +140,15 @@ const (
 // Special events for stats aggregations and metrics.
 const (
 	TrackSyscallStats ID = iota + 4100
+)
+
+// Signal meta-events
+const (
+	SignalCgroupMkdir ID = iota + 5000
+	SignalCgroupRmdir
+	SignalSchedProcessFork
+	SignalSchedProcessExec
+	SignalSchedProcessExit
 )
 
 // Signature events

--- a/pkg/ebpftracer/probes.go
+++ b/pkg/ebpftracer/probes.go
@@ -240,6 +240,8 @@ const (
 	ProbeLayoutAndAllocate
 	ProbeInetSockSetState
 	ProbeOomMarkVictim
+	SignalCgroupMkdir
+	SignalCgroupRmdir
 )
 
 func newProbes(objs *tracerObjects, cgroupPath string) map[handle]probe {
@@ -350,5 +352,7 @@ func newProbes(objs *tracerObjects, cgroupPath string) map[handle]probe {
 		//ProbeLayoutAndAllocate:           NewTraceProbe(kretProbe, "layout_and_allocate", "trace_ret_layout_and_allocate"),
 		ProbeInetSockSetState: newTraceProbe(rawTracepoint, "sock:inet_sock_set_state", objs.TraceInetSockSetState),
 		ProbeOomMarkVictim:    newTraceProbe(rawTracepoint, "oom:mark_victim", objs.OomMarkVictim),
+		SignalCgroupMkdir:     newTraceProbe(rawTracepoint, "cgroup:cgroup_mkdir", objs.CgroupMkdirSignal),
+		SignalCgroupRmdir:     newTraceProbe(rawTracepoint, "cgroup:cgroup_rmdir", objs.CgroupRmdirSignal),
 	}
 }

--- a/pkg/ebpftracer/tracer_cleanup_test.go
+++ b/pkg/ebpftracer/tracer_cleanup_test.go
@@ -1,0 +1,131 @@
+package ebpftracer
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+)
+
+func TestCgroupCleanupLoop(t *testing.T) {
+	defer goleak.VerifyNone(t)
+	r := require.New(t)
+
+	tracer := buildTestTracer(withCgroupCleanupConfigured(100*time.Millisecond, 100*time.Millisecond))
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	doneChan := make(chan struct{}, 1)
+
+	go func() {
+		tracer.cgroupCleanupLoop(ctx)
+		doneChan <- struct{}{}
+	}()
+
+	tracer.queueCgroupForRemoval(10)
+	tracer.queueCgroupForRemoval(20)
+	tracer.queueCgroupForRemoval(30)
+
+	r.Len(tracer.requestedCgroupCleanups, 3)
+
+	r.Eventually(func() bool {
+		tracer.cgroupCleanupMu.Lock()
+		defer tracer.cgroupCleanupMu.Unlock()
+		return len(tracer.requestedCgroupCleanups) == 0
+	}, 5*time.Second, 100*time.Millisecond)
+
+	cancel()
+
+	select {
+	case <-doneChan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timeout reached!")
+	}
+}
+
+func TestGetCgroupsToCleanup(t *testing.T) {
+	type testCase struct {
+		title           string
+		now             time.Time
+		cleanupRequests []cgroupCleanupRequest
+	}
+
+	now := time.Now()
+
+	testCases := []testCase{
+		{
+			title: "requests before and after",
+			now:   now,
+			cleanupRequests: []cgroupCleanupRequest{
+				{
+					cgroupID:     10,
+					cleanupAfter: now.Add(-10 * time.Second),
+				},
+				{
+					cgroupID:     20,
+					cleanupAfter: now.Add(10 * time.Second),
+				},
+				{
+					cgroupID:     30,
+					cleanupAfter: now.Add(15 * time.Second),
+				},
+			},
+		},
+		{
+			title: "empty requests",
+			now:   now,
+		},
+		{
+			title: "only after",
+			now:   now,
+			cleanupRequests: []cgroupCleanupRequest{
+				{
+					cgroupID:     20,
+					cleanupAfter: now.Add(10 * time.Second),
+				},
+				{
+					cgroupID:     30,
+					cleanupAfter: now.Add(15 * time.Second),
+				},
+			},
+		},
+		{
+			title: "only before",
+			now:   now,
+			cleanupRequests: []cgroupCleanupRequest{
+				{
+					cgroupID:     20,
+					cleanupAfter: now.Add(-10 * time.Second),
+				},
+				{
+					cgroupID:     30,
+					cleanupAfter: now.Add(-5 * time.Second),
+				},
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.title, func(t *testing.T) {
+			r := require.New(t)
+
+			toCleanup, future := splitCleanupRequests(test.now, test.cleanupRequests)
+
+			for _, req := range toCleanup {
+				r.True(req.cleanupAfter.Before(test.now))
+			}
+			for _, req := range future {
+				r.False(req.cleanupAfter.Before(test.now))
+			}
+		})
+	}
+
+}
+
+func withCgroupCleanupConfigured(cleanupTickRate time.Duration, cleanupDelay time.Duration) tracerOption {
+	return func(t *Tracer) {
+		t.cleanupTimerTickRate = cleanupTickRate
+		t.cgroupCleanupDelay = cleanupDelay
+	}
+}

--- a/pkg/ebpftracer/tracer_test.go
+++ b/pkg/ebpftracer/tracer_test.go
@@ -64,16 +64,17 @@ func TestTracer(t *testing.T) {
 					PodUID:       dummyContainerID,
 					PodName:      "dummy-container-" + dummyContainerID,
 					Cgroup: &cgroup.Cgroup{
-						Id:            cgroupID,
-						Version:       cgroup.V2,
-						ContainerType: cgroup.ContainerTypeContainerd,
-						ContainerID:   dummyContainerID,
-						Path:          "",
+						Id:               cgroupID,
+						Version:          cgroup.V2,
+						ContainerRuntime: cgroup.ContainerdRuntime,
+						ContainerID:      dummyContainerID,
+						Path:             "",
 					},
 					PIDs: []uint32{},
 				}, nil
 			},
 		},
+		CgroupClient: &ebpftracer.MockCgroupClient{},
 		EnrichEvent: func(er *enrichment.EnrichRequest) bool {
 			return false
 		},

--- a/pkg/ebpftracer/types/args.go
+++ b/pkg/ebpftracer/types/args.go
@@ -3,7 +3,7 @@
 package types
 
 type Args interface {
-  args()
+	args()
 }
 
 // internalArgs is a marker type to distinguish Args interface from basically any
@@ -12,4257 +12,4257 @@ type internalArgs struct{}
 func (c internalArgs) args() {}
 
 type ReadArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Buf uintptr
-  Count uint64
+	Fd    int32
+	Buf   uintptr
+	Count uint64
 }
 
 type WriteArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Buf uintptr
-  Count uint64
+	Fd    int32
+	Buf   uintptr
+	Count uint64
 }
 
 type OpenArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Flags int32
-  Mode uint32
+	Pathname string
+	Flags    int32
+	Mode     uint32
 }
 
 type CloseArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
+	Fd int32
 }
 
 type StatArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Statbuf uintptr
+	Pathname string
+	Statbuf  uintptr
 }
 
 type FstatArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Statbuf uintptr
+	Fd      int32
+	Statbuf uintptr
 }
 
 type LstatArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Statbuf uintptr
+	Pathname string
+	Statbuf  uintptr
 }
 
 type PollArgs struct {
-  internalArgs
+	internalArgs
 
-  Fds uintptr
-  Nfds uint32
-  Timeout int32
+	Fds     uintptr
+	Nfds    uint32
+	Timeout int32
 }
 
 type LseekArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Offset uint64
-  Whence uint32
+	Fd     int32
+	Offset uint64
+	Whence uint32
 }
 
 type MmapArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Length uint64
-  Prot int32
-  Flags int32
-  Fd int32
-  Off uint64
+	Addr   uintptr
+	Length uint64
+	Prot   int32
+	Flags  int32
+	Fd     int32
+	Off    uint64
 }
 
 type MprotectArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Len uint64
-  Prot int32
+	Addr uintptr
+	Len  uint64
+	Prot int32
 }
 
 type MunmapArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Length uint64
+	Addr   uintptr
+	Length uint64
 }
 
 type BrkArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
+	Addr uintptr
 }
 
 type RtSigactionArgs struct {
-  internalArgs
+	internalArgs
 
-  Signum int32
-  Act uintptr
-  Oldact uintptr
-  Sigsetsize uint64
+	Signum     int32
+	Act        uintptr
+	Oldact     uintptr
+	Sigsetsize uint64
 }
 
 type RtSigprocmaskArgs struct {
-  internalArgs
+	internalArgs
 
-  How int32
-  Set uintptr
-  Oldset uintptr
-  Sigsetsize uint64
+	How        int32
+	Set        uintptr
+	Oldset     uintptr
+	Sigsetsize uint64
 }
 
 type RtSigreturnArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type IoctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Request uint64
-  Arg uint64
+	Fd      int32
+	Request uint64
+	Arg     uint64
 }
 
 type Pread64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Buf uintptr
-  Count uint64
-  Offset uint64
+	Fd     int32
+	Buf    uintptr
+	Count  uint64
+	Offset uint64
 }
 
 type Pwrite64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Buf uintptr
-  Count uint64
-  Offset uint64
+	Fd     int32
+	Buf    uintptr
+	Count  uint64
+	Offset uint64
 }
 
 type ReadvArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Iov uintptr
-  Iovcnt int32
+	Fd     int32
+	Iov    uintptr
+	Iovcnt int32
 }
 
 type WritevArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Iov uintptr
-  Iovcnt int32
+	Fd     int32
+	Iov    uintptr
+	Iovcnt int32
 }
 
 type AccessArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Mode int32
+	Pathname string
+	Mode     int32
 }
 
 type PipeArgs struct {
-  internalArgs
+	internalArgs
 
-  Pipefd [2]int32
+	Pipefd [2]int32
 }
 
 type SelectArgs struct {
-  internalArgs
+	internalArgs
 
-  Nfds int32
-  Readfds uintptr
-  Writefds uintptr
-  Exceptfds uintptr
-  Timeout uintptr
+	Nfds      int32
+	Readfds   uintptr
+	Writefds  uintptr
+	Exceptfds uintptr
+	Timeout   uintptr
 }
 
 type SchedYieldArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type MremapArgs struct {
-  internalArgs
+	internalArgs
 
-  OldAddress uintptr
-  OldSize uint64
-  NewSize uint64
-  Flags int32
-  NewAddress uintptr
+	OldAddress uintptr
+	OldSize    uint64
+	NewSize    uint64
+	Flags      int32
+	NewAddress uintptr
 }
 
 type MsyncArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Length uint64
-  Flags int32
+	Addr   uintptr
+	Length uint64
+	Flags  int32
 }
 
 type MincoreArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Length uint64
-  Vec uintptr
+	Addr   uintptr
+	Length uint64
+	Vec    uintptr
 }
 
 type MadviseArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Length uint64
-  Advice int32
+	Addr   uintptr
+	Length uint64
+	Advice int32
 }
 
 type ShmgetArgs struct {
-  internalArgs
+	internalArgs
 
-  Key int32
-  Size uint64
-  Shmflg int32
+	Key    int32
+	Size   uint64
+	Shmflg int32
 }
 
 type ShmatArgs struct {
-  internalArgs
+	internalArgs
 
-  Shmid int32
-  Shmaddr uintptr
-  Shmflg int32
+	Shmid   int32
+	Shmaddr uintptr
+	Shmflg  int32
 }
 
 type ShmctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Shmid int32
-  Cmd int32
-  Buf uintptr
+	Shmid int32
+	Cmd   int32
+	Buf   uintptr
 }
 
 type DupArgs struct {
-  internalArgs
+	internalArgs
 
-  Oldfd int32
+	Oldfd int32
 }
 
 type Dup2Args struct {
-  internalArgs
+	internalArgs
 
-  Oldfd int32
-  Newfd int32
+	Oldfd int32
+	Newfd int32
 }
 
 type PauseArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type NanosleepArgs struct {
-  internalArgs
+	internalArgs
 
-  Req float64
-  Rem float64
+	Req float64
+	Rem float64
 }
 
 type GetitimerArgs struct {
-  internalArgs
+	internalArgs
 
-  Which int32
-  CurrValue uintptr
+	Which     int32
+	CurrValue uintptr
 }
 
 type AlarmArgs struct {
-  internalArgs
+	internalArgs
 
-  Seconds uint32
+	Seconds uint32
 }
 
 type SetitimerArgs struct {
-  internalArgs
+	internalArgs
 
-  Which int32
-  NewValue uintptr
-  OldValue uintptr
+	Which    int32
+	NewValue uintptr
+	OldValue uintptr
 }
 
 type GetpidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SendfileArgs struct {
-  internalArgs
+	internalArgs
 
-  OutFd int32
-  InFd int32
-  Offset uintptr
-  Count uint64
+	OutFd  int32
+	InFd   int32
+	Offset uintptr
+	Count  uint64
 }
 
 type SocketArgs struct {
-  internalArgs
+	internalArgs
 
-  Domain int32
-  Type int32
-  Protocol int32
+	Domain   int32
+	Type     int32
+	Protocol int32
 }
 
 type ConnectArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Addr Sockaddr
-  Addrlen int32
+	Sockfd  int32
+	Addr    Sockaddr
+	Addrlen int32
 }
 
 type AcceptArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Addr Sockaddr
-  Addrlen uintptr
+	Sockfd  int32
+	Addr    Sockaddr
+	Addrlen uintptr
 }
 
 type SendtoArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Buf uintptr
-  Len uint64
-  Flags int32
-  DestAddr Sockaddr
-  Addrlen int32
+	Sockfd   int32
+	Buf      uintptr
+	Len      uint64
+	Flags    int32
+	DestAddr Sockaddr
+	Addrlen  int32
 }
 
 type RecvfromArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Buf uintptr
-  Len uint64
-  Flags int32
-  SrcAddr Sockaddr
-  Addrlen uintptr
+	Sockfd  int32
+	Buf     uintptr
+	Len     uint64
+	Flags   int32
+	SrcAddr Sockaddr
+	Addrlen uintptr
 }
 
 type SendmsgArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Msg uintptr
-  Flags int32
+	Sockfd int32
+	Msg    uintptr
+	Flags  int32
 }
 
 type RecvmsgArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Msg uintptr
-  Flags int32
+	Sockfd int32
+	Msg    uintptr
+	Flags  int32
 }
 
 type ShutdownArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  How int32
+	Sockfd int32
+	How    int32
 }
 
 type BindArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Addr Sockaddr
-  Addrlen int32
+	Sockfd  int32
+	Addr    Sockaddr
+	Addrlen int32
 }
 
 type ListenArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Backlog int32
+	Sockfd  int32
+	Backlog int32
 }
 
 type GetsocknameArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Addr Sockaddr
-  Addrlen uintptr
+	Sockfd  int32
+	Addr    Sockaddr
+	Addrlen uintptr
 }
 
 type GetpeernameArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Addr Sockaddr
-  Addrlen uintptr
+	Sockfd  int32
+	Addr    Sockaddr
+	Addrlen uintptr
 }
 
 type SocketpairArgs struct {
-  internalArgs
+	internalArgs
 
-  Domain int32
-  Type int32
-  Protocol int32
-  Sv [2]int32
+	Domain   int32
+	Type     int32
+	Protocol int32
+	Sv       [2]int32
 }
 
 type SetsockoptArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Level int32
-  Optname int32
-  Optval uintptr
-  Optlen int32
+	Sockfd  int32
+	Level   int32
+	Optname int32
+	Optval  uintptr
+	Optlen  int32
 }
 
 type GetsockoptArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Level int32
-  Optname int32
-  Optval uintptr
-  Optlen uintptr
+	Sockfd  int32
+	Level   int32
+	Optname int32
+	Optval  uintptr
+	Optlen  uintptr
 }
 
 type CloneArgs struct {
-  internalArgs
+	internalArgs
 
-  Flags uint64
-  Stack uintptr
-  ParentTid uintptr
-  ChildTid uintptr
-  Tls uint64
+	Flags     uint64
+	Stack     uintptr
+	ParentTid uintptr
+	ChildTid  uintptr
+	Tls       uint64
 }
 
 type ForkArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type VforkArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type ExecveArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Argv []string
-  Envp []string
+	Pathname string
+	Argv     []string
+	Envp     []string
 }
 
 type ExitArgs struct {
-  internalArgs
+	internalArgs
 
-  Status int32
+	Status int32
 }
 
 type Wait4Args struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Wstatus uintptr
-  Options int32
-  Rusage uintptr
+	Pid     int32
+	Wstatus uintptr
+	Options int32
+	Rusage  uintptr
 }
 
 type KillArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Sig int32
+	Pid int32
+	Sig int32
 }
 
 type UnameArgs struct {
-  internalArgs
+	internalArgs
 
-  Buf uintptr
+	Buf uintptr
 }
 
 type SemgetArgs struct {
-  internalArgs
+	internalArgs
 
-  Key int32
-  Nsems int32
-  Semflg int32
+	Key    int32
+	Nsems  int32
+	Semflg int32
 }
 
 type SemopArgs struct {
-  internalArgs
+	internalArgs
 
-  Semid int32
-  Sops uintptr
-  Nsops uint64
+	Semid int32
+	Sops  uintptr
+	Nsops uint64
 }
 
 type SemctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Semid int32
-  Semnum int32
-  Cmd int32
-  Arg uint64
+	Semid  int32
+	Semnum int32
+	Cmd    int32
+	Arg    uint64
 }
 
 type ShmdtArgs struct {
-  internalArgs
+	internalArgs
 
-  Shmaddr uintptr
+	Shmaddr uintptr
 }
 
 type MsggetArgs struct {
-  internalArgs
+	internalArgs
 
-  Key int32
-  Msgflg int32
+	Key    int32
+	Msgflg int32
 }
 
 type MsgsndArgs struct {
-  internalArgs
+	internalArgs
 
-  Msqid int32
-  Msgp uintptr
-  Msgsz uint64
-  Msgflg int32
+	Msqid  int32
+	Msgp   uintptr
+	Msgsz  uint64
+	Msgflg int32
 }
 
 type MsgrcvArgs struct {
-  internalArgs
+	internalArgs
 
-  Msqid int32
-  Msgp uintptr
-  Msgsz uint64
-  Msgtyp int64
-  Msgflg int32
+	Msqid  int32
+	Msgp   uintptr
+	Msgsz  uint64
+	Msgtyp int64
+	Msgflg int32
 }
 
 type MsgctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Msqid int32
-  Cmd int32
-  Buf uintptr
+	Msqid int32
+	Cmd   int32
+	Buf   uintptr
 }
 
 type FcntlArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Cmd int32
-  Arg uint64
+	Fd  int32
+	Cmd int32
+	Arg uint64
 }
 
 type FlockArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Operation int32
+	Fd        int32
+	Operation int32
 }
 
 type FsyncArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
+	Fd int32
 }
 
 type FdatasyncArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
+	Fd int32
 }
 
 type TruncateArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Length uint64
+	Path   string
+	Length uint64
 }
 
 type FtruncateArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Length uint64
+	Fd     int32
+	Length uint64
 }
 
 type GetdentsArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Dirp uintptr
-  Count uint32
+	Fd    int32
+	Dirp  uintptr
+	Count uint32
 }
 
 type GetcwdArgs struct {
-  internalArgs
+	internalArgs
 
-  Buf string
-  Size uint64
+	Buf  string
+	Size uint64
 }
 
 type ChdirArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
+	Path string
 }
 
 type FchdirArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
+	Fd int32
 }
 
 type RenameArgs struct {
-  internalArgs
+	internalArgs
 
-  Oldpath string
-  Newpath string
+	Oldpath string
+	Newpath string
 }
 
 type MkdirArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Mode uint32
+	Pathname string
+	Mode     uint32
 }
 
 type RmdirArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
+	Pathname string
 }
 
 type CreatArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Mode uint32
+	Pathname string
+	Mode     uint32
 }
 
 type LinkArgs struct {
-  internalArgs
+	internalArgs
 
-  Oldpath string
-  Newpath string
+	Oldpath string
+	Newpath string
 }
 
 type UnlinkArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
+	Pathname string
 }
 
 type SymlinkArgs struct {
-  internalArgs
+	internalArgs
 
-  Target string
-  Linkpath string
+	Target   string
+	Linkpath string
 }
 
 type ReadlinkArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Buf string
-  Bufsiz uint64
+	Pathname string
+	Buf      string
+	Bufsiz   uint64
 }
 
 type ChmodArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Mode uint32
+	Pathname string
+	Mode     uint32
 }
 
 type FchmodArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Mode uint32
+	Fd   int32
+	Mode uint32
 }
 
 type ChownArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Owner int32
-  Group int32
+	Pathname string
+	Owner    int32
+	Group    int32
 }
 
 type FchownArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Owner int32
-  Group int32
+	Fd    int32
+	Owner int32
+	Group int32
 }
 
 type LchownArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Owner int32
-  Group int32
+	Pathname string
+	Owner    int32
+	Group    int32
 }
 
 type UmaskArgs struct {
-  internalArgs
+	internalArgs
 
-  Mask uint32
+	Mask uint32
 }
 
 type GettimeofdayArgs struct {
-  internalArgs
+	internalArgs
 
-  Tv uintptr
-  Tz uintptr
+	Tv uintptr
+	Tz uintptr
 }
 
 type GetrlimitArgs struct {
-  internalArgs
+	internalArgs
 
-  Resource int32
-  Rlim uintptr
+	Resource int32
+	Rlim     uintptr
 }
 
 type GetrusageArgs struct {
-  internalArgs
+	internalArgs
 
-  Who int32
-  Usage uintptr
+	Who   int32
+	Usage uintptr
 }
 
 type SysinfoArgs struct {
-  internalArgs
+	internalArgs
 
-  Info uintptr
+	Info uintptr
 }
 
 type TimesArgs struct {
-  internalArgs
+	internalArgs
 
-  Buf uintptr
+	Buf uintptr
 }
 
 type PtraceArgs struct {
-  internalArgs
+	internalArgs
 
-  Request int64
-  Pid int32
-  Addr uintptr
-  Data uintptr
+	Request int64
+	Pid     int32
+	Addr    uintptr
+	Data    uintptr
 }
 
 type GetuidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SyslogArgs struct {
-  internalArgs
+	internalArgs
 
-  Type int32
-  Bufp string
-  Len int32
+	Type int32
+	Bufp string
+	Len  int32
 }
 
 type GetgidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SetuidArgs struct {
-  internalArgs
+	internalArgs
 
-  Uid int32
+	Uid int32
 }
 
 type SetgidArgs struct {
-  internalArgs
+	internalArgs
 
-  Gid int32
+	Gid int32
 }
 
 type GeteuidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type GetegidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SetpgidArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Pgid int32
+	Pid  int32
+	Pgid int32
 }
 
 type GetppidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type GetpgrpArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SetsidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SetreuidArgs struct {
-  internalArgs
+	internalArgs
 
-  Ruid int32
-  Euid int32
+	Ruid int32
+	Euid int32
 }
 
 type SetregidArgs struct {
-  internalArgs
+	internalArgs
 
-  Rgid int32
-  Egid int32
+	Rgid int32
+	Egid int32
 }
 
 type GetgroupsArgs struct {
-  internalArgs
+	internalArgs
 
-  Size int32
-  List uintptr
+	Size int32
+	List uintptr
 }
 
 type SetgroupsArgs struct {
-  internalArgs
+	internalArgs
 
-  Size int32
-  List uintptr
+	Size int32
+	List uintptr
 }
 
 type SetresuidArgs struct {
-  internalArgs
+	internalArgs
 
-  Ruid int32
-  Euid int32
-  Suid int32
+	Ruid int32
+	Euid int32
+	Suid int32
 }
 
 type GetresuidArgs struct {
-  internalArgs
+	internalArgs
 
-  Ruid uintptr
-  Euid uintptr
-  Suid uintptr
+	Ruid uintptr
+	Euid uintptr
+	Suid uintptr
 }
 
 type SetresgidArgs struct {
-  internalArgs
+	internalArgs
 
-  Rgid int32
-  Egid int32
-  Sgid int32
+	Rgid int32
+	Egid int32
+	Sgid int32
 }
 
 type GetresgidArgs struct {
-  internalArgs
+	internalArgs
 
-  Rgid uintptr
-  Egid uintptr
-  Sgid uintptr
+	Rgid uintptr
+	Egid uintptr
+	Sgid uintptr
 }
 
 type GetpgidArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
+	Pid int32
 }
 
 type SetfsuidArgs struct {
-  internalArgs
+	internalArgs
 
-  Fsuid int32
+	Fsuid int32
 }
 
 type SetfsgidArgs struct {
-  internalArgs
+	internalArgs
 
-  Fsgid int32
+	Fsgid int32
 }
 
 type GetsidArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
+	Pid int32
 }
 
 type CapgetArgs struct {
-  internalArgs
+	internalArgs
 
-  Hdrp uintptr
-  Datap uintptr
+	Hdrp  uintptr
+	Datap uintptr
 }
 
 type CapsetArgs struct {
-  internalArgs
+	internalArgs
 
-  Hdrp uintptr
-  Datap uintptr
+	Hdrp  uintptr
+	Datap uintptr
 }
 
 type RtSigpendingArgs struct {
-  internalArgs
+	internalArgs
 
-  Set uintptr
-  Sigsetsize uint64
+	Set        uintptr
+	Sigsetsize uint64
 }
 
 type RtSigtimedwaitArgs struct {
-  internalArgs
+	internalArgs
 
-  Set uintptr
-  Info uintptr
-  Timeout float64
-  Sigsetsize uint64
+	Set        uintptr
+	Info       uintptr
+	Timeout    float64
+	Sigsetsize uint64
 }
 
 type RtSigqueueinfoArgs struct {
-  internalArgs
+	internalArgs
 
-  Tgid int32
-  Sig int32
-  Info uintptr
+	Tgid int32
+	Sig  int32
+	Info uintptr
 }
 
 type RtSigsuspendArgs struct {
-  internalArgs
+	internalArgs
 
-  Mask uintptr
-  Sigsetsize uint64
+	Mask       uintptr
+	Sigsetsize uint64
 }
 
 type SigaltstackArgs struct {
-  internalArgs
+	internalArgs
 
-  Ss uintptr
-  OldSs uintptr
+	Ss    uintptr
+	OldSs uintptr
 }
 
 type UtimeArgs struct {
-  internalArgs
+	internalArgs
 
-  Filename string
-  Times uintptr
+	Filename string
+	Times    uintptr
 }
 
 type MknodArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Mode uint32
-  Dev uint32
+	Pathname string
+	Mode     uint32
+	Dev      uint32
 }
 
 type UselibArgs struct {
-  internalArgs
+	internalArgs
 
-  Library string
+	Library string
 }
 
 type PersonalityArgs struct {
-  internalArgs
+	internalArgs
 
-  Persona uint64
+	Persona uint64
 }
 
 type UstatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dev uint32
-  Ubuf uintptr
+	Dev  uint32
+	Ubuf uintptr
 }
 
 type StatfsArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Buf uintptr
+	Path string
+	Buf  uintptr
 }
 
 type FstatfsArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Buf uintptr
+	Fd  int32
+	Buf uintptr
 }
 
 type SysfsArgs struct {
-  internalArgs
+	internalArgs
 
-  Option int32
+	Option int32
 }
 
 type GetpriorityArgs struct {
-  internalArgs
+	internalArgs
 
-  Which int32
-  Who int32
+	Which int32
+	Who   int32
 }
 
 type SetpriorityArgs struct {
-  internalArgs
+	internalArgs
 
-  Which int32
-  Who int32
-  Prio int32
+	Which int32
+	Who   int32
+	Prio  int32
 }
 
 type SchedSetparamArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Param uintptr
+	Pid   int32
+	Param uintptr
 }
 
 type SchedGetparamArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Param uintptr
+	Pid   int32
+	Param uintptr
 }
 
 type SchedSetschedulerArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Policy int32
-  Param uintptr
+	Pid    int32
+	Policy int32
+	Param  uintptr
 }
 
 type SchedGetschedulerArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
+	Pid int32
 }
 
 type SchedGetPriorityMaxArgs struct {
-  internalArgs
+	internalArgs
 
-  Policy int32
+	Policy int32
 }
 
 type SchedGetPriorityMinArgs struct {
-  internalArgs
+	internalArgs
 
-  Policy int32
+	Policy int32
 }
 
 type SchedRrGetIntervalArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Tp float64
+	Pid int32
+	Tp  float64
 }
 
 type MlockArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Len uint64
+	Addr uintptr
+	Len  uint64
 }
 
 type MunlockArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Len uint64
+	Addr uintptr
+	Len  uint64
 }
 
 type MlockallArgs struct {
-  internalArgs
+	internalArgs
 
-  Flags int32
+	Flags int32
 }
 
 type MunlockallArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type VhangupArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type ModifyLdtArgs struct {
-  internalArgs
+	internalArgs
 
-  Func int32
-  Ptr uintptr
-  Bytecount uint64
+	Func      int32
+	Ptr       uintptr
+	Bytecount uint64
 }
 
 type PivotRootArgs struct {
-  internalArgs
+	internalArgs
 
-  NewRoot string
-  PutOld string
+	NewRoot string
+	PutOld  string
 }
 
 type SysctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Args uintptr
+	Args uintptr
 }
 
 type PrctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Option int32
-  Arg2 uint64
-  Arg3 uint64
-  Arg4 uint64
-  Arg5 uint64
+	Option int32
+	Arg2   uint64
+	Arg3   uint64
+	Arg4   uint64
+	Arg5   uint64
 }
 
 type ArchPrctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Option int32
-  Addr uint64
+	Option int32
+	Addr   uint64
 }
 
 type AdjtimexArgs struct {
-  internalArgs
+	internalArgs
 
-  Buf uintptr
+	Buf uintptr
 }
 
 type SetrlimitArgs struct {
-  internalArgs
+	internalArgs
 
-  Resource int32
-  Rlim uintptr
+	Resource int32
+	Rlim     uintptr
 }
 
 type ChrootArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
+	Path string
 }
 
 type SyncArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type AcctArgs struct {
-  internalArgs
+	internalArgs
 
-  Filename string
+	Filename string
 }
 
 type SettimeofdayArgs struct {
-  internalArgs
+	internalArgs
 
-  Tv uintptr
-  Tz uintptr
+	Tv uintptr
+	Tz uintptr
 }
 
 type MountArgs struct {
-  internalArgs
+	internalArgs
 
-  Source string
-  Target string
-  Filesystemtype string
-  Mountflags uint64
-  Data uintptr
+	Source         string
+	Target         string
+	Filesystemtype string
+	Mountflags     uint64
+	Data           uintptr
 }
 
 type Umount2Args struct {
-  internalArgs
+	internalArgs
 
-  Target string
-  Flags int32
+	Target string
+	Flags  int32
 }
 
 type SwaponArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Swapflags int32
+	Path      string
+	Swapflags int32
 }
 
 type SwapoffArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
+	Path string
 }
 
 type RebootArgs struct {
-  internalArgs
+	internalArgs
 
-  Magic int32
-  Magic2 int32
-  Cmd int32
-  Arg uintptr
+	Magic  int32
+	Magic2 int32
+	Cmd    int32
+	Arg    uintptr
 }
 
 type SethostnameArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Len uint64
+	Name string
+	Len  uint64
 }
 
 type SetdomainnameArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Len uint64
+	Name string
+	Len  uint64
 }
 
 type IoplArgs struct {
-  internalArgs
+	internalArgs
 
-  Level int32
+	Level int32
 }
 
 type IopermArgs struct {
-  internalArgs
+	internalArgs
 
-  From uint64
-  Num uint64
-  TurnOn int32
+	From   uint64
+	Num    uint64
+	TurnOn int32
 }
 
 type CreateModuleArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type InitModuleArgs struct {
-  internalArgs
+	internalArgs
 
-  ModuleImage uintptr
-  Len uint64
-  ParamValues string
+	ModuleImage uintptr
+	Len         uint64
+	ParamValues string
 }
 
 type DeleteModuleArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Flags int32
+	Name  string
+	Flags int32
 }
 
 type GetKernelSymsArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type QueryModuleArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type QuotactlArgs struct {
-  internalArgs
+	internalArgs
 
-  Cmd int32
-  Special string
-  Id int32
-  Addr uintptr
+	Cmd     int32
+	Special string
+	Id      int32
+	Addr    uintptr
 }
 
 type NfsservctlArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type GetpmsgArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type PutpmsgArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type AfsArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type TuxcallArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SecurityArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type GettidArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type ReadaheadArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Offset uint64
-  Count uint64
+	Fd     int32
+	Offset uint64
+	Count  uint64
 }
 
 type SetxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Name string
-  Value uintptr
-  Size uint64
-  Flags int32
+	Path  string
+	Name  string
+	Value uintptr
+	Size  uint64
+	Flags int32
 }
 
 type LsetxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Name string
-  Value uintptr
-  Size uint64
-  Flags int32
+	Path  string
+	Name  string
+	Value uintptr
+	Size  uint64
+	Flags int32
 }
 
 type FsetxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Name string
-  Value uintptr
-  Size uint64
-  Flags int32
+	Fd    int32
+	Name  string
+	Value uintptr
+	Size  uint64
+	Flags int32
 }
 
 type GetxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Name string
-  Value uintptr
-  Size uint64
+	Path  string
+	Name  string
+	Value uintptr
+	Size  uint64
 }
 
 type LgetxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Name string
-  Value uintptr
-  Size uint64
+	Path  string
+	Name  string
+	Value uintptr
+	Size  uint64
 }
 
 type FgetxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Name string
-  Value uintptr
-  Size uint64
+	Fd    int32
+	Name  string
+	Value uintptr
+	Size  uint64
 }
 
 type ListxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  List string
-  Size uint64
+	Path string
+	List string
+	Size uint64
 }
 
 type LlistxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  List string
-  Size uint64
+	Path string
+	List string
+	Size uint64
 }
 
 type FlistxattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  List string
-  Size uint64
+	Fd   int32
+	List string
+	Size uint64
 }
 
 type RemovexattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Name string
+	Path string
+	Name string
 }
 
 type LremovexattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Name string
+	Path string
+	Name string
 }
 
 type FremovexattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Name string
+	Fd   int32
+	Name string
 }
 
 type TkillArgs struct {
-  internalArgs
+	internalArgs
 
-  Tid int32
-  Sig int32
+	Tid int32
+	Sig int32
 }
 
 type TimeArgs struct {
-  internalArgs
+	internalArgs
 
-  Tloc uintptr
+	Tloc uintptr
 }
 
 type FutexArgs struct {
-  internalArgs
+	internalArgs
 
-  Uaddr uintptr
-  FutexOp int32
-  Val int32
-  Timeout float64
-  Uaddr2 uintptr
-  Val3 int32
+	Uaddr   uintptr
+	FutexOp int32
+	Val     int32
+	Timeout float64
+	Uaddr2  uintptr
+	Val3    int32
 }
 
 type SchedSetaffinityArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Cpusetsize uint64
-  Mask uintptr
+	Pid        int32
+	Cpusetsize uint64
+	Mask       uintptr
 }
 
 type SchedGetaffinityArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Cpusetsize uint64
-  Mask uintptr
+	Pid        int32
+	Cpusetsize uint64
+	Mask       uintptr
 }
 
 type SetThreadAreaArgs struct {
-  internalArgs
+	internalArgs
 
-  UInfo uintptr
+	UInfo uintptr
 }
 
 type IoSetupArgs struct {
-  internalArgs
+	internalArgs
 
-  NrEvents uint32
-  CtxIdp uintptr
+	NrEvents uint32
+	CtxIdp   uintptr
 }
 
 type IoDestroyArgs struct {
-  internalArgs
+	internalArgs
 
-  CtxId uintptr
+	CtxId uintptr
 }
 
 type IoGeteventsArgs struct {
-  internalArgs
+	internalArgs
 
-  CtxId uintptr
-  MinNr int64
-  Nr int64
-  Events uintptr
-  Timeout float64
+	CtxId   uintptr
+	MinNr   int64
+	Nr      int64
+	Events  uintptr
+	Timeout float64
 }
 
 type IoSubmitArgs struct {
-  internalArgs
+	internalArgs
 
-  CtxId uintptr
-  Nr int64
-  Iocbpp uintptr
+	CtxId  uintptr
+	Nr     int64
+	Iocbpp uintptr
 }
 
 type IoCancelArgs struct {
-  internalArgs
+	internalArgs
 
-  CtxId uintptr
-  Iocb uintptr
-  Result uintptr
+	CtxId  uintptr
+	Iocb   uintptr
+	Result uintptr
 }
 
 type GetThreadAreaArgs struct {
-  internalArgs
+	internalArgs
 
-  UInfo uintptr
+	UInfo uintptr
 }
 
 type LookupDcookieArgs struct {
-  internalArgs
+	internalArgs
 
-  Cookie uint64
-  Buffer string
-  Len uint64
+	Cookie uint64
+	Buffer string
+	Len    uint64
 }
 
 type EpollCreateArgs struct {
-  internalArgs
+	internalArgs
 
-  Size int32
+	Size int32
 }
 
 type EpollCtlOldArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type EpollWaitOldArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type RemapFilePagesArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Size uint64
-  Prot int32
-  Pgoff uint64
-  Flags int32
+	Addr  uintptr
+	Size  uint64
+	Prot  int32
+	Pgoff uint64
+	Flags int32
 }
 
 type Getdents64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd uint32
-  Dirp uintptr
-  Count uint32
+	Fd    uint32
+	Dirp  uintptr
+	Count uint32
 }
 
 type SetTidAddressArgs struct {
-  internalArgs
+	internalArgs
 
-  Tidptr uintptr
+	Tidptr uintptr
 }
 
 type RestartSyscallArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SemtimedopArgs struct {
-  internalArgs
+	internalArgs
 
-  Semid int32
-  Sops uintptr
-  Nsops uint64
-  Timeout float64
+	Semid   int32
+	Sops    uintptr
+	Nsops   uint64
+	Timeout float64
 }
 
 type Fadvise64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Offset uint64
-  Len uint64
-  Advice int32
+	Fd     int32
+	Offset uint64
+	Len    uint64
+	Advice int32
 }
 
 type TimerCreateArgs struct {
-  internalArgs
+	internalArgs
 
-  Clockid int32
-  Sevp uintptr
-  TimerId uintptr
+	Clockid int32
+	Sevp    uintptr
+	TimerId uintptr
 }
 
 type TimerSettimeArgs struct {
-  internalArgs
+	internalArgs
 
-  TimerId int32
-  Flags int32
-  NewValue uintptr
-  OldValue uintptr
+	TimerId  int32
+	Flags    int32
+	NewValue uintptr
+	OldValue uintptr
 }
 
 type TimerGettimeArgs struct {
-  internalArgs
+	internalArgs
 
-  TimerId int32
-  CurrValue uintptr
+	TimerId   int32
+	CurrValue uintptr
 }
 
 type TimerGetoverrunArgs struct {
-  internalArgs
+	internalArgs
 
-  TimerId int32
+	TimerId int32
 }
 
 type TimerDeleteArgs struct {
-  internalArgs
+	internalArgs
 
-  TimerId int32
+	TimerId int32
 }
 
 type ClockSettimeArgs struct {
-  internalArgs
+	internalArgs
 
-  Clockid int32
-  Tp float64
+	Clockid int32
+	Tp      float64
 }
 
 type ClockGettimeArgs struct {
-  internalArgs
+	internalArgs
 
-  Clockid int32
-  Tp float64
+	Clockid int32
+	Tp      float64
 }
 
 type ClockGetresArgs struct {
-  internalArgs
+	internalArgs
 
-  Clockid int32
-  Res float64
+	Clockid int32
+	Res     float64
 }
 
 type ClockNanosleepArgs struct {
-  internalArgs
+	internalArgs
 
-  Clockid int32
-  Flags int32
-  Request float64
-  Remain float64
+	Clockid int32
+	Flags   int32
+	Request float64
+	Remain  float64
 }
 
 type ExitGroupArgs struct {
-  internalArgs
+	internalArgs
 
-  Status int32
+	Status int32
 }
 
 type EpollWaitArgs struct {
-  internalArgs
+	internalArgs
 
-  Epfd int32
-  Events uintptr
-  Maxevents int32
-  Timeout int32
+	Epfd      int32
+	Events    uintptr
+	Maxevents int32
+	Timeout   int32
 }
 
 type EpollCtlArgs struct {
-  internalArgs
+	internalArgs
 
-  Epfd int32
-  Op int32
-  Fd int32
-  Event uintptr
+	Epfd  int32
+	Op    int32
+	Fd    int32
+	Event uintptr
 }
 
 type TgkillArgs struct {
-  internalArgs
+	internalArgs
 
-  Tgid int32
-  Tid int32
-  Sig int32
+	Tgid int32
+	Tid  int32
+	Sig  int32
 }
 
 type UtimesArgs struct {
-  internalArgs
+	internalArgs
 
-  Filename string
-  Times uintptr
+	Filename string
+	Times    uintptr
 }
 
 type VserverArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type MbindArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Len uint64
-  Mode int32
-  Nodemask uintptr
-  Maxnode uint64
-  Flags uint32
+	Addr     uintptr
+	Len      uint64
+	Mode     int32
+	Nodemask uintptr
+	Maxnode  uint64
+	Flags    uint32
 }
 
 type SetMempolicyArgs struct {
-  internalArgs
+	internalArgs
 
-  Mode int32
-  Nodemask uintptr
-  Maxnode uint64
+	Mode     int32
+	Nodemask uintptr
+	Maxnode  uint64
 }
 
 type GetMempolicyArgs struct {
-  internalArgs
+	internalArgs
 
-  Mode uintptr
-  Nodemask uintptr
-  Maxnode uint64
-  Addr uintptr
-  Flags uint64
+	Mode     uintptr
+	Nodemask uintptr
+	Maxnode  uint64
+	Addr     uintptr
+	Flags    uint64
 }
 
 type MqOpenArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Oflag int32
-  Mode uint32
-  Attr uintptr
+	Name  string
+	Oflag int32
+	Mode  uint32
+	Attr  uintptr
 }
 
 type MqUnlinkArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
+	Name string
 }
 
 type MqTimedsendArgs struct {
-  internalArgs
+	internalArgs
 
-  Mqdes int32
-  MsgPtr string
-  MsgLen uint64
-  MsgPrio uint32
-  AbsTimeout float64
+	Mqdes      int32
+	MsgPtr     string
+	MsgLen     uint64
+	MsgPrio    uint32
+	AbsTimeout float64
 }
 
 type MqTimedreceiveArgs struct {
-  internalArgs
+	internalArgs
 
-  Mqdes int32
-  MsgPtr string
-  MsgLen uint64
-  MsgPrio uintptr
-  AbsTimeout float64
+	Mqdes      int32
+	MsgPtr     string
+	MsgLen     uint64
+	MsgPrio    uintptr
+	AbsTimeout float64
 }
 
 type MqNotifyArgs struct {
-  internalArgs
+	internalArgs
 
-  Mqdes int32
-  Sevp uintptr
+	Mqdes int32
+	Sevp  uintptr
 }
 
 type MqGetsetattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Mqdes int32
-  Newattr uintptr
-  Oldattr uintptr
+	Mqdes   int32
+	Newattr uintptr
+	Oldattr uintptr
 }
 
 type KexecLoadArgs struct {
-  internalArgs
+	internalArgs
 
-  Entry uint64
-  NrSegments uint64
-  Segments uintptr
-  Flags uint64
+	Entry      uint64
+	NrSegments uint64
+	Segments   uintptr
+	Flags      uint64
 }
 
 type WaitidArgs struct {
-  internalArgs
+	internalArgs
 
-  Idtype int32
-  Id int32
-  Infop uintptr
-  Options int32
-  Rusage uintptr
+	Idtype  int32
+	Id      int32
+	Infop   uintptr
+	Options int32
+	Rusage  uintptr
 }
 
 type AddKeyArgs struct {
-  internalArgs
+	internalArgs
 
-  Type string
-  Description string
-  Payload uintptr
-  Plen uint64
-  Keyring int32
+	Type        string
+	Description string
+	Payload     uintptr
+	Plen        uint64
+	Keyring     int32
 }
 
 type RequestKeyArgs struct {
-  internalArgs
+	internalArgs
 
-  Type string
-  Description string
-  CalloutInfo string
-  DestKeyring int32
+	Type        string
+	Description string
+	CalloutInfo string
+	DestKeyring int32
 }
 
 type KeyctlArgs struct {
-  internalArgs
+	internalArgs
 
-  Operation int32
-  Arg2 uint64
-  Arg3 uint64
-  Arg4 uint64
-  Arg5 uint64
+	Operation int32
+	Arg2      uint64
+	Arg3      uint64
+	Arg4      uint64
+	Arg5      uint64
 }
 
 type IoprioSetArgs struct {
-  internalArgs
+	internalArgs
 
-  Which int32
-  Who int32
-  Ioprio int32
+	Which  int32
+	Who    int32
+	Ioprio int32
 }
 
 type IoprioGetArgs struct {
-  internalArgs
+	internalArgs
 
-  Which int32
-  Who int32
+	Which int32
+	Who   int32
 }
 
 type InotifyInitArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type InotifyAddWatchArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Pathname string
-  Mask uint32
+	Fd       int32
+	Pathname string
+	Mask     uint32
 }
 
 type InotifyRmWatchArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Wd int32
+	Fd int32
+	Wd int32
 }
 
 type MigratePagesArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Maxnode uint64
-  OldNodes uintptr
-  NewNodes uintptr
+	Pid      int32
+	Maxnode  uint64
+	OldNodes uintptr
+	NewNodes uintptr
 }
 
 type OpenatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Flags int32
-  Mode uint32
+	Dirfd    int32
+	Pathname string
+	Flags    int32
+	Mode     uint32
 }
 
 type MkdiratArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Mode uint32
+	Dirfd    int32
+	Pathname string
+	Mode     uint32
 }
 
 type MknodatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Mode uint32
-  Dev uint32
+	Dirfd    int32
+	Pathname string
+	Mode     uint32
+	Dev      uint32
 }
 
 type FchownatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Owner int32
-  Group int32
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Owner    int32
+	Group    int32
+	Flags    int32
 }
 
 type FutimesatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Times uintptr
+	Dirfd    int32
+	Pathname string
+	Times    uintptr
 }
 
 type NewfstatatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Statbuf uintptr
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Statbuf  uintptr
+	Flags    int32
 }
 
 type UnlinkatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Flags    int32
 }
 
 type RenameatArgs struct {
-  internalArgs
+	internalArgs
 
-  Olddirfd int32
-  Oldpath string
-  Newdirfd int32
-  Newpath string
+	Olddirfd int32
+	Oldpath  string
+	Newdirfd int32
+	Newpath  string
 }
 
 type LinkatArgs struct {
-  internalArgs
+	internalArgs
 
-  Olddirfd int32
-  Oldpath string
-  Newdirfd int32
-  Newpath string
-  Flags uint32
+	Olddirfd int32
+	Oldpath  string
+	Newdirfd int32
+	Newpath  string
+	Flags    uint32
 }
 
 type SymlinkatArgs struct {
-  internalArgs
+	internalArgs
 
-  Target string
-  Newdirfd int32
-  Linkpath string
+	Target   string
+	Newdirfd int32
+	Linkpath string
 }
 
 type ReadlinkatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Buf string
-  Bufsiz int32
+	Dirfd    int32
+	Pathname string
+	Buf      string
+	Bufsiz   int32
 }
 
 type FchmodatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Mode uint32
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Mode     uint32
+	Flags    int32
 }
 
 type FaccessatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Mode int32
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Mode     int32
+	Flags    int32
 }
 
 type Pselect6Args struct {
-  internalArgs
+	internalArgs
 
-  Nfds int32
-  Readfds uintptr
-  Writefds uintptr
-  Exceptfds uintptr
-  Timeout float64
-  Sigmask uintptr
+	Nfds      int32
+	Readfds   uintptr
+	Writefds  uintptr
+	Exceptfds uintptr
+	Timeout   float64
+	Sigmask   uintptr
 }
 
 type PpollArgs struct {
-  internalArgs
+	internalArgs
 
-  Fds uintptr
-  Nfds uint32
-  TmoP float64
-  Sigmask uintptr
-  Sigsetsize uint64
+	Fds        uintptr
+	Nfds       uint32
+	TmoP       float64
+	Sigmask    uintptr
+	Sigsetsize uint64
 }
 
 type UnshareArgs struct {
-  internalArgs
+	internalArgs
 
-  Flags int32
+	Flags int32
 }
 
 type SetRobustListArgs struct {
-  internalArgs
+	internalArgs
 
-  Head uintptr
-  Len uint64
+	Head uintptr
+	Len  uint64
 }
 
 type GetRobustListArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  HeadPtr uintptr
-  LenPtr uintptr
+	Pid     int32
+	HeadPtr uintptr
+	LenPtr  uintptr
 }
 
 type SpliceArgs struct {
-  internalArgs
+	internalArgs
 
-  FdIn int32
-  OffIn uintptr
-  FdOut int32
-  OffOut uintptr
-  Len uint64
-  Flags uint32
+	FdIn   int32
+	OffIn  uintptr
+	FdOut  int32
+	OffOut uintptr
+	Len    uint64
+	Flags  uint32
 }
 
 type TeeArgs struct {
-  internalArgs
+	internalArgs
 
-  FdIn int32
-  FdOut int32
-  Len uint64
-  Flags uint32
+	FdIn  int32
+	FdOut int32
+	Len   uint64
+	Flags uint32
 }
 
 type SyncFileRangeArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Offset uint64
-  Nbytes uint64
-  Flags uint32
+	Fd     int32
+	Offset uint64
+	Nbytes uint64
+	Flags  uint32
 }
 
 type VmspliceArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Iov uintptr
-  NrSegs uint64
-  Flags uint32
+	Fd     int32
+	Iov    uintptr
+	NrSegs uint64
+	Flags  uint32
 }
 
 type MovePagesArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Count uint64
-  Pages uintptr
-  Nodes uintptr
-  Status uintptr
-  Flags int32
+	Pid    int32
+	Count  uint64
+	Pages  uintptr
+	Nodes  uintptr
+	Status uintptr
+	Flags  int32
 }
 
 type UtimensatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Times float64
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Times    float64
+	Flags    int32
 }
 
 type EpollPwaitArgs struct {
-  internalArgs
+	internalArgs
 
-  Epfd int32
-  Events uintptr
-  Maxevents int32
-  Timeout int32
-  Sigmask uintptr
-  Sigsetsize uint64
+	Epfd       int32
+	Events     uintptr
+	Maxevents  int32
+	Timeout    int32
+	Sigmask    uintptr
+	Sigsetsize uint64
 }
 
 type SignalfdArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Mask uintptr
-  Flags int32
+	Fd    int32
+	Mask  uintptr
+	Flags int32
 }
 
 type TimerfdCreateArgs struct {
-  internalArgs
+	internalArgs
 
-  Clockid int32
-  Flags int32
+	Clockid int32
+	Flags   int32
 }
 
 type EventfdArgs struct {
-  internalArgs
+	internalArgs
 
-  Initval uint32
-  Flags int32
+	Initval uint32
+	Flags   int32
 }
 
 type FallocateArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Mode int32
-  Offset uint64
-  Len uint64
+	Fd     int32
+	Mode   int32
+	Offset uint64
+	Len    uint64
 }
 
 type TimerfdSettimeArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Flags int32
-  NewValue uintptr
-  OldValue uintptr
+	Fd       int32
+	Flags    int32
+	NewValue uintptr
+	OldValue uintptr
 }
 
 type TimerfdGettimeArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  CurrValue uintptr
+	Fd        int32
+	CurrValue uintptr
 }
 
 type Accept4Args struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Addr Sockaddr
-  Addrlen uintptr
-  Flags int32
+	Sockfd  int32
+	Addr    Sockaddr
+	Addrlen uintptr
+	Flags   int32
 }
 
 type Signalfd4Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Mask uintptr
-  Sizemask uint64
-  Flags int32
+	Fd       int32
+	Mask     uintptr
+	Sizemask uint64
+	Flags    int32
 }
 
 type Eventfd2Args struct {
-  internalArgs
+	internalArgs
 
-  Initval uint32
-  Flags int32
+	Initval uint32
+	Flags   int32
 }
 
 type EpollCreate1Args struct {
-  internalArgs
+	internalArgs
 
-  Flags int32
+	Flags int32
 }
 
 type Dup3Args struct {
-  internalArgs
+	internalArgs
 
-  Oldfd int32
-  Newfd int32
-  Flags int32
+	Oldfd int32
+	Newfd int32
+	Flags int32
 }
 
 type Pipe2Args struct {
-  internalArgs
+	internalArgs
 
-  Pipefd [2]int32
-  Flags int32
+	Pipefd [2]int32
+	Flags  int32
 }
 
 type InotifyInit1Args struct {
-  internalArgs
+	internalArgs
 
-  Flags int32
+	Flags int32
 }
 
 type PreadvArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Iov uintptr
-  Iovcnt uint64
-  PosL uint64
-  PosH uint64
+	Fd     int32
+	Iov    uintptr
+	Iovcnt uint64
+	PosL   uint64
+	PosH   uint64
 }
 
 type PwritevArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Iov uintptr
-  Iovcnt uint64
-  PosL uint64
-  PosH uint64
+	Fd     int32
+	Iov    uintptr
+	Iovcnt uint64
+	PosL   uint64
+	PosH   uint64
 }
 
 type RtTgsigqueueinfoArgs struct {
-  internalArgs
+	internalArgs
 
-  Tgid int32
-  Tid int32
-  Sig int32
-  Info uintptr
+	Tgid int32
+	Tid  int32
+	Sig  int32
+	Info uintptr
 }
 
 type PerfEventOpenArgs struct {
-  internalArgs
+	internalArgs
 
-  Attr uintptr
-  Pid int32
-  Cpu int32
-  GroupFd int32
-  Flags uint64
+	Attr    uintptr
+	Pid     int32
+	Cpu     int32
+	GroupFd int32
+	Flags   uint64
 }
 
 type RecvmmsgArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Msgvec uintptr
-  Vlen uint32
-  Flags int32
-  Timeout float64
+	Sockfd  int32
+	Msgvec  uintptr
+	Vlen    uint32
+	Flags   int32
+	Timeout float64
 }
 
 type FanotifyInitArgs struct {
-  internalArgs
+	internalArgs
 
-  Flags uint32
-  EventFFlags uint32
+	Flags       uint32
+	EventFFlags uint32
 }
 
 type FanotifyMarkArgs struct {
-  internalArgs
+	internalArgs
 
-  FanotifyFd int32
-  Flags uint32
-  Mask uint64
-  Dirfd int32
-  Pathname string
+	FanotifyFd int32
+	Flags      uint32
+	Mask       uint64
+	Dirfd      int32
+	Pathname   string
 }
 
 type Prlimit64Args struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Resource int32
-  NewLimit uintptr
-  OldLimit uintptr
+	Pid      int32
+	Resource int32
+	NewLimit uintptr
+	OldLimit uintptr
 }
 
 type NameToHandleAtArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Handle uintptr
-  MountId uintptr
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Handle   uintptr
+	MountId  uintptr
+	Flags    int32
 }
 
 type OpenByHandleAtArgs struct {
-  internalArgs
+	internalArgs
 
-  MountFd int32
-  Handle uintptr
-  Flags int32
+	MountFd int32
+	Handle  uintptr
+	Flags   int32
 }
 
 type ClockAdjtimeArgs struct {
-  internalArgs
+	internalArgs
 
-  ClkId int32
-  Buf uintptr
+	ClkId int32
+	Buf   uintptr
 }
 
 type SyncfsArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
+	Fd int32
 }
 
 type SendmmsgArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Msgvec uintptr
-  Vlen uint32
-  Flags int32
+	Sockfd int32
+	Msgvec uintptr
+	Vlen   uint32
+	Flags  int32
 }
 
 type SetnsArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Nstype int32
+	Fd     int32
+	Nstype int32
 }
 
 type GetcpuArgs struct {
-  internalArgs
+	internalArgs
 
-  Cpu uintptr
-  Node uintptr
-  Tcache uintptr
+	Cpu    uintptr
+	Node   uintptr
+	Tcache uintptr
 }
 
 type ProcessVmReadvArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  LocalIov uintptr
-  Liovcnt uint64
-  RemoteIov uintptr
-  Riovcnt uint64
-  Flags uint64
+	Pid       int32
+	LocalIov  uintptr
+	Liovcnt   uint64
+	RemoteIov uintptr
+	Riovcnt   uint64
+	Flags     uint64
 }
 
 type ProcessVmWritevArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  LocalIov uintptr
-  Liovcnt uint64
-  RemoteIov uintptr
-  Riovcnt uint64
-  Flags uint64
+	Pid       int32
+	LocalIov  uintptr
+	Liovcnt   uint64
+	RemoteIov uintptr
+	Riovcnt   uint64
+	Flags     uint64
 }
 
 type KcmpArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid1 int32
-  Pid2 int32
-  Type int32
-  Idx1 uint64
-  Idx2 uint64
+	Pid1 int32
+	Pid2 int32
+	Type int32
+	Idx1 uint64
+	Idx2 uint64
 }
 
 type FinitModuleArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  ParamValues string
-  Flags int32
+	Fd          int32
+	ParamValues string
+	Flags       int32
 }
 
 type SchedSetattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Attr uintptr
-  Flags uint32
+	Pid   int32
+	Attr  uintptr
+	Flags uint32
 }
 
 type SchedGetattrArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Attr uintptr
-  Size uint32
-  Flags uint32
+	Pid   int32
+	Attr  uintptr
+	Size  uint32
+	Flags uint32
 }
 
 type Renameat2Args struct {
-  internalArgs
+	internalArgs
 
-  Olddirfd int32
-  Oldpath string
-  Newdirfd int32
-  Newpath string
-  Flags uint32
+	Olddirfd int32
+	Oldpath  string
+	Newdirfd int32
+	Newpath  string
+	Flags    uint32
 }
 
 type SeccompArgs struct {
-  internalArgs
+	internalArgs
 
-  Operation uint32
-  Flags uint32
-  Args uintptr
+	Operation uint32
+	Flags     uint32
+	Args      uintptr
 }
 
 type GetrandomArgs struct {
-  internalArgs
+	internalArgs
 
-  Buf uintptr
-  Buflen uint64
-  Flags uint32
+	Buf    uintptr
+	Buflen uint64
+	Flags  uint32
 }
 
 type MemfdCreateArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Flags uint32
+	Name  string
+	Flags uint32
 }
 
 type KexecFileLoadArgs struct {
-  internalArgs
+	internalArgs
 
-  KernelFd int32
-  InitrdFd int32
-  CmdlineLen uint64
-  Cmdline string
-  Flags uint64
+	KernelFd   int32
+	InitrdFd   int32
+	CmdlineLen uint64
+	Cmdline    string
+	Flags      uint64
 }
 
 type BpfArgs struct {
-  internalArgs
+	internalArgs
 
-  Cmd int32
-  Attr uintptr
-  Size uint32
+	Cmd  int32
+	Attr uintptr
+	Size uint32
 }
 
 type ExecveatArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Argv []string
-  Envp []string
-  Flags int32
+	Dirfd    int32
+	Pathname string
+	Argv     []string
+	Envp     []string
+	Flags    int32
 }
 
 type UserfaultfdArgs struct {
-  internalArgs
+	internalArgs
 
-  Flags int32
+	Flags int32
 }
 
 type MembarrierArgs struct {
-  internalArgs
+	internalArgs
 
-  Cmd int32
-  Flags int32
+	Cmd   int32
+	Flags int32
 }
 
 type Mlock2Args struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Len uint64
-  Flags int32
+	Addr  uintptr
+	Len   uint64
+	Flags int32
 }
 
 type CopyFileRangeArgs struct {
-  internalArgs
+	internalArgs
 
-  FdIn int32
-  OffIn uintptr
-  FdOut int32
-  OffOut uintptr
-  Len uint64
-  Flags uint32
+	FdIn   int32
+	OffIn  uintptr
+	FdOut  int32
+	OffOut uintptr
+	Len    uint64
+	Flags  uint32
 }
 
 type Preadv2Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Iov uintptr
-  Iovcnt uint64
-  PosL uint64
-  PosH uint64
-  Flags int32
+	Fd     int32
+	Iov    uintptr
+	Iovcnt uint64
+	PosL   uint64
+	PosH   uint64
+	Flags  int32
 }
 
 type Pwritev2Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Iov uintptr
-  Iovcnt uint64
-  PosL uint64
-  PosH uint64
-  Flags int32
+	Fd     int32
+	Iov    uintptr
+	Iovcnt uint64
+	PosL   uint64
+	PosH   uint64
+	Flags  int32
 }
 
 type PkeyMprotectArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Len uint64
-  Prot int32
-  Pkey int32
+	Addr uintptr
+	Len  uint64
+	Prot int32
+	Pkey int32
 }
 
 type PkeyAllocArgs struct {
-  internalArgs
+	internalArgs
 
-  Flags uint32
-  AccessRights uint64
+	Flags        uint32
+	AccessRights uint64
 }
 
 type PkeyFreeArgs struct {
-  internalArgs
+	internalArgs
 
-  Pkey int32
+	Pkey int32
 }
 
 type StatxArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Flags int32
-  Mask uint32
-  Statxbuf uintptr
+	Dirfd    int32
+	Pathname string
+	Flags    int32
+	Mask     uint32
+	Statxbuf uintptr
 }
 
 type IoPgeteventsArgs struct {
-  internalArgs
+	internalArgs
 
-  CtxId uintptr
-  MinNr int64
-  Nr int64
-  Events uintptr
-  Timeout float64
-  Usig uintptr
+	CtxId   uintptr
+	MinNr   int64
+	Nr      int64
+	Events  uintptr
+	Timeout float64
+	Usig    uintptr
 }
 
 type RseqArgs struct {
-  internalArgs
+	internalArgs
 
-  Rseq uintptr
-  RseqLen uint32
-  Flags int32
-  Sig uint32
+	Rseq    uintptr
+	RseqLen uint32
+	Flags   int32
+	Sig     uint32
 }
 
 type PidfdSendSignalArgs struct {
-  internalArgs
+	internalArgs
 
-  Pidfd int32
-  Sig int32
-  Info uintptr
-  Flags uint32
+	Pidfd int32
+	Sig   int32
+	Info  uintptr
+	Flags uint32
 }
 
 type IoUringSetupArgs struct {
-  internalArgs
+	internalArgs
 
-  Entries uint32
-  P uintptr
+	Entries uint32
+	P       uintptr
 }
 
 type IoUringEnterArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd uint32
-  ToSubmit uint32
-  MinComplete uint32
-  Flags uint32
-  Sig uintptr
+	Fd          uint32
+	ToSubmit    uint32
+	MinComplete uint32
+	Flags       uint32
+	Sig         uintptr
 }
 
 type IoUringRegisterArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd uint32
-  Opcode uint32
-  Arg uintptr
-  NrArgs uint32
+	Fd     uint32
+	Opcode uint32
+	Arg    uintptr
+	NrArgs uint32
 }
 
 type OpenTreeArgs struct {
-  internalArgs
+	internalArgs
 
-  Dfd int32
-  Filename string
-  Flags uint32
+	Dfd      int32
+	Filename string
+	Flags    uint32
 }
 
 type MoveMountArgs struct {
-  internalArgs
+	internalArgs
 
-  FromDfd int32
-  FromPath string
-  ToDfd int32
-  ToPath string
-  Flags uint32
+	FromDfd  int32
+	FromPath string
+	ToDfd    int32
+	ToPath   string
+	Flags    uint32
 }
 
 type FsopenArgs struct {
-  internalArgs
+	internalArgs
 
-  Fsname string
-  Flags uint32
+	Fsname string
+	Flags  uint32
 }
 
 type FsconfigArgs struct {
-  internalArgs
+	internalArgs
 
-  FsFd uintptr
-  Cmd uint32
-  Key string
-  Value uintptr
-  Aux int32
+	FsFd  uintptr
+	Cmd   uint32
+	Key   string
+	Value uintptr
+	Aux   int32
 }
 
 type FsmountArgs struct {
-  internalArgs
+	internalArgs
 
-  Fsfd int32
-  Flags uint32
-  MsFlags uint32
+	Fsfd    int32
+	Flags   uint32
+	MsFlags uint32
 }
 
 type FspickArgs struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  Flags uint32
+	Dirfd    int32
+	Pathname string
+	Flags    uint32
 }
 
 type PidfdOpenArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Flags uint32
+	Pid   int32
+	Flags uint32
 }
 
 type Clone3Args struct {
-  internalArgs
+	internalArgs
 
-  ClArgs uintptr
-  Size uint64
+	ClArgs uintptr
+	Size   uint64
 }
 
 type CloseRangeArgs struct {
-  internalArgs
+	internalArgs
 
-  First uint32
-  Last uint32
+	First uint32
+	Last  uint32
 }
 
 type Openat2Args struct {
-  internalArgs
+	internalArgs
 
-  Dirfd int32
-  Pathname string
-  How uintptr
-  Size uint64
+	Dirfd    int32
+	Pathname string
+	How      uintptr
+	Size     uint64
 }
 
 type PidfdGetfdArgs struct {
-  internalArgs
+	internalArgs
 
-  Pidfd int32
-  Targetfd int32
-  Flags uint32
+	Pidfd    int32
+	Targetfd int32
+	Flags    uint32
 }
 
 type Faccessat2Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Path string
-  Mode int32
-  Flag int32
+	Fd   int32
+	Path string
+	Mode int32
+	Flag int32
 }
 
 type ProcessMadviseArgs struct {
-  internalArgs
+	internalArgs
 
-  Pidfd int32
-  Addr uintptr
-  Length uint64
-  Advice int32
-  Flags uint64
+	Pidfd  int32
+	Addr   uintptr
+	Length uint64
+	Advice int32
+	Flags  uint64
 }
 
 type EpollPwait2Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Events uintptr
-  Maxevents int32
-  Timeout float64
-  Sigset uintptr
+	Fd        int32
+	Events    uintptr
+	Maxevents int32
+	Timeout   float64
+	Sigset    uintptr
 }
 
 type MountSetattArgs struct {
-  internalArgs
+	internalArgs
 
-  Dfd int32
-  Path string
-  Flags uint32
-  Uattr uintptr
-  Usize uint64
+	Dfd   int32
+	Path  string
+	Flags uint32
+	Uattr uintptr
+	Usize uint64
 }
 
 type QuotactlFdArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd uint32
-  Cmd uint32
-  Id uintptr
-  Addr uintptr
+	Fd   uint32
+	Cmd  uint32
+	Id   uintptr
+	Addr uintptr
 }
 
 type LandlockCreateRulesetArgs struct {
-  internalArgs
+	internalArgs
 
-  Attr uintptr
-  Size uint64
-  Flags uint32
+	Attr  uintptr
+	Size  uint64
+	Flags uint32
 }
 
 type LandlockAddRuleArgs struct {
-  internalArgs
+	internalArgs
 
-  RulesetFd int32
-  RuleType uintptr
-  RuleAttr uintptr
-  Flags uint32
+	RulesetFd int32
+	RuleType  uintptr
+	RuleAttr  uintptr
+	Flags     uint32
 }
 
 type LandloclRestrictSetArgs struct {
-  internalArgs
+	internalArgs
 
-  RulesetFd int32
-  Flags uint32
+	RulesetFd int32
+	Flags     uint32
 }
 
 type MemfdSecretArgs struct {
-  internalArgs
+	internalArgs
 
-  Flags uint32
+	Flags uint32
 }
 
 type ProcessMreleaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Pidfd int32
-  Flags uint32
+	Pidfd int32
+	Flags uint32
 }
 
 type WaitpidArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Status uintptr
-  Options int32
+	Pid     int32
+	Status  uintptr
+	Options int32
 }
 
 type OldfstatArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type BreakArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type OldstatArgs struct {
-  internalArgs
+	internalArgs
 
-  Filename string
-  Statbuf uintptr
+	Filename string
+	Statbuf  uintptr
 }
 
 type UmountArgs struct {
-  internalArgs
+	internalArgs
 
-  Target string
+	Target string
 }
 
 type StimeArgs struct {
-  internalArgs
+	internalArgs
 
-  T uintptr
+	T uintptr
 }
 
 type SttyArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type GttyArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type NiceArgs struct {
-  internalArgs
+	internalArgs
 
-  Inc int32
+	Inc int32
 }
 
 type FtimeArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type ProfArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SignalArgs struct {
-  internalArgs
+	internalArgs
 
-  Signum int32
-  Handler uintptr
+	Signum  int32
+	Handler uintptr
 }
 
 type LockArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type MpxArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type UlimitArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type OldoldunameArgs struct {
-  internalArgs
+	internalArgs
 
-  Name uintptr
+	Name uintptr
 }
 
 type SigactionArgs struct {
-  internalArgs
+	internalArgs
 
-  Sig int32
-  Act uintptr
-  Oact uintptr
+	Sig  int32
+	Act  uintptr
+	Oact uintptr
 }
 
 type SgetmaskArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SsetmaskArgs struct {
-  internalArgs
+	internalArgs
 
-  Newmask int64
+	Newmask int64
 }
 
 type SigsuspendArgs struct {
-  internalArgs
+	internalArgs
 
-  Mask uintptr
+	Mask uintptr
 }
 
 type SigpendingArgs struct {
-  internalArgs
+	internalArgs
 
-  Set uintptr
+	Set uintptr
 }
 
 type OldlstatArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Statbuf uintptr
+	Pathname string
+	Statbuf  uintptr
 }
 
 type ReaddirArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd uint32
-  Dirp uintptr
-  Count uint32
+	Fd    uint32
+	Dirp  uintptr
+	Count uint32
 }
 
 type ProfilArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SocketcallArgs struct {
-  internalArgs
+	internalArgs
 
-  Call int32
-  Args uintptr
+	Call int32
+	Args uintptr
 }
 
 type OldunameArgs struct {
-  internalArgs
+	internalArgs
 
-  Buf uintptr
+	Buf uintptr
 }
 
 type IdleArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type Vm86oldArgs struct {
-  internalArgs
+	internalArgs
 
-  Info uintptr
+	Info uintptr
 }
 
 type IpcArgs struct {
-  internalArgs
+	internalArgs
 
-  Call uint32
-  First int32
-  Second uint64
-  Third uint64
-  Ptr uintptr
-  Fifth int64
+	Call   uint32
+	First  int32
+	Second uint64
+	Third  uint64
+	Ptr    uintptr
+	Fifth  int64
 }
 
 type SigreturnArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SigprocmaskArgs struct {
-  internalArgs
+	internalArgs
 
-  How int32
-  Set uintptr
-  Oldset uintptr
+	How    int32
+	Set    uintptr
+	Oldset uintptr
 }
 
 type BdflushArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type Afs_syscallArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type LlseekArgs struct {
-  internalArgs
+	internalArgs
 
-  Fd uint32
-  OffsetHigh uint64
-  OffsetLow uint64
-  Result uintptr
-  Whence uint32
+	Fd         uint32
+	OffsetHigh uint64
+	OffsetLow  uint64
+	Result     uintptr
+	Whence     uint32
 }
 
 type OldSelectArgs struct {
-  internalArgs
+	internalArgs
 
-  Nfds int32
-  Readfds uintptr
-  Writefds uintptr
-  Exceptfds uintptr
-  Timeout uintptr
+	Nfds      int32
+	Readfds   uintptr
+	Writefds  uintptr
+	Exceptfds uintptr
+	Timeout   uintptr
 }
 
 type Vm86Args struct {
-  internalArgs
+	internalArgs
 
-  Fn uint64
-  V86 uintptr
+	Fn  uint64
+	V86 uintptr
 }
 
 type OldGetrlimitArgs struct {
-  internalArgs
+	internalArgs
 
-  Resource int32
-  Rlim uintptr
+	Resource int32
+	Rlim     uintptr
 }
 
 type Mmap2Args struct {
-  internalArgs
+	internalArgs
 
-  Addr uint64
-  Length uint64
-  Prot uint64
-  Flags uint64
-  Fd uint64
-  Pgoffset uint64
+	Addr     uint64
+	Length   uint64
+	Prot     uint64
+	Flags    uint64
+	Fd       uint64
+	Pgoffset uint64
 }
 
 type Truncate64Args struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Length uint64
+	Path   string
+	Length uint64
 }
 
 type Ftruncate64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Length uint64
+	Fd     int32
+	Length uint64
 }
 
 type Stat64Args struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Statbuf uintptr
+	Pathname string
+	Statbuf  uintptr
 }
 
 type Lstat64Args struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Statbuf uintptr
+	Pathname string
+	Statbuf  uintptr
 }
 
 type Fstat64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Statbuf uintptr
+	Fd      int32
+	Statbuf uintptr
 }
 
 type Lchown16Args struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Owner uintptr
-  Group uintptr
+	Pathname string
+	Owner    uintptr
+	Group    uintptr
 }
 
 type Getuid16Args struct {
-  internalArgs
+	internalArgs
 }
 
 type Getgid16Args struct {
-  internalArgs
+	internalArgs
 }
 
 type Geteuid16Args struct {
-  internalArgs
+	internalArgs
 }
 
 type Getegid16Args struct {
-  internalArgs
+	internalArgs
 }
 
 type Setreuid16Args struct {
-  internalArgs
+	internalArgs
 
-  Ruid uintptr
-  Euid uintptr
+	Ruid uintptr
+	Euid uintptr
 }
 
 type Setregid16Args struct {
-  internalArgs
+	internalArgs
 
-  Rgid uintptr
-  Egid uintptr
+	Rgid uintptr
+	Egid uintptr
 }
 
 type Getgroups16Args struct {
-  internalArgs
+	internalArgs
 
-  Size int32
-  List uintptr
+	Size int32
+	List uintptr
 }
 
 type Setgroups16Args struct {
-  internalArgs
+	internalArgs
 
-  Size uint64
-  List uintptr
+	Size uint64
+	List uintptr
 }
 
 type Fchown16Args struct {
-  internalArgs
+	internalArgs
 
-  Fd uint32
-  User uintptr
-  Group uintptr
+	Fd    uint32
+	User  uintptr
+	Group uintptr
 }
 
 type Setresuid16Args struct {
-  internalArgs
+	internalArgs
 
-  Ruid uintptr
-  Euid uintptr
-  Suid uintptr
+	Ruid uintptr
+	Euid uintptr
+	Suid uintptr
 }
 
 type Getresuid16Args struct {
-  internalArgs
+	internalArgs
 
-  Ruid uintptr
-  Euid uintptr
-  Suid uintptr
+	Ruid uintptr
+	Euid uintptr
+	Suid uintptr
 }
 
 type Setresgid16Args struct {
-  internalArgs
+	internalArgs
 
-  Rgid uintptr
-  Euid uintptr
-  Suid uintptr
+	Rgid uintptr
+	Euid uintptr
+	Suid uintptr
 }
 
 type Getresgid16Args struct {
-  internalArgs
+	internalArgs
 
-  Rgid uintptr
-  Egid uintptr
-  Sgid uintptr
+	Rgid uintptr
+	Egid uintptr
+	Sgid uintptr
 }
 
 type Chown16Args struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Owner uintptr
-  Group uintptr
+	Pathname string
+	Owner    uintptr
+	Group    uintptr
 }
 
 type Setuid16Args struct {
-  internalArgs
+	internalArgs
 
-  Uid uintptr
+	Uid uintptr
 }
 
 type Setgid16Args struct {
-  internalArgs
+	internalArgs
 
-  Gid uintptr
+	Gid uintptr
 }
 
 type Setfsuid16Args struct {
-  internalArgs
+	internalArgs
 
-  Fsuid uintptr
+	Fsuid uintptr
 }
 
 type Setfsgid16Args struct {
-  internalArgs
+	internalArgs
 
-  Fsgid uintptr
+	Fsgid uintptr
 }
 
 type Fcntl64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Cmd int32
-  Arg uint64
+	Fd  int32
+	Cmd int32
+	Arg uint64
 }
 
 type Sendfile32Args struct {
-  internalArgs
+	internalArgs
 
-  OutFd int32
-  InFd int32
-  Offset uintptr
-  Count uint64
+	OutFd  int32
+	InFd   int32
+	Offset uintptr
+	Count  uint64
 }
 
 type Statfs64Args struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  Sz uint64
-  Buf uintptr
+	Path string
+	Sz   uint64
+	Buf  uintptr
 }
 
 type Fstatfs64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Sz uint64
-  Buf uintptr
+	Fd  int32
+	Sz  uint64
+	Buf uintptr
 }
 
 type Fadvise64_64Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Offset uint64
-  Len uint64
-  Advice int32
+	Fd     int32
+	Offset uint64
+	Len    uint64
+	Advice int32
 }
 
 type ClockGettime32Args struct {
-  internalArgs
+	internalArgs
 
-  WhichClock int32
-  Tp uintptr
+	WhichClock int32
+	Tp         uintptr
 }
 
 type ClockSettime32Args struct {
-  internalArgs
+	internalArgs
 
-  WhichClock int32
-  Tp uintptr
+	WhichClock int32
+	Tp         uintptr
 }
 
 type ClockAdjtime64Args struct {
-  internalArgs
+	internalArgs
 }
 
 type ClockGetresTime32Args struct {
-  internalArgs
+	internalArgs
 
-  WhichClock int32
-  Tp uintptr
+	WhichClock int32
+	Tp         uintptr
 }
 
 type ClockNanosleepTime32Args struct {
-  internalArgs
+	internalArgs
 
-  WhichClock int32
-  Flags int32
-  Rqtp uintptr
-  Rmtp uintptr
+	WhichClock int32
+	Flags      int32
+	Rqtp       uintptr
+	Rmtp       uintptr
 }
 
 type TimerGettime32Args struct {
-  internalArgs
+	internalArgs
 
-  TimerId int32
-  Setting uintptr
+	TimerId int32
+	Setting uintptr
 }
 
 type TimerSettime32Args struct {
-  internalArgs
+	internalArgs
 
-  TimerId int32
-  Flags int32
-  New uintptr
-  Old uintptr
+	TimerId int32
+	Flags   int32
+	New     uintptr
+	Old     uintptr
 }
 
 type TimerfdGettime32Args struct {
-  internalArgs
+	internalArgs
 
-  Ufd int32
-  Otmr uintptr
+	Ufd  int32
+	Otmr uintptr
 }
 
 type TimerfdSettime32Args struct {
-  internalArgs
+	internalArgs
 
-  Ufd int32
-  Flags int32
-  Utmr uintptr
-  Otmr uintptr
+	Ufd   int32
+	Flags int32
+	Utmr  uintptr
+	Otmr  uintptr
 }
 
 type UtimensatTime32Args struct {
-  internalArgs
+	internalArgs
 
-  Dfd uint32
-  Filename string
-  T uintptr
-  Flags int32
+	Dfd      uint32
+	Filename string
+	T        uintptr
+	Flags    int32
 }
 
 type Pselect6Time32Args struct {
-  internalArgs
+	internalArgs
 
-  N int32
-  Inp uintptr
-  Outp uintptr
-  Exp uintptr
-  Tsp uintptr
-  Sig uintptr
+	N    int32
+	Inp  uintptr
+	Outp uintptr
+	Exp  uintptr
+	Tsp  uintptr
+	Sig  uintptr
 }
 
 type PpollTime32Args struct {
-  internalArgs
+	internalArgs
 
-  Ufds uintptr
-  Nfds uint32
-  Tsp uintptr
-  Sigmask uintptr
-  Sigsetsize uint64
+	Ufds       uintptr
+	Nfds       uint32
+	Tsp        uintptr
+	Sigmask    uintptr
+	Sigsetsize uint64
 }
 
 type IoPgeteventsTime32Args struct {
-  internalArgs
+	internalArgs
 }
 
 type RecvmmsgTime32Args struct {
-  internalArgs
+	internalArgs
 
-  Fd int32
-  Mmsg uintptr
-  Vlen uint32
-  Flags uint32
-  Timeout uintptr
+	Fd      int32
+	Mmsg    uintptr
+	Vlen    uint32
+	Flags   uint32
+	Timeout uintptr
 }
 
 type MqTimedsendTime32Args struct {
-  internalArgs
+	internalArgs
 
-  Mqdes int32
-  UMsgPtr string
-  MsgLen uint32
-  MsgPrio uint32
-  UAbsTimeout uintptr
+	Mqdes       int32
+	UMsgPtr     string
+	MsgLen      uint32
+	MsgPrio     uint32
+	UAbsTimeout uintptr
 }
 
 type MqTimedreceiveTime32Args struct {
-  internalArgs
+	internalArgs
 
-  Mqdes int32
-  UMsgPtr string
-  MsgLen uint32
-  UMsgPrio uintptr
-  UAbsTimeout uintptr
+	Mqdes       int32
+	UMsgPtr     string
+	MsgLen      uint32
+	UMsgPrio    uintptr
+	UAbsTimeout uintptr
 }
 
 type RtSigtimedwaitTime32Args struct {
-  internalArgs
+	internalArgs
 
-  Uthese uintptr
-  Uinfo uintptr
-  Uts uintptr
-  Sigsetsize uint64
+	Uthese     uintptr
+	Uinfo      uintptr
+	Uts        uintptr
+	Sigsetsize uint64
 }
 
 type FutexTime32Args struct {
-  internalArgs
+	internalArgs
 
-  Uaddr uintptr
-  Op int32
-  Val uint32
-  Utime uintptr
-  Uaddr2 uintptr
-  Val3 uint32
+	Uaddr  uintptr
+	Op     int32
+	Val    uint32
+	Utime  uintptr
+	Uaddr2 uintptr
+	Val3   uint32
 }
 
 type SchedRrGetInterval32Args struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  Interval uintptr
+	Pid      int32
+	Interval uintptr
 }
 
 type SysEnterArgs struct {
-  internalArgs
+	internalArgs
 
-  Syscall int32
+	Syscall int32
 }
 
 type SysExitArgs struct {
-  internalArgs
+	internalArgs
 
-  Syscall int32
+	Syscall int32
 }
 
 type SchedProcessForkArgs struct {
-  internalArgs
+	internalArgs
 
-  ParentTid int32
-  ParentNsTid int32
-  ParentPid int32
-  ParentNsPid int32
-  ChildTid int32
-  ChildNsTid int32
-  ChildPid int32
-  ChildNsPid int32
-  StartTime uint64
+	ParentTid   int32
+	ParentNsTid int32
+	ParentPid   int32
+	ParentNsPid int32
+	ChildTid    int32
+	ChildNsTid  int32
+	ChildPid    int32
+	ChildNsPid  int32
+	StartTime   uint64
 }
 
 type SchedProcessExecArgs struct {
-  internalArgs
+	internalArgs
 
-  Cmdpath string
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Ctime uint64
-  InodeMode uint16
-  InterpreterPathname string
-  InterpreterDev uint32
-  InterpreterInode uint64
-  InterpreterCtime uint64
-  Argv []string
-  Interp string
-  StdinType uint16
-  StdinPath string
-  InvokedFromKernel int32
-  Env []string
+	Cmdpath             string
+	Pathname            string
+	Dev                 uint32
+	Inode               uint64
+	Ctime               uint64
+	InodeMode           uint16
+	InterpreterPathname string
+	InterpreterDev      uint32
+	InterpreterInode    uint64
+	InterpreterCtime    uint64
+	Argv                []string
+	Interp              string
+	StdinType           uint16
+	StdinPath           string
+	InvokedFromKernel   int32
+	Env                 []string
 }
 
 type SchedProcessExitArgs struct {
-  internalArgs
+	internalArgs
 
-  ExitCode int64
-  ProcessGroupExit bool
+	ExitCode         int64
+	ProcessGroupExit bool
 }
 
 type SchedSwitchArgs struct {
-  internalArgs
+	internalArgs
 
-  Cpu int32
-  PrevTid int32
-  PrevComm string
-  NextTid int32
-  NextComm string
+	Cpu      int32
+	PrevTid  int32
+	PrevComm string
+	NextTid  int32
+	NextComm string
 }
 
 type ProcessOomKilledArgs struct {
-  internalArgs
+	internalArgs
 
-  ExitCode int64
-  ProcessGroupExit bool
+	ExitCode         int64
+	ProcessGroupExit bool
 }
 
 type DoExitArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type CapCapableArgs struct {
-  internalArgs
+	internalArgs
 
-  Cap int32
+	Cap int32
 }
 
 type VfsWriteArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Count uint64
-  Pos uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Count    uint64
+	Pos      uint64
 }
 
 type VfsWritevArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Vlen uint64
-  Pos uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Vlen     uint64
+	Pos      uint64
 }
 
 type MemProtAlertArgs struct {
-  internalArgs
+	internalArgs
 
-  Alert uint32
-  Addr uintptr
-  Len uint64
-  Prot int32
-  PrevProt int32
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Ctime uint64
+	Alert    uint32
+	Addr     uintptr
+	Len      uint64
+	Prot     int32
+	PrevProt int32
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Ctime    uint64
 }
 
 type CommitCredsArgs struct {
-  internalArgs
+	internalArgs
 
-  OldCred SlimCred
-  NewCred SlimCred
+	OldCred SlimCred
+	NewCred SlimCred
 }
 
 type SwitchTaskNSArgs struct {
-  internalArgs
+	internalArgs
 
-  Pid int32
-  NewMnt uint32
-  NewPid uint32
-  NewUts uint32
-  NewIpc uint32
-  NewNet uint32
-  NewCgroup uint32
+	Pid       int32
+	NewMnt    uint32
+	NewPid    uint32
+	NewUts    uint32
+	NewIpc    uint32
+	NewNet    uint32
+	NewCgroup uint32
 }
 
 type MagicWriteArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Bytes []byte
-  Dev uint32
-  Inode uint64
+	Pathname string
+	Bytes    []byte
+	Dev      uint32
+	Inode    uint64
 }
 
 type CgroupAttachTaskArgs struct {
-  internalArgs
+	internalArgs
 
-  CgroupPath string
-  Comm string
-  Pid int32
+	CgroupPath string
+	Comm       string
+	Pid        int32
 }
 
 type CgroupMkdirArgs struct {
-  internalArgs
+	internalArgs
 
-  CgroupId uint64
-  CgroupPath string
-  HierarchyId uint32
+	CgroupId    uint64
+	CgroupPath  string
+	HierarchyId uint32
 }
 
 type CgroupRmdirArgs struct {
-  internalArgs
+	internalArgs
 
-  CgroupId uint64
-  CgroupPath string
-  HierarchyId uint32
+	CgroupId    uint64
+	CgroupPath  string
+	HierarchyId uint32
 }
 
 type SecurityFileOpenArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Flags int32
-  Dev uint32
-  Inode uint64
-  Ctime uint64
-  SyscallPathname string
+	Pathname        string
+	Flags           int32
+	Dev             uint32
+	Inode           uint64
+	Ctime           uint64
+	SyscallPathname string
 }
 
 type SecurityInodeUnlinkArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Inode uint64
-  Dev uint32
-  Ctime uint64
+	Pathname string
+	Inode    uint64
+	Dev      uint32
+	Ctime    uint64
 }
 
 type SecuritySocketCreateArgs struct {
-  internalArgs
+	internalArgs
 
-  Family int32
-  Type int32
-  Protocol int32
-  Kern int32
+	Family   int32
+	Type     int32
+	Protocol int32
+	Kern     int32
 }
 
 type SecuritySocketListenArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  LocalAddr Sockaddr
-  Backlog int32
+	Sockfd    int32
+	LocalAddr Sockaddr
+	Backlog   int32
 }
 
 type SecuritySocketConnectArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Type int32
-  RemoteAddr Sockaddr
+	Sockfd     int32
+	Type       int32
+	RemoteAddr Sockaddr
 }
 
 type SecuritySocketAcceptArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  LocalAddr Sockaddr
+	Sockfd    int32
+	LocalAddr Sockaddr
 }
 
 type SecuritySocketBindArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  LocalAddr Sockaddr
+	Sockfd    int32
+	LocalAddr Sockaddr
 }
 
 type SecuritySocketSetsockoptArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  Level int32
-  Optname int32
-  LocalAddr Sockaddr
+	Sockfd    int32
+	Level     int32
+	Optname   int32
+	LocalAddr Sockaddr
 }
 
 type SecuritySbMountArgs struct {
-  internalArgs
+	internalArgs
 
-  DevName string
-  Path string
-  Type string
-  Flags uint64
+	DevName string
+	Path    string
+	Type    string
+	Flags   uint64
 }
 
 type SecurityBPFArgs struct {
-  internalArgs
+	internalArgs
 
-  Cmd int32
+	Cmd int32
 }
 
 type SecurityBPFMapArgs struct {
-  internalArgs
+	internalArgs
 
-  MapId uint32
-  MapName string
+	MapId   uint32
+	MapName string
 }
 
 type SecurityKernelReadFileArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Type int32
-  Ctime uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Type     int32
+	Ctime    uint64
 }
 
 type SecurityPostReadFileArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Size int64
-  Type int32
+	Pathname string
+	Size     int64
+	Type     int32
 }
 
 type SecurityInodeMknodArgs struct {
-  internalArgs
+	internalArgs
 
-  FileName string
-  Mode uint16
-  Dev uint32
+	FileName string
+	Mode     uint16
+	Dev      uint32
 }
 
 type SecurityInodeSymlinkEventIdArgs struct {
-  internalArgs
+	internalArgs
 
-  Linkpath string
-  Target string
+	Linkpath string
+	Target   string
 }
 
 type SecurityMmapFileArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Flags int32
-  Dev uint32
-  Inode uint64
-  Ctime uint64
-  Prot uint64
-  MmapFlags uint64
+	Pathname  string
+	Flags     int32
+	Dev       uint32
+	Inode     uint64
+	Ctime     uint64
+	Prot      uint64
+	MmapFlags uint64
 }
 
 type DoMmapArgs struct {
-  internalArgs
+	internalArgs
 
-  Addr uintptr
-  Pathname string
-  Flags uint32
-  Dev uint32
-  Inode uint64
-  Ctime uint64
-  Pgoff uint64
-  Len uint64
-  Prot uint64
-  MmapFlags uint64
+	Addr      uintptr
+	Pathname  string
+	Flags     uint32
+	Dev       uint32
+	Inode     uint64
+	Ctime     uint64
+	Pgoff     uint64
+	Len       uint64
+	Prot      uint64
+	MmapFlags uint64
 }
 
 type SecurityFileMprotectArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Prot int32
-  Ctime uint64
-  PrevProt int32
-  Addr uintptr
-  Len uint64
-  Pkey int32
+	Pathname string
+	Prot     int32
+	Ctime    uint64
+	PrevProt int32
+	Addr     uintptr
+	Len      uint64
+	Pkey     int32
 }
 
 type InitNamespacesArgs struct {
-  internalArgs
+	internalArgs
 
-  Cgroup uint32
-  Ipc uint32
-  Mnt uint32
-  Net uint32
-  Pid uint32
-  PidForChildren uint32
-  Time uint32
-  TimeForChildren uint32
-  User uint32
-  Uts uint32
+	Cgroup          uint32
+	Ipc             uint32
+	Mnt             uint32
+	Net             uint32
+	Pid             uint32
+	PidForChildren  uint32
+	Time            uint32
+	TimeForChildren uint32
+	User            uint32
+	Uts             uint32
 }
 
 type SocketDupArgs struct {
-  internalArgs
+	internalArgs
 
-  Oldfd int32
-  Newfd int32
-  RemoteAddr Sockaddr
+	Oldfd      int32
+	Newfd      int32
+	RemoteAddr Sockaddr
 }
 
 type HiddenInodesArgs struct {
-  internalArgs
+	internalArgs
 
-  HiddenProcess string
+	HiddenProcess string
 }
 
 type KernelWriteArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Count uint64
-  Pos uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Count    uint64
+	Pos      uint64
 }
 
 type DirtyPipeSpliceArgs struct {
-  internalArgs
+	internalArgs
 
-  InodeIn uint64
-  InFileType uint16
-  InFilePath string
-  ExposedDataStartOffset uint64
-  ExposedDataLen uint64
-  InodeOut uint64
-  OutPipeLastBufferFlags uint32
+	InodeIn                uint64
+	InFileType             uint16
+	InFilePath             string
+	ExposedDataStartOffset uint64
+	ExposedDataLen         uint64
+	InodeOut               uint64
+	OutPipeLastBufferFlags uint32
 }
 
 type ContainerCreateArgs struct {
-  internalArgs
+	internalArgs
 
-  Runtime string
-  ContainerId string
-  Ctime uint64
-  ContainerImage string
-  ContainerImageDigest string
-  ContainerName string
-  PodName string
-  PodNamespace string
-  PodUid string
-  PodSandbox bool
+	Runtime              string
+	ContainerId          string
+	Ctime                uint64
+	ContainerImage       string
+	ContainerImageDigest string
+	ContainerName        string
+	PodName              string
+	PodNamespace         string
+	PodUid               string
+	PodSandbox           bool
 }
 
 type ContainerRemoveArgs struct {
-  internalArgs
+	internalArgs
 
-  Runtime string
-  ContainerId string
+	Runtime     string
+	ContainerId string
 }
 
 type ExistingContainerArgs struct {
-  internalArgs
+	internalArgs
 
-  Runtime string
-  ContainerId string
-  Ctime uint64
-  ContainerImage string
-  ContainerImageDigest string
-  ContainerName string
-  PodName string
-  PodNamespace string
-  PodUid string
-  PodSandbox bool
+	Runtime              string
+	ContainerId          string
+	Ctime                uint64
+	ContainerImage       string
+	ContainerImageDigest string
+	ContainerName        string
+	PodName              string
+	PodNamespace         string
+	PodUid               string
+	PodSandbox           bool
 }
 
 type ProcCreateArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  ProcOpsAddr uintptr
+	Name        string
+	ProcOpsAddr uintptr
 }
 
 type KprobeAttachArgs struct {
-  internalArgs
+	internalArgs
 
-  SymbolName string
-  PreHandlerAddr uintptr
-  PostHandlerAddr uintptr
+	SymbolName      string
+	PreHandlerAddr  uintptr
+	PostHandlerAddr uintptr
 }
 
 type CallUsermodeHelperArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Argv []string
-  Envp []string
-  Wait int32
+	Pathname string
+	Argv     []string
+	Envp     []string
+	Wait     int32
 }
 
 type DebugfsCreateFileArgs struct {
-  internalArgs
+	internalArgs
 
-  FileName string
-  Path string
-  Mode uint32
-  ProcOpsAddr uintptr
+	FileName    string
+	Path        string
+	Mode        uint32
+	ProcOpsAddr uintptr
 }
 
 type PrintSyscallTableArgs struct {
-  internalArgs
+	internalArgs
 
-  SyscallsAddresses []uint64
-  CallerContextId uint64
+	SyscallsAddresses []uint64
+	CallerContextId   uint64
 }
 
 type HiddenKernelModuleArgs struct {
-  internalArgs
+	internalArgs
 
-  Address string
-  Name string
-  Srcversion string
+	Address    string
+	Name       string
+	Srcversion string
 }
 
 type HiddenKernelModuleSeekerArgs struct {
-  internalArgs
+	internalArgs
 
-  Address uint64
-  Name []byte
-  Flags uint32
-  Srcversion []byte
+	Address    uint64
+	Name       []byte
+	Flags      uint32
+	Srcversion []byte
 }
 
 type HookedSyscallsArgs struct {
-  internalArgs
+	internalArgs
 
-  CheckSyscalls uintptr
-  HookedSyscalls uintptr
+	CheckSyscalls  uintptr
+	HookedSyscalls uintptr
 }
 
 type DebugfsCreateDirArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Path string
+	Name string
+	Path string
 }
 
 type DeviceAddArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  ParentName string
+	Name       string
+	ParentName string
 }
 
 type RegisterChrdevArgs struct {
-  internalArgs
+	internalArgs
 
-  RequestedMajorNumber uint32
-  GrantedMajorNumber uint32
-  CharDeviceName string
-  CharDeviceFops uintptr
+	RequestedMajorNumber uint32
+	GrantedMajorNumber   uint32
+	CharDeviceName       string
+	CharDeviceFops       uintptr
 }
 
 type SharedObjectLoadedArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Flags int32
-  Dev uint32
-  Inode uint64
-  Ctime uint64
+	Pathname string
+	Flags    int32
+	Dev      uint32
+	Inode    uint64
+	Ctime    uint64
 }
 
 type SymbolsLoadedArgs struct {
-  internalArgs
+	internalArgs
 
-  LibraryPath string
-  Symbols []string
+	LibraryPath string
+	Symbols     []string
 }
 
 type SymbolsCollisionArgs struct {
-  internalArgs
+	internalArgs
 
-  LoadedPath string
-  CollisionPath string
-  Symbols []string
+	LoadedPath    string
+	CollisionPath string
+	Symbols       []string
 }
 
 type CaptureFileWriteArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type CaptureFileReadArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type CaptureExecArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type CaptureModuleArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type CaptureMemArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type CaptureBpfArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type DoInitModuleArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Version string
-  SrcVersion string
+	Name       string
+	Version    string
+	SrcVersion string
 }
 
 type ModuleLoadArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Version string
-  SrcVersion string
+	Name       string
+	Version    string
+	SrcVersion string
 }
 
 type ModuleFreeArgs struct {
-  internalArgs
+	internalArgs
 
-  Name string
-  Version string
-  SrcVersion string
+	Name       string
+	Version    string
+	SrcVersion string
 }
 
 type SocketAcceptArgs struct {
-  internalArgs
+	internalArgs
 
-  Sockfd int32
-  LocalAddr Sockaddr
-  RemoteAddr Sockaddr
+	Sockfd     int32
+	LocalAddr  Sockaddr
+	RemoteAddr Sockaddr
 }
 
 type LoadElfPhdrsArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
 }
 
 type PrintNetSeqOpsArgs struct {
-  internalArgs
+	internalArgs
 
-  NetSeqOps []uint64
-  CallerContextId uint64
+	NetSeqOps       []uint64
+	CallerContextId uint64
 }
 
 type HookedSeqOpsArgs struct {
-  internalArgs
+	internalArgs
 
-  HookedSeqOps uintptr
+	HookedSeqOps uintptr
 }
 
 type TaskRenameArgs struct {
-  internalArgs
+	internalArgs
 
-  OldName string
-  NewName string
+	OldName string
+	NewName string
 }
 
 type SecurityInodeRenameArgs struct {
-  internalArgs
+	internalArgs
 
-  OldPath string
-  NewPath string
+	OldPath string
+	NewPath string
 }
 
 type DoSigactionArgs struct {
-  internalArgs
+	internalArgs
 
-  Sig int32
-  IsSaInitialized bool
-  SaFlags uint64
-  SaMask uint64
-  SaHandleMethod uint8
-  SaHandler uintptr
-  IsOldSaInitialized bool
-  OldSaFlags uint64
-  OldSaMask uint64
-  OldSaHandleMethod uint8
-  OldSaHandler uintptr
+	Sig                int32
+	IsSaInitialized    bool
+	SaFlags            uint64
+	SaMask             uint64
+	SaHandleMethod     uint8
+	SaHandler          uintptr
+	IsOldSaInitialized bool
+	OldSaFlags         uint64
+	OldSaMask          uint64
+	OldSaHandleMethod  uint8
+	OldSaHandler       uintptr
 }
 
 type BpfAttachArgs struct {
-  internalArgs
+	internalArgs
 
-  ProgType int32
-  ProgName string
-  ProgId uint32
-  ProgHelpers []uint64
-  SymbolName string
-  SymbolAddr uint64
-  AttachType int32
+	ProgType    int32
+	ProgName    string
+	ProgId      uint32
+	ProgHelpers []uint64
+	SymbolName  string
+	SymbolAddr  uint64
+	AttachType  int32
 }
 
 type KallsymsLookupNameArgs struct {
-  internalArgs
+	internalArgs
 
-  SymbolName string
-  SymbolAddress uintptr
+	SymbolName    string
+	SymbolAddress uintptr
 }
 
 type PrintMemDumpArgs struct {
-  internalArgs
+	internalArgs
 
-  Bytes []byte
-  Address uintptr
-  Length uint64
-  CallerContextId uint64
-  Arch string
-  SymbolName string
-  SymbolOwner string
+	Bytes           []byte
+	Address         uintptr
+	Length          uint64
+	CallerContextId uint64
+	Arch            string
+	SymbolName      string
+	SymbolOwner     string
 }
 
 type VfsReadArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Count uint64
-  Pos uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Count    uint64
+	Pos      uint64
 }
 
 type VfsReadvArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Vlen uint64
-  Pos uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Vlen     uint64
+	Pos      uint64
 }
 
 type VfsUtimesArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Dev uint32
-  Inode uint64
-  Atime uint64
-  Mtime uint64
+	Pathname string
+	Dev      uint32
+	Inode    uint64
+	Atime    uint64
+	Mtime    uint64
 }
 
 type DoTruncateArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Inode uint64
-  Dev uint32
-  Length uint64
+	Pathname string
+	Inode    uint64
+	Dev      uint32
+	Length   uint64
 }
 
 type FileModificationArgs struct {
-  internalArgs
+	internalArgs
 
-  FilePath string
-  Dev uint32
-  Inode uint64
-  OldCtime uint64
-  NewCtime uint64
+	FilePath string
+	Dev      uint32
+	Inode    uint64
+	OldCtime uint64
+	NewCtime uint64
 }
 
 type InotifyWatchArgs struct {
-  internalArgs
+	internalArgs
 
-  Pathname string
-  Inode uint64
-  Dev uint32
+	Pathname string
+	Inode    uint64
+	Dev      uint32
 }
 
 type ProcessExecuteFailedArgs struct {
-  internalArgs
+	internalArgs
 
-  Path string
-  BinaryPath string
-  BinaryDeviceId uint32
-  BinaryInodeNumber uint64
-  BinaryCtime uint64
-  BinaryInodeMode uint16
-  InterpreterPath string
-  StdinType uint16
-  StdinPath string
-  KernelInvoked int32
-  BinaryArguments []string
-  Environment []string
+	Path              string
+	BinaryPath        string
+	BinaryDeviceId    uint32
+	BinaryInodeNumber uint64
+	BinaryCtime       uint64
+	BinaryInodeMode   uint16
+	InterpreterPath   string
+	StdinType         uint16
+	StdinPath         string
+	KernelInvoked     int32
+	BinaryArguments   []string
+	Environment       []string
 }
 
 type NetPacketBaseArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type NetPacketIPBaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type NetPacketIPv4Args struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  ProtoIpv4 uintptr
+	Src       string
+	Dst       string
+	ProtoIpv4 uintptr
 }
 
 type NetPacketIPv6Args struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  ProtoIpv6 uintptr
+	Src       string
+	Dst       string
+	ProtoIpv6 uintptr
 }
 
 type NetPacketTCPBaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type NetPacketTCPArgs struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  SrcPort uint16
-  DstPort uint16
-  ProtoTcp uintptr
+	Src      string
+	Dst      string
+	SrcPort  uint16
+	DstPort  uint16
+	ProtoTcp uintptr
 }
 
 type NetPacketUDPBaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type NetPacketUDPArgs struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  SrcPort uint16
-  DstPort uint16
-  ProtoUdp uintptr
+	Src      string
+	Dst      string
+	SrcPort  uint16
+	DstPort  uint16
+	ProtoUdp uintptr
 }
 
 type NetPacketICMPBaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type NetPacketICMPArgs struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  ProtoIcmp uintptr
+	Src       string
+	Dst       string
+	ProtoIcmp uintptr
 }
 
 type NetPacketICMPv6BaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type NetPacketICMPv6Args struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  ProtoIcmpv6 uintptr
+	Src         string
+	Dst         string
+	ProtoIcmpv6 uintptr
 }
 
 type NetPacketDNSBaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type NetPacketDNSArgs struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  SrcPort uint16
-  DstPort uint16
-  ProtoDns uintptr
+	Src      string
+	Dst      string
+	SrcPort  uint16
+	DstPort  uint16
+	ProtoDns uintptr
 }
 
 type NetPacketDNSRequestArgs struct {
-  internalArgs
+	internalArgs
 
-  Metadata uintptr
-  DnsQuestions uintptr
+	Metadata     uintptr
+	DnsQuestions uintptr
 }
 
 type NetPacketDNSResponseArgs struct {
-  internalArgs
+	internalArgs
 
-  Metadata uintptr
-  DnsResponse uintptr
+	Metadata    uintptr
+	DnsResponse uintptr
 }
 
 type NetPacketHTTPBaseArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type NetPacketHTTPArgs struct {
-  internalArgs
+	internalArgs
 
-  Src string
-  Dst string
-  SrcPort uint16
-  DstPort uint16
-  ProtoHttp uintptr
+	Src       string
+	Dst       string
+	SrcPort   uint16
+	DstPort   uint16
+	ProtoHttp uintptr
 }
 
 type NetPacketHTTPRequestArgs struct {
-  internalArgs
+	internalArgs
 
-  Metadata uintptr
-  HttpRequest uintptr
+	Metadata    uintptr
+	HttpRequest uintptr
 }
 
 type NetPacketHTTPResponseArgs struct {
-  internalArgs
+	internalArgs
 
-  Metadata uintptr
-  HttpResponse uintptr
+	Metadata     uintptr
+	HttpResponse uintptr
 }
 
 type NetPacketCaptureArgs struct {
-  internalArgs
+	internalArgs
 
-  Payload []byte
+	Payload []byte
 }
 
 type CaptureNetPacketArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SockSetStateArgs struct {
-  internalArgs
+	internalArgs
 
-  OldState uint32
-  NewState uint32
-  Tuple AddrTuple
+	OldState uint32
+	NewState uint32
+	Tuple    AddrTuple
 }
 
 type TrackSyscallStatsArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type TestEventArgs struct {
-  internalArgs
+	internalArgs
 }
 
 type SignalCgroupMkdirArgs struct {
-  internalArgs
+	internalArgs
 
-  CgroupId uint64
-  CgroupPath string
-  HierarchyId uint32
+	CgroupId    uint64
+	CgroupPath  string
+	HierarchyId uint32
 }
 
 type SignalCgroupRmdirArgs struct {
-  internalArgs
+	internalArgs
 
-  CgroupId uint64
-  CgroupPath string
-  HierarchyId uint32
+	CgroupId    uint64
+	CgroupPath  string
+	HierarchyId uint32
 }

--- a/pkg/ebpftracer/types/args.go
+++ b/pkg/ebpftracer/types/args.go
@@ -3,7 +3,7 @@
 package types
 
 type Args interface {
-	args()
+  args()
 }
 
 // internalArgs is a marker type to distinguish Args interface from basically any
@@ -12,4247 +12,4257 @@ type internalArgs struct{}
 func (c internalArgs) args() {}
 
 type ReadArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    int32
-	Buf   uintptr
-	Count uint64
+  Fd int32
+  Buf uintptr
+  Count uint64
 }
 
 type WriteArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    int32
-	Buf   uintptr
-	Count uint64
+  Fd int32
+  Buf uintptr
+  Count uint64
 }
 
 type OpenArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Flags    int32
-	Mode     uint32
+  Pathname string
+  Flags int32
+  Mode uint32
 }
 
 type CloseArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd int32
+  Fd int32
 }
 
 type StatArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Statbuf  uintptr
+  Pathname string
+  Statbuf uintptr
 }
 
 type FstatArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd      int32
-	Statbuf uintptr
+  Fd int32
+  Statbuf uintptr
 }
 
 type LstatArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Statbuf  uintptr
+  Pathname string
+  Statbuf uintptr
 }
 
 type PollArgs struct {
-	internalArgs
+  internalArgs
 
-	Fds     uintptr
-	Nfds    uint32
-	Timeout int32
+  Fds uintptr
+  Nfds uint32
+  Timeout int32
 }
 
 type LseekArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Offset uint64
-	Whence uint32
+  Fd int32
+  Offset uint64
+  Whence uint32
 }
 
 type MmapArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr   uintptr
-	Length uint64
-	Prot   int32
-	Flags  int32
-	Fd     int32
-	Off    uint64
+  Addr uintptr
+  Length uint64
+  Prot int32
+  Flags int32
+  Fd int32
+  Off uint64
 }
 
 type MprotectArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr uintptr
-	Len  uint64
-	Prot int32
+  Addr uintptr
+  Len uint64
+  Prot int32
 }
 
 type MunmapArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr   uintptr
-	Length uint64
+  Addr uintptr
+  Length uint64
 }
 
 type BrkArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr uintptr
+  Addr uintptr
 }
 
 type RtSigactionArgs struct {
-	internalArgs
+  internalArgs
 
-	Signum     int32
-	Act        uintptr
-	Oldact     uintptr
-	Sigsetsize uint64
+  Signum int32
+  Act uintptr
+  Oldact uintptr
+  Sigsetsize uint64
 }
 
 type RtSigprocmaskArgs struct {
-	internalArgs
+  internalArgs
 
-	How        int32
-	Set        uintptr
-	Oldset     uintptr
-	Sigsetsize uint64
+  How int32
+  Set uintptr
+  Oldset uintptr
+  Sigsetsize uint64
 }
 
 type RtSigreturnArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type IoctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd      int32
-	Request uint64
-	Arg     uint64
+  Fd int32
+  Request uint64
+  Arg uint64
 }
 
 type Pread64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Buf    uintptr
-	Count  uint64
-	Offset uint64
+  Fd int32
+  Buf uintptr
+  Count uint64
+  Offset uint64
 }
 
 type Pwrite64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Buf    uintptr
-	Count  uint64
-	Offset uint64
+  Fd int32
+  Buf uintptr
+  Count uint64
+  Offset uint64
 }
 
 type ReadvArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Iov    uintptr
-	Iovcnt int32
+  Fd int32
+  Iov uintptr
+  Iovcnt int32
 }
 
 type WritevArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Iov    uintptr
-	Iovcnt int32
+  Fd int32
+  Iov uintptr
+  Iovcnt int32
 }
 
 type AccessArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Mode     int32
+  Pathname string
+  Mode int32
 }
 
 type PipeArgs struct {
-	internalArgs
+  internalArgs
 
-	Pipefd [2]int32
+  Pipefd [2]int32
 }
 
 type SelectArgs struct {
-	internalArgs
+  internalArgs
 
-	Nfds      int32
-	Readfds   uintptr
-	Writefds  uintptr
-	Exceptfds uintptr
-	Timeout   uintptr
+  Nfds int32
+  Readfds uintptr
+  Writefds uintptr
+  Exceptfds uintptr
+  Timeout uintptr
 }
 
 type SchedYieldArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type MremapArgs struct {
-	internalArgs
+  internalArgs
 
-	OldAddress uintptr
-	OldSize    uint64
-	NewSize    uint64
-	Flags      int32
-	NewAddress uintptr
+  OldAddress uintptr
+  OldSize uint64
+  NewSize uint64
+  Flags int32
+  NewAddress uintptr
 }
 
 type MsyncArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr   uintptr
-	Length uint64
-	Flags  int32
+  Addr uintptr
+  Length uint64
+  Flags int32
 }
 
 type MincoreArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr   uintptr
-	Length uint64
-	Vec    uintptr
+  Addr uintptr
+  Length uint64
+  Vec uintptr
 }
 
 type MadviseArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr   uintptr
-	Length uint64
-	Advice int32
+  Addr uintptr
+  Length uint64
+  Advice int32
 }
 
 type ShmgetArgs struct {
-	internalArgs
+  internalArgs
 
-	Key    int32
-	Size   uint64
-	Shmflg int32
+  Key int32
+  Size uint64
+  Shmflg int32
 }
 
 type ShmatArgs struct {
-	internalArgs
+  internalArgs
 
-	Shmid   int32
-	Shmaddr uintptr
-	Shmflg  int32
+  Shmid int32
+  Shmaddr uintptr
+  Shmflg int32
 }
 
 type ShmctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Shmid int32
-	Cmd   int32
-	Buf   uintptr
+  Shmid int32
+  Cmd int32
+  Buf uintptr
 }
 
 type DupArgs struct {
-	internalArgs
+  internalArgs
 
-	Oldfd int32
+  Oldfd int32
 }
 
 type Dup2Args struct {
-	internalArgs
+  internalArgs
 
-	Oldfd int32
-	Newfd int32
+  Oldfd int32
+  Newfd int32
 }
 
 type PauseArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type NanosleepArgs struct {
-	internalArgs
+  internalArgs
 
-	Req float64
-	Rem float64
+  Req float64
+  Rem float64
 }
 
 type GetitimerArgs struct {
-	internalArgs
+  internalArgs
 
-	Which     int32
-	CurrValue uintptr
+  Which int32
+  CurrValue uintptr
 }
 
 type AlarmArgs struct {
-	internalArgs
+  internalArgs
 
-	Seconds uint32
+  Seconds uint32
 }
 
 type SetitimerArgs struct {
-	internalArgs
+  internalArgs
 
-	Which    int32
-	NewValue uintptr
-	OldValue uintptr
+  Which int32
+  NewValue uintptr
+  OldValue uintptr
 }
 
 type GetpidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SendfileArgs struct {
-	internalArgs
+  internalArgs
 
-	OutFd  int32
-	InFd   int32
-	Offset uintptr
-	Count  uint64
+  OutFd int32
+  InFd int32
+  Offset uintptr
+  Count uint64
 }
 
 type SocketArgs struct {
-	internalArgs
+  internalArgs
 
-	Domain   int32
-	Type     int32
-	Protocol int32
+  Domain int32
+  Type int32
+  Protocol int32
 }
 
 type ConnectArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Addr    Sockaddr
-	Addrlen int32
+  Sockfd int32
+  Addr Sockaddr
+  Addrlen int32
 }
 
 type AcceptArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Addr    Sockaddr
-	Addrlen uintptr
+  Sockfd int32
+  Addr Sockaddr
+  Addrlen uintptr
 }
 
 type SendtoArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd   int32
-	Buf      uintptr
-	Len      uint64
-	Flags    int32
-	DestAddr Sockaddr
-	Addrlen  int32
+  Sockfd int32
+  Buf uintptr
+  Len uint64
+  Flags int32
+  DestAddr Sockaddr
+  Addrlen int32
 }
 
 type RecvfromArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Buf     uintptr
-	Len     uint64
-	Flags   int32
-	SrcAddr Sockaddr
-	Addrlen uintptr
+  Sockfd int32
+  Buf uintptr
+  Len uint64
+  Flags int32
+  SrcAddr Sockaddr
+  Addrlen uintptr
 }
 
 type SendmsgArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd int32
-	Msg    uintptr
-	Flags  int32
+  Sockfd int32
+  Msg uintptr
+  Flags int32
 }
 
 type RecvmsgArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd int32
-	Msg    uintptr
-	Flags  int32
+  Sockfd int32
+  Msg uintptr
+  Flags int32
 }
 
 type ShutdownArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd int32
-	How    int32
+  Sockfd int32
+  How int32
 }
 
 type BindArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Addr    Sockaddr
-	Addrlen int32
+  Sockfd int32
+  Addr Sockaddr
+  Addrlen int32
 }
 
 type ListenArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Backlog int32
+  Sockfd int32
+  Backlog int32
 }
 
 type GetsocknameArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Addr    Sockaddr
-	Addrlen uintptr
+  Sockfd int32
+  Addr Sockaddr
+  Addrlen uintptr
 }
 
 type GetpeernameArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Addr    Sockaddr
-	Addrlen uintptr
+  Sockfd int32
+  Addr Sockaddr
+  Addrlen uintptr
 }
 
 type SocketpairArgs struct {
-	internalArgs
+  internalArgs
 
-	Domain   int32
-	Type     int32
-	Protocol int32
-	Sv       [2]int32
+  Domain int32
+  Type int32
+  Protocol int32
+  Sv [2]int32
 }
 
 type SetsockoptArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Level   int32
-	Optname int32
-	Optval  uintptr
-	Optlen  int32
+  Sockfd int32
+  Level int32
+  Optname int32
+  Optval uintptr
+  Optlen int32
 }
 
 type GetsockoptArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Level   int32
-	Optname int32
-	Optval  uintptr
-	Optlen  uintptr
+  Sockfd int32
+  Level int32
+  Optname int32
+  Optval uintptr
+  Optlen uintptr
 }
 
 type CloneArgs struct {
-	internalArgs
+  internalArgs
 
-	Flags     uint64
-	Stack     uintptr
-	ParentTid uintptr
-	ChildTid  uintptr
-	Tls       uint64
+  Flags uint64
+  Stack uintptr
+  ParentTid uintptr
+  ChildTid uintptr
+  Tls uint64
 }
 
 type ForkArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type VforkArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type ExecveArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Argv     []string
-	Envp     []string
+  Pathname string
+  Argv []string
+  Envp []string
 }
 
 type ExitArgs struct {
-	internalArgs
+  internalArgs
 
-	Status int32
+  Status int32
 }
 
 type Wait4Args struct {
-	internalArgs
+  internalArgs
 
-	Pid     int32
-	Wstatus uintptr
-	Options int32
-	Rusage  uintptr
+  Pid int32
+  Wstatus uintptr
+  Options int32
+  Rusage uintptr
 }
 
 type KillArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid int32
-	Sig int32
+  Pid int32
+  Sig int32
 }
 
 type UnameArgs struct {
-	internalArgs
+  internalArgs
 
-	Buf uintptr
+  Buf uintptr
 }
 
 type SemgetArgs struct {
-	internalArgs
+  internalArgs
 
-	Key    int32
-	Nsems  int32
-	Semflg int32
+  Key int32
+  Nsems int32
+  Semflg int32
 }
 
 type SemopArgs struct {
-	internalArgs
+  internalArgs
 
-	Semid int32
-	Sops  uintptr
-	Nsops uint64
+  Semid int32
+  Sops uintptr
+  Nsops uint64
 }
 
 type SemctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Semid  int32
-	Semnum int32
-	Cmd    int32
-	Arg    uint64
+  Semid int32
+  Semnum int32
+  Cmd int32
+  Arg uint64
 }
 
 type ShmdtArgs struct {
-	internalArgs
+  internalArgs
 
-	Shmaddr uintptr
+  Shmaddr uintptr
 }
 
 type MsggetArgs struct {
-	internalArgs
+  internalArgs
 
-	Key    int32
-	Msgflg int32
+  Key int32
+  Msgflg int32
 }
 
 type MsgsndArgs struct {
-	internalArgs
+  internalArgs
 
-	Msqid  int32
-	Msgp   uintptr
-	Msgsz  uint64
-	Msgflg int32
+  Msqid int32
+  Msgp uintptr
+  Msgsz uint64
+  Msgflg int32
 }
 
 type MsgrcvArgs struct {
-	internalArgs
+  internalArgs
 
-	Msqid  int32
-	Msgp   uintptr
-	Msgsz  uint64
-	Msgtyp int64
-	Msgflg int32
+  Msqid int32
+  Msgp uintptr
+  Msgsz uint64
+  Msgtyp int64
+  Msgflg int32
 }
 
 type MsgctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Msqid int32
-	Cmd   int32
-	Buf   uintptr
+  Msqid int32
+  Cmd int32
+  Buf uintptr
 }
 
 type FcntlArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd  int32
-	Cmd int32
-	Arg uint64
+  Fd int32
+  Cmd int32
+  Arg uint64
 }
 
 type FlockArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd        int32
-	Operation int32
+  Fd int32
+  Operation int32
 }
 
 type FsyncArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd int32
+  Fd int32
 }
 
 type FdatasyncArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd int32
+  Fd int32
 }
 
 type TruncateArgs struct {
-	internalArgs
+  internalArgs
 
-	Path   string
-	Length uint64
+  Path string
+  Length uint64
 }
 
 type FtruncateArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Length uint64
+  Fd int32
+  Length uint64
 }
 
 type GetdentsArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    int32
-	Dirp  uintptr
-	Count uint32
+  Fd int32
+  Dirp uintptr
+  Count uint32
 }
 
 type GetcwdArgs struct {
-	internalArgs
+  internalArgs
 
-	Buf  string
-	Size uint64
+  Buf string
+  Size uint64
 }
 
 type ChdirArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
+  Path string
 }
 
 type FchdirArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd int32
+  Fd int32
 }
 
 type RenameArgs struct {
-	internalArgs
+  internalArgs
 
-	Oldpath string
-	Newpath string
+  Oldpath string
+  Newpath string
 }
 
 type MkdirArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Mode     uint32
+  Pathname string
+  Mode uint32
 }
 
 type RmdirArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
+  Pathname string
 }
 
 type CreatArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Mode     uint32
+  Pathname string
+  Mode uint32
 }
 
 type LinkArgs struct {
-	internalArgs
+  internalArgs
 
-	Oldpath string
-	Newpath string
+  Oldpath string
+  Newpath string
 }
 
 type UnlinkArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
+  Pathname string
 }
 
 type SymlinkArgs struct {
-	internalArgs
+  internalArgs
 
-	Target   string
-	Linkpath string
+  Target string
+  Linkpath string
 }
 
 type ReadlinkArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Buf      string
-	Bufsiz   uint64
+  Pathname string
+  Buf string
+  Bufsiz uint64
 }
 
 type ChmodArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Mode     uint32
+  Pathname string
+  Mode uint32
 }
 
 type FchmodArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd   int32
-	Mode uint32
+  Fd int32
+  Mode uint32
 }
 
 type ChownArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Owner    int32
-	Group    int32
+  Pathname string
+  Owner int32
+  Group int32
 }
 
 type FchownArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    int32
-	Owner int32
-	Group int32
+  Fd int32
+  Owner int32
+  Group int32
 }
 
 type LchownArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Owner    int32
-	Group    int32
+  Pathname string
+  Owner int32
+  Group int32
 }
 
 type UmaskArgs struct {
-	internalArgs
+  internalArgs
 
-	Mask uint32
+  Mask uint32
 }
 
 type GettimeofdayArgs struct {
-	internalArgs
+  internalArgs
 
-	Tv uintptr
-	Tz uintptr
+  Tv uintptr
+  Tz uintptr
 }
 
 type GetrlimitArgs struct {
-	internalArgs
+  internalArgs
 
-	Resource int32
-	Rlim     uintptr
+  Resource int32
+  Rlim uintptr
 }
 
 type GetrusageArgs struct {
-	internalArgs
+  internalArgs
 
-	Who   int32
-	Usage uintptr
+  Who int32
+  Usage uintptr
 }
 
 type SysinfoArgs struct {
-	internalArgs
+  internalArgs
 
-	Info uintptr
+  Info uintptr
 }
 
 type TimesArgs struct {
-	internalArgs
+  internalArgs
 
-	Buf uintptr
+  Buf uintptr
 }
 
 type PtraceArgs struct {
-	internalArgs
+  internalArgs
 
-	Request int64
-	Pid     int32
-	Addr    uintptr
-	Data    uintptr
+  Request int64
+  Pid int32
+  Addr uintptr
+  Data uintptr
 }
 
 type GetuidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SyslogArgs struct {
-	internalArgs
+  internalArgs
 
-	Type int32
-	Bufp string
-	Len  int32
+  Type int32
+  Bufp string
+  Len int32
 }
 
 type GetgidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SetuidArgs struct {
-	internalArgs
+  internalArgs
 
-	Uid int32
+  Uid int32
 }
 
 type SetgidArgs struct {
-	internalArgs
+  internalArgs
 
-	Gid int32
+  Gid int32
 }
 
 type GeteuidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type GetegidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SetpgidArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid  int32
-	Pgid int32
+  Pid int32
+  Pgid int32
 }
 
 type GetppidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type GetpgrpArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SetsidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SetreuidArgs struct {
-	internalArgs
+  internalArgs
 
-	Ruid int32
-	Euid int32
+  Ruid int32
+  Euid int32
 }
 
 type SetregidArgs struct {
-	internalArgs
+  internalArgs
 
-	Rgid int32
-	Egid int32
+  Rgid int32
+  Egid int32
 }
 
 type GetgroupsArgs struct {
-	internalArgs
+  internalArgs
 
-	Size int32
-	List uintptr
+  Size int32
+  List uintptr
 }
 
 type SetgroupsArgs struct {
-	internalArgs
+  internalArgs
 
-	Size int32
-	List uintptr
+  Size int32
+  List uintptr
 }
 
 type SetresuidArgs struct {
-	internalArgs
+  internalArgs
 
-	Ruid int32
-	Euid int32
-	Suid int32
+  Ruid int32
+  Euid int32
+  Suid int32
 }
 
 type GetresuidArgs struct {
-	internalArgs
+  internalArgs
 
-	Ruid uintptr
-	Euid uintptr
-	Suid uintptr
+  Ruid uintptr
+  Euid uintptr
+  Suid uintptr
 }
 
 type SetresgidArgs struct {
-	internalArgs
+  internalArgs
 
-	Rgid int32
-	Egid int32
-	Sgid int32
+  Rgid int32
+  Egid int32
+  Sgid int32
 }
 
 type GetresgidArgs struct {
-	internalArgs
+  internalArgs
 
-	Rgid uintptr
-	Egid uintptr
-	Sgid uintptr
+  Rgid uintptr
+  Egid uintptr
+  Sgid uintptr
 }
 
 type GetpgidArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid int32
+  Pid int32
 }
 
 type SetfsuidArgs struct {
-	internalArgs
+  internalArgs
 
-	Fsuid int32
+  Fsuid int32
 }
 
 type SetfsgidArgs struct {
-	internalArgs
+  internalArgs
 
-	Fsgid int32
+  Fsgid int32
 }
 
 type GetsidArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid int32
+  Pid int32
 }
 
 type CapgetArgs struct {
-	internalArgs
+  internalArgs
 
-	Hdrp  uintptr
-	Datap uintptr
+  Hdrp uintptr
+  Datap uintptr
 }
 
 type CapsetArgs struct {
-	internalArgs
+  internalArgs
 
-	Hdrp  uintptr
-	Datap uintptr
+  Hdrp uintptr
+  Datap uintptr
 }
 
 type RtSigpendingArgs struct {
-	internalArgs
+  internalArgs
 
-	Set        uintptr
-	Sigsetsize uint64
+  Set uintptr
+  Sigsetsize uint64
 }
 
 type RtSigtimedwaitArgs struct {
-	internalArgs
+  internalArgs
 
-	Set        uintptr
-	Info       uintptr
-	Timeout    float64
-	Sigsetsize uint64
+  Set uintptr
+  Info uintptr
+  Timeout float64
+  Sigsetsize uint64
 }
 
 type RtSigqueueinfoArgs struct {
-	internalArgs
+  internalArgs
 
-	Tgid int32
-	Sig  int32
-	Info uintptr
+  Tgid int32
+  Sig int32
+  Info uintptr
 }
 
 type RtSigsuspendArgs struct {
-	internalArgs
+  internalArgs
 
-	Mask       uintptr
-	Sigsetsize uint64
+  Mask uintptr
+  Sigsetsize uint64
 }
 
 type SigaltstackArgs struct {
-	internalArgs
+  internalArgs
 
-	Ss    uintptr
-	OldSs uintptr
+  Ss uintptr
+  OldSs uintptr
 }
 
 type UtimeArgs struct {
-	internalArgs
+  internalArgs
 
-	Filename string
-	Times    uintptr
+  Filename string
+  Times uintptr
 }
 
 type MknodArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Mode     uint32
-	Dev      uint32
+  Pathname string
+  Mode uint32
+  Dev uint32
 }
 
 type UselibArgs struct {
-	internalArgs
+  internalArgs
 
-	Library string
+  Library string
 }
 
 type PersonalityArgs struct {
-	internalArgs
+  internalArgs
 
-	Persona uint64
+  Persona uint64
 }
 
 type UstatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dev  uint32
-	Ubuf uintptr
+  Dev uint32
+  Ubuf uintptr
 }
 
 type StatfsArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
-	Buf  uintptr
+  Path string
+  Buf uintptr
 }
 
 type FstatfsArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd  int32
-	Buf uintptr
+  Fd int32
+  Buf uintptr
 }
 
 type SysfsArgs struct {
-	internalArgs
+  internalArgs
 
-	Option int32
+  Option int32
 }
 
 type GetpriorityArgs struct {
-	internalArgs
+  internalArgs
 
-	Which int32
-	Who   int32
+  Which int32
+  Who int32
 }
 
 type SetpriorityArgs struct {
-	internalArgs
+  internalArgs
 
-	Which int32
-	Who   int32
-	Prio  int32
+  Which int32
+  Who int32
+  Prio int32
 }
 
 type SchedSetparamArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid   int32
-	Param uintptr
+  Pid int32
+  Param uintptr
 }
 
 type SchedGetparamArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid   int32
-	Param uintptr
+  Pid int32
+  Param uintptr
 }
 
 type SchedSetschedulerArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid    int32
-	Policy int32
-	Param  uintptr
+  Pid int32
+  Policy int32
+  Param uintptr
 }
 
 type SchedGetschedulerArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid int32
+  Pid int32
 }
 
 type SchedGetPriorityMaxArgs struct {
-	internalArgs
+  internalArgs
 
-	Policy int32
+  Policy int32
 }
 
 type SchedGetPriorityMinArgs struct {
-	internalArgs
+  internalArgs
 
-	Policy int32
+  Policy int32
 }
 
 type SchedRrGetIntervalArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid int32
-	Tp  float64
+  Pid int32
+  Tp float64
 }
 
 type MlockArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr uintptr
-	Len  uint64
+  Addr uintptr
+  Len uint64
 }
 
 type MunlockArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr uintptr
-	Len  uint64
+  Addr uintptr
+  Len uint64
 }
 
 type MlockallArgs struct {
-	internalArgs
+  internalArgs
 
-	Flags int32
+  Flags int32
 }
 
 type MunlockallArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type VhangupArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type ModifyLdtArgs struct {
-	internalArgs
+  internalArgs
 
-	Func      int32
-	Ptr       uintptr
-	Bytecount uint64
+  Func int32
+  Ptr uintptr
+  Bytecount uint64
 }
 
 type PivotRootArgs struct {
-	internalArgs
+  internalArgs
 
-	NewRoot string
-	PutOld  string
+  NewRoot string
+  PutOld string
 }
 
 type SysctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Args uintptr
+  Args uintptr
 }
 
 type PrctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Option int32
-	Arg2   uint64
-	Arg3   uint64
-	Arg4   uint64
-	Arg5   uint64
+  Option int32
+  Arg2 uint64
+  Arg3 uint64
+  Arg4 uint64
+  Arg5 uint64
 }
 
 type ArchPrctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Option int32
-	Addr   uint64
+  Option int32
+  Addr uint64
 }
 
 type AdjtimexArgs struct {
-	internalArgs
+  internalArgs
 
-	Buf uintptr
+  Buf uintptr
 }
 
 type SetrlimitArgs struct {
-	internalArgs
+  internalArgs
 
-	Resource int32
-	Rlim     uintptr
+  Resource int32
+  Rlim uintptr
 }
 
 type ChrootArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
+  Path string
 }
 
 type SyncArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type AcctArgs struct {
-	internalArgs
+  internalArgs
 
-	Filename string
+  Filename string
 }
 
 type SettimeofdayArgs struct {
-	internalArgs
+  internalArgs
 
-	Tv uintptr
-	Tz uintptr
+  Tv uintptr
+  Tz uintptr
 }
 
 type MountArgs struct {
-	internalArgs
+  internalArgs
 
-	Source         string
-	Target         string
-	Filesystemtype string
-	Mountflags     uint64
-	Data           uintptr
+  Source string
+  Target string
+  Filesystemtype string
+  Mountflags uint64
+  Data uintptr
 }
 
 type Umount2Args struct {
-	internalArgs
+  internalArgs
 
-	Target string
-	Flags  int32
+  Target string
+  Flags int32
 }
 
 type SwaponArgs struct {
-	internalArgs
+  internalArgs
 
-	Path      string
-	Swapflags int32
+  Path string
+  Swapflags int32
 }
 
 type SwapoffArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
+  Path string
 }
 
 type RebootArgs struct {
-	internalArgs
+  internalArgs
 
-	Magic  int32
-	Magic2 int32
-	Cmd    int32
-	Arg    uintptr
+  Magic int32
+  Magic2 int32
+  Cmd int32
+  Arg uintptr
 }
 
 type SethostnameArgs struct {
-	internalArgs
+  internalArgs
 
-	Name string
-	Len  uint64
+  Name string
+  Len uint64
 }
 
 type SetdomainnameArgs struct {
-	internalArgs
+  internalArgs
 
-	Name string
-	Len  uint64
+  Name string
+  Len uint64
 }
 
 type IoplArgs struct {
-	internalArgs
+  internalArgs
 
-	Level int32
+  Level int32
 }
 
 type IopermArgs struct {
-	internalArgs
+  internalArgs
 
-	From   uint64
-	Num    uint64
-	TurnOn int32
+  From uint64
+  Num uint64
+  TurnOn int32
 }
 
 type CreateModuleArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type InitModuleArgs struct {
-	internalArgs
+  internalArgs
 
-	ModuleImage uintptr
-	Len         uint64
-	ParamValues string
+  ModuleImage uintptr
+  Len uint64
+  ParamValues string
 }
 
 type DeleteModuleArgs struct {
-	internalArgs
+  internalArgs
 
-	Name  string
-	Flags int32
+  Name string
+  Flags int32
 }
 
 type GetKernelSymsArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type QueryModuleArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type QuotactlArgs struct {
-	internalArgs
+  internalArgs
 
-	Cmd     int32
-	Special string
-	Id      int32
-	Addr    uintptr
+  Cmd int32
+  Special string
+  Id int32
+  Addr uintptr
 }
 
 type NfsservctlArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type GetpmsgArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type PutpmsgArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type AfsArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type TuxcallArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SecurityArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type GettidArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type ReadaheadArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Offset uint64
-	Count  uint64
+  Fd int32
+  Offset uint64
+  Count uint64
 }
 
 type SetxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path  string
-	Name  string
-	Value uintptr
-	Size  uint64
-	Flags int32
+  Path string
+  Name string
+  Value uintptr
+  Size uint64
+  Flags int32
 }
 
 type LsetxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path  string
-	Name  string
-	Value uintptr
-	Size  uint64
-	Flags int32
+  Path string
+  Name string
+  Value uintptr
+  Size uint64
+  Flags int32
 }
 
 type FsetxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    int32
-	Name  string
-	Value uintptr
-	Size  uint64
-	Flags int32
+  Fd int32
+  Name string
+  Value uintptr
+  Size uint64
+  Flags int32
 }
 
 type GetxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path  string
-	Name  string
-	Value uintptr
-	Size  uint64
+  Path string
+  Name string
+  Value uintptr
+  Size uint64
 }
 
 type LgetxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path  string
-	Name  string
-	Value uintptr
-	Size  uint64
+  Path string
+  Name string
+  Value uintptr
+  Size uint64
 }
 
 type FgetxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    int32
-	Name  string
-	Value uintptr
-	Size  uint64
+  Fd int32
+  Name string
+  Value uintptr
+  Size uint64
 }
 
 type ListxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
-	List string
-	Size uint64
+  Path string
+  List string
+  Size uint64
 }
 
 type LlistxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
-	List string
-	Size uint64
+  Path string
+  List string
+  Size uint64
 }
 
 type FlistxattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd   int32
-	List string
-	Size uint64
+  Fd int32
+  List string
+  Size uint64
 }
 
 type RemovexattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
-	Name string
+  Path string
+  Name string
 }
 
 type LremovexattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Path string
-	Name string
+  Path string
+  Name string
 }
 
 type FremovexattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd   int32
-	Name string
+  Fd int32
+  Name string
 }
 
 type TkillArgs struct {
-	internalArgs
+  internalArgs
 
-	Tid int32
-	Sig int32
+  Tid int32
+  Sig int32
 }
 
 type TimeArgs struct {
-	internalArgs
+  internalArgs
 
-	Tloc uintptr
+  Tloc uintptr
 }
 
 type FutexArgs struct {
-	internalArgs
+  internalArgs
 
-	Uaddr   uintptr
-	FutexOp int32
-	Val     int32
-	Timeout float64
-	Uaddr2  uintptr
-	Val3    int32
+  Uaddr uintptr
+  FutexOp int32
+  Val int32
+  Timeout float64
+  Uaddr2 uintptr
+  Val3 int32
 }
 
 type SchedSetaffinityArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid        int32
-	Cpusetsize uint64
-	Mask       uintptr
+  Pid int32
+  Cpusetsize uint64
+  Mask uintptr
 }
 
 type SchedGetaffinityArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid        int32
-	Cpusetsize uint64
-	Mask       uintptr
+  Pid int32
+  Cpusetsize uint64
+  Mask uintptr
 }
 
 type SetThreadAreaArgs struct {
-	internalArgs
+  internalArgs
 
-	UInfo uintptr
+  UInfo uintptr
 }
 
 type IoSetupArgs struct {
-	internalArgs
+  internalArgs
 
-	NrEvents uint32
-	CtxIdp   uintptr
+  NrEvents uint32
+  CtxIdp uintptr
 }
 
 type IoDestroyArgs struct {
-	internalArgs
+  internalArgs
 
-	CtxId uintptr
+  CtxId uintptr
 }
 
 type IoGeteventsArgs struct {
-	internalArgs
+  internalArgs
 
-	CtxId   uintptr
-	MinNr   int64
-	Nr      int64
-	Events  uintptr
-	Timeout float64
+  CtxId uintptr
+  MinNr int64
+  Nr int64
+  Events uintptr
+  Timeout float64
 }
 
 type IoSubmitArgs struct {
-	internalArgs
+  internalArgs
 
-	CtxId  uintptr
-	Nr     int64
-	Iocbpp uintptr
+  CtxId uintptr
+  Nr int64
+  Iocbpp uintptr
 }
 
 type IoCancelArgs struct {
-	internalArgs
+  internalArgs
 
-	CtxId  uintptr
-	Iocb   uintptr
-	Result uintptr
+  CtxId uintptr
+  Iocb uintptr
+  Result uintptr
 }
 
 type GetThreadAreaArgs struct {
-	internalArgs
+  internalArgs
 
-	UInfo uintptr
+  UInfo uintptr
 }
 
 type LookupDcookieArgs struct {
-	internalArgs
+  internalArgs
 
-	Cookie uint64
-	Buffer string
-	Len    uint64
+  Cookie uint64
+  Buffer string
+  Len uint64
 }
 
 type EpollCreateArgs struct {
-	internalArgs
+  internalArgs
 
-	Size int32
+  Size int32
 }
 
 type EpollCtlOldArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type EpollWaitOldArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type RemapFilePagesArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr  uintptr
-	Size  uint64
-	Prot  int32
-	Pgoff uint64
-	Flags int32
+  Addr uintptr
+  Size uint64
+  Prot int32
+  Pgoff uint64
+  Flags int32
 }
 
 type Getdents64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd    uint32
-	Dirp  uintptr
-	Count uint32
+  Fd uint32
+  Dirp uintptr
+  Count uint32
 }
 
 type SetTidAddressArgs struct {
-	internalArgs
+  internalArgs
 
-	Tidptr uintptr
+  Tidptr uintptr
 }
 
 type RestartSyscallArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SemtimedopArgs struct {
-	internalArgs
+  internalArgs
 
-	Semid   int32
-	Sops    uintptr
-	Nsops   uint64
-	Timeout float64
+  Semid int32
+  Sops uintptr
+  Nsops uint64
+  Timeout float64
 }
 
 type Fadvise64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Offset uint64
-	Len    uint64
-	Advice int32
+  Fd int32
+  Offset uint64
+  Len uint64
+  Advice int32
 }
 
 type TimerCreateArgs struct {
-	internalArgs
+  internalArgs
 
-	Clockid int32
-	Sevp    uintptr
-	TimerId uintptr
+  Clockid int32
+  Sevp uintptr
+  TimerId uintptr
 }
 
 type TimerSettimeArgs struct {
-	internalArgs
+  internalArgs
 
-	TimerId  int32
-	Flags    int32
-	NewValue uintptr
-	OldValue uintptr
+  TimerId int32
+  Flags int32
+  NewValue uintptr
+  OldValue uintptr
 }
 
 type TimerGettimeArgs struct {
-	internalArgs
+  internalArgs
 
-	TimerId   int32
-	CurrValue uintptr
+  TimerId int32
+  CurrValue uintptr
 }
 
 type TimerGetoverrunArgs struct {
-	internalArgs
+  internalArgs
 
-	TimerId int32
+  TimerId int32
 }
 
 type TimerDeleteArgs struct {
-	internalArgs
+  internalArgs
 
-	TimerId int32
+  TimerId int32
 }
 
 type ClockSettimeArgs struct {
-	internalArgs
+  internalArgs
 
-	Clockid int32
-	Tp      float64
+  Clockid int32
+  Tp float64
 }
 
 type ClockGettimeArgs struct {
-	internalArgs
+  internalArgs
 
-	Clockid int32
-	Tp      float64
+  Clockid int32
+  Tp float64
 }
 
 type ClockGetresArgs struct {
-	internalArgs
+  internalArgs
 
-	Clockid int32
-	Res     float64
+  Clockid int32
+  Res float64
 }
 
 type ClockNanosleepArgs struct {
-	internalArgs
+  internalArgs
 
-	Clockid int32
-	Flags   int32
-	Request float64
-	Remain  float64
+  Clockid int32
+  Flags int32
+  Request float64
+  Remain float64
 }
 
 type ExitGroupArgs struct {
-	internalArgs
+  internalArgs
 
-	Status int32
+  Status int32
 }
 
 type EpollWaitArgs struct {
-	internalArgs
+  internalArgs
 
-	Epfd      int32
-	Events    uintptr
-	Maxevents int32
-	Timeout   int32
+  Epfd int32
+  Events uintptr
+  Maxevents int32
+  Timeout int32
 }
 
 type EpollCtlArgs struct {
-	internalArgs
+  internalArgs
 
-	Epfd  int32
-	Op    int32
-	Fd    int32
-	Event uintptr
+  Epfd int32
+  Op int32
+  Fd int32
+  Event uintptr
 }
 
 type TgkillArgs struct {
-	internalArgs
+  internalArgs
 
-	Tgid int32
-	Tid  int32
-	Sig  int32
+  Tgid int32
+  Tid int32
+  Sig int32
 }
 
 type UtimesArgs struct {
-	internalArgs
+  internalArgs
 
-	Filename string
-	Times    uintptr
+  Filename string
+  Times uintptr
 }
 
 type VserverArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type MbindArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr     uintptr
-	Len      uint64
-	Mode     int32
-	Nodemask uintptr
-	Maxnode  uint64
-	Flags    uint32
+  Addr uintptr
+  Len uint64
+  Mode int32
+  Nodemask uintptr
+  Maxnode uint64
+  Flags uint32
 }
 
 type SetMempolicyArgs struct {
-	internalArgs
+  internalArgs
 
-	Mode     int32
-	Nodemask uintptr
-	Maxnode  uint64
+  Mode int32
+  Nodemask uintptr
+  Maxnode uint64
 }
 
 type GetMempolicyArgs struct {
-	internalArgs
+  internalArgs
 
-	Mode     uintptr
-	Nodemask uintptr
-	Maxnode  uint64
-	Addr     uintptr
-	Flags    uint64
+  Mode uintptr
+  Nodemask uintptr
+  Maxnode uint64
+  Addr uintptr
+  Flags uint64
 }
 
 type MqOpenArgs struct {
-	internalArgs
+  internalArgs
 
-	Name  string
-	Oflag int32
-	Mode  uint32
-	Attr  uintptr
+  Name string
+  Oflag int32
+  Mode uint32
+  Attr uintptr
 }
 
 type MqUnlinkArgs struct {
-	internalArgs
+  internalArgs
 
-	Name string
+  Name string
 }
 
 type MqTimedsendArgs struct {
-	internalArgs
+  internalArgs
 
-	Mqdes      int32
-	MsgPtr     string
-	MsgLen     uint64
-	MsgPrio    uint32
-	AbsTimeout float64
+  Mqdes int32
+  MsgPtr string
+  MsgLen uint64
+  MsgPrio uint32
+  AbsTimeout float64
 }
 
 type MqTimedreceiveArgs struct {
-	internalArgs
+  internalArgs
 
-	Mqdes      int32
-	MsgPtr     string
-	MsgLen     uint64
-	MsgPrio    uintptr
-	AbsTimeout float64
+  Mqdes int32
+  MsgPtr string
+  MsgLen uint64
+  MsgPrio uintptr
+  AbsTimeout float64
 }
 
 type MqNotifyArgs struct {
-	internalArgs
+  internalArgs
 
-	Mqdes int32
-	Sevp  uintptr
+  Mqdes int32
+  Sevp uintptr
 }
 
 type MqGetsetattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Mqdes   int32
-	Newattr uintptr
-	Oldattr uintptr
+  Mqdes int32
+  Newattr uintptr
+  Oldattr uintptr
 }
 
 type KexecLoadArgs struct {
-	internalArgs
+  internalArgs
 
-	Entry      uint64
-	NrSegments uint64
-	Segments   uintptr
-	Flags      uint64
+  Entry uint64
+  NrSegments uint64
+  Segments uintptr
+  Flags uint64
 }
 
 type WaitidArgs struct {
-	internalArgs
+  internalArgs
 
-	Idtype  int32
-	Id      int32
-	Infop   uintptr
-	Options int32
-	Rusage  uintptr
+  Idtype int32
+  Id int32
+  Infop uintptr
+  Options int32
+  Rusage uintptr
 }
 
 type AddKeyArgs struct {
-	internalArgs
+  internalArgs
 
-	Type        string
-	Description string
-	Payload     uintptr
-	Plen        uint64
-	Keyring     int32
+  Type string
+  Description string
+  Payload uintptr
+  Plen uint64
+  Keyring int32
 }
 
 type RequestKeyArgs struct {
-	internalArgs
+  internalArgs
 
-	Type        string
-	Description string
-	CalloutInfo string
-	DestKeyring int32
+  Type string
+  Description string
+  CalloutInfo string
+  DestKeyring int32
 }
 
 type KeyctlArgs struct {
-	internalArgs
+  internalArgs
 
-	Operation int32
-	Arg2      uint64
-	Arg3      uint64
-	Arg4      uint64
-	Arg5      uint64
+  Operation int32
+  Arg2 uint64
+  Arg3 uint64
+  Arg4 uint64
+  Arg5 uint64
 }
 
 type IoprioSetArgs struct {
-	internalArgs
+  internalArgs
 
-	Which  int32
-	Who    int32
-	Ioprio int32
+  Which int32
+  Who int32
+  Ioprio int32
 }
 
 type IoprioGetArgs struct {
-	internalArgs
+  internalArgs
 
-	Which int32
-	Who   int32
+  Which int32
+  Who int32
 }
 
 type InotifyInitArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type InotifyAddWatchArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd       int32
-	Pathname string
-	Mask     uint32
+  Fd int32
+  Pathname string
+  Mask uint32
 }
 
 type InotifyRmWatchArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd int32
-	Wd int32
+  Fd int32
+  Wd int32
 }
 
 type MigratePagesArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid      int32
-	Maxnode  uint64
-	OldNodes uintptr
-	NewNodes uintptr
+  Pid int32
+  Maxnode uint64
+  OldNodes uintptr
+  NewNodes uintptr
 }
 
 type OpenatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Flags    int32
-	Mode     uint32
+  Dirfd int32
+  Pathname string
+  Flags int32
+  Mode uint32
 }
 
 type MkdiratArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Mode     uint32
+  Dirfd int32
+  Pathname string
+  Mode uint32
 }
 
 type MknodatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Mode     uint32
-	Dev      uint32
+  Dirfd int32
+  Pathname string
+  Mode uint32
+  Dev uint32
 }
 
 type FchownatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Owner    int32
-	Group    int32
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Owner int32
+  Group int32
+  Flags int32
 }
 
 type FutimesatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Times    uintptr
+  Dirfd int32
+  Pathname string
+  Times uintptr
 }
 
 type NewfstatatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Statbuf  uintptr
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Statbuf uintptr
+  Flags int32
 }
 
 type UnlinkatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Flags int32
 }
 
 type RenameatArgs struct {
-	internalArgs
+  internalArgs
 
-	Olddirfd int32
-	Oldpath  string
-	Newdirfd int32
-	Newpath  string
+  Olddirfd int32
+  Oldpath string
+  Newdirfd int32
+  Newpath string
 }
 
 type LinkatArgs struct {
-	internalArgs
+  internalArgs
 
-	Olddirfd int32
-	Oldpath  string
-	Newdirfd int32
-	Newpath  string
-	Flags    uint32
+  Olddirfd int32
+  Oldpath string
+  Newdirfd int32
+  Newpath string
+  Flags uint32
 }
 
 type SymlinkatArgs struct {
-	internalArgs
+  internalArgs
 
-	Target   string
-	Newdirfd int32
-	Linkpath string
+  Target string
+  Newdirfd int32
+  Linkpath string
 }
 
 type ReadlinkatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Buf      string
-	Bufsiz   int32
+  Dirfd int32
+  Pathname string
+  Buf string
+  Bufsiz int32
 }
 
 type FchmodatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Mode     uint32
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Mode uint32
+  Flags int32
 }
 
 type FaccessatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Mode     int32
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Mode int32
+  Flags int32
 }
 
 type Pselect6Args struct {
-	internalArgs
+  internalArgs
 
-	Nfds      int32
-	Readfds   uintptr
-	Writefds  uintptr
-	Exceptfds uintptr
-	Timeout   float64
-	Sigmask   uintptr
+  Nfds int32
+  Readfds uintptr
+  Writefds uintptr
+  Exceptfds uintptr
+  Timeout float64
+  Sigmask uintptr
 }
 
 type PpollArgs struct {
-	internalArgs
+  internalArgs
 
-	Fds        uintptr
-	Nfds       uint32
-	TmoP       float64
-	Sigmask    uintptr
-	Sigsetsize uint64
+  Fds uintptr
+  Nfds uint32
+  TmoP float64
+  Sigmask uintptr
+  Sigsetsize uint64
 }
 
 type UnshareArgs struct {
-	internalArgs
+  internalArgs
 
-	Flags int32
+  Flags int32
 }
 
 type SetRobustListArgs struct {
-	internalArgs
+  internalArgs
 
-	Head uintptr
-	Len  uint64
+  Head uintptr
+  Len uint64
 }
 
 type GetRobustListArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid     int32
-	HeadPtr uintptr
-	LenPtr  uintptr
+  Pid int32
+  HeadPtr uintptr
+  LenPtr uintptr
 }
 
 type SpliceArgs struct {
-	internalArgs
+  internalArgs
 
-	FdIn   int32
-	OffIn  uintptr
-	FdOut  int32
-	OffOut uintptr
-	Len    uint64
-	Flags  uint32
+  FdIn int32
+  OffIn uintptr
+  FdOut int32
+  OffOut uintptr
+  Len uint64
+  Flags uint32
 }
 
 type TeeArgs struct {
-	internalArgs
+  internalArgs
 
-	FdIn  int32
-	FdOut int32
-	Len   uint64
-	Flags uint32
+  FdIn int32
+  FdOut int32
+  Len uint64
+  Flags uint32
 }
 
 type SyncFileRangeArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Offset uint64
-	Nbytes uint64
-	Flags  uint32
+  Fd int32
+  Offset uint64
+  Nbytes uint64
+  Flags uint32
 }
 
 type VmspliceArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Iov    uintptr
-	NrSegs uint64
-	Flags  uint32
+  Fd int32
+  Iov uintptr
+  NrSegs uint64
+  Flags uint32
 }
 
 type MovePagesArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid    int32
-	Count  uint64
-	Pages  uintptr
-	Nodes  uintptr
-	Status uintptr
-	Flags  int32
+  Pid int32
+  Count uint64
+  Pages uintptr
+  Nodes uintptr
+  Status uintptr
+  Flags int32
 }
 
 type UtimensatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Times    float64
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Times float64
+  Flags int32
 }
 
 type EpollPwaitArgs struct {
-	internalArgs
+  internalArgs
 
-	Epfd       int32
-	Events     uintptr
-	Maxevents  int32
-	Timeout    int32
-	Sigmask    uintptr
-	Sigsetsize uint64
+  Epfd int32
+  Events uintptr
+  Maxevents int32
+  Timeout int32
+  Sigmask uintptr
+  Sigsetsize uint64
 }
 
 type SignalfdArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    int32
-	Mask  uintptr
-	Flags int32
+  Fd int32
+  Mask uintptr
+  Flags int32
 }
 
 type TimerfdCreateArgs struct {
-	internalArgs
+  internalArgs
 
-	Clockid int32
-	Flags   int32
+  Clockid int32
+  Flags int32
 }
 
 type EventfdArgs struct {
-	internalArgs
+  internalArgs
 
-	Initval uint32
-	Flags   int32
+  Initval uint32
+  Flags int32
 }
 
 type FallocateArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Mode   int32
-	Offset uint64
-	Len    uint64
+  Fd int32
+  Mode int32
+  Offset uint64
+  Len uint64
 }
 
 type TimerfdSettimeArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd       int32
-	Flags    int32
-	NewValue uintptr
-	OldValue uintptr
+  Fd int32
+  Flags int32
+  NewValue uintptr
+  OldValue uintptr
 }
 
 type TimerfdGettimeArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd        int32
-	CurrValue uintptr
+  Fd int32
+  CurrValue uintptr
 }
 
 type Accept4Args struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Addr    Sockaddr
-	Addrlen uintptr
-	Flags   int32
+  Sockfd int32
+  Addr Sockaddr
+  Addrlen uintptr
+  Flags int32
 }
 
 type Signalfd4Args struct {
-	internalArgs
+  internalArgs
 
-	Fd       int32
-	Mask     uintptr
-	Sizemask uint64
-	Flags    int32
+  Fd int32
+  Mask uintptr
+  Sizemask uint64
+  Flags int32
 }
 
 type Eventfd2Args struct {
-	internalArgs
+  internalArgs
 
-	Initval uint32
-	Flags   int32
+  Initval uint32
+  Flags int32
 }
 
 type EpollCreate1Args struct {
-	internalArgs
+  internalArgs
 
-	Flags int32
+  Flags int32
 }
 
 type Dup3Args struct {
-	internalArgs
+  internalArgs
 
-	Oldfd int32
-	Newfd int32
-	Flags int32
+  Oldfd int32
+  Newfd int32
+  Flags int32
 }
 
 type Pipe2Args struct {
-	internalArgs
+  internalArgs
 
-	Pipefd [2]int32
-	Flags  int32
+  Pipefd [2]int32
+  Flags int32
 }
 
 type InotifyInit1Args struct {
-	internalArgs
+  internalArgs
 
-	Flags int32
+  Flags int32
 }
 
 type PreadvArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Iov    uintptr
-	Iovcnt uint64
-	PosL   uint64
-	PosH   uint64
+  Fd int32
+  Iov uintptr
+  Iovcnt uint64
+  PosL uint64
+  PosH uint64
 }
 
 type PwritevArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Iov    uintptr
-	Iovcnt uint64
-	PosL   uint64
-	PosH   uint64
+  Fd int32
+  Iov uintptr
+  Iovcnt uint64
+  PosL uint64
+  PosH uint64
 }
 
 type RtTgsigqueueinfoArgs struct {
-	internalArgs
+  internalArgs
 
-	Tgid int32
-	Tid  int32
-	Sig  int32
-	Info uintptr
+  Tgid int32
+  Tid int32
+  Sig int32
+  Info uintptr
 }
 
 type PerfEventOpenArgs struct {
-	internalArgs
+  internalArgs
 
-	Attr    uintptr
-	Pid     int32
-	Cpu     int32
-	GroupFd int32
-	Flags   uint64
+  Attr uintptr
+  Pid int32
+  Cpu int32
+  GroupFd int32
+  Flags uint64
 }
 
 type RecvmmsgArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd  int32
-	Msgvec  uintptr
-	Vlen    uint32
-	Flags   int32
-	Timeout float64
+  Sockfd int32
+  Msgvec uintptr
+  Vlen uint32
+  Flags int32
+  Timeout float64
 }
 
 type FanotifyInitArgs struct {
-	internalArgs
+  internalArgs
 
-	Flags       uint32
-	EventFFlags uint32
+  Flags uint32
+  EventFFlags uint32
 }
 
 type FanotifyMarkArgs struct {
-	internalArgs
+  internalArgs
 
-	FanotifyFd int32
-	Flags      uint32
-	Mask       uint64
-	Dirfd      int32
-	Pathname   string
+  FanotifyFd int32
+  Flags uint32
+  Mask uint64
+  Dirfd int32
+  Pathname string
 }
 
 type Prlimit64Args struct {
-	internalArgs
+  internalArgs
 
-	Pid      int32
-	Resource int32
-	NewLimit uintptr
-	OldLimit uintptr
+  Pid int32
+  Resource int32
+  NewLimit uintptr
+  OldLimit uintptr
 }
 
 type NameToHandleAtArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Handle   uintptr
-	MountId  uintptr
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Handle uintptr
+  MountId uintptr
+  Flags int32
 }
 
 type OpenByHandleAtArgs struct {
-	internalArgs
+  internalArgs
 
-	MountFd int32
-	Handle  uintptr
-	Flags   int32
+  MountFd int32
+  Handle uintptr
+  Flags int32
 }
 
 type ClockAdjtimeArgs struct {
-	internalArgs
+  internalArgs
 
-	ClkId int32
-	Buf   uintptr
+  ClkId int32
+  Buf uintptr
 }
 
 type SyncfsArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd int32
+  Fd int32
 }
 
 type SendmmsgArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd int32
-	Msgvec uintptr
-	Vlen   uint32
-	Flags  int32
+  Sockfd int32
+  Msgvec uintptr
+  Vlen uint32
+  Flags int32
 }
 
 type SetnsArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Nstype int32
+  Fd int32
+  Nstype int32
 }
 
 type GetcpuArgs struct {
-	internalArgs
+  internalArgs
 
-	Cpu    uintptr
-	Node   uintptr
-	Tcache uintptr
+  Cpu uintptr
+  Node uintptr
+  Tcache uintptr
 }
 
 type ProcessVmReadvArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid       int32
-	LocalIov  uintptr
-	Liovcnt   uint64
-	RemoteIov uintptr
-	Riovcnt   uint64
-	Flags     uint64
+  Pid int32
+  LocalIov uintptr
+  Liovcnt uint64
+  RemoteIov uintptr
+  Riovcnt uint64
+  Flags uint64
 }
 
 type ProcessVmWritevArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid       int32
-	LocalIov  uintptr
-	Liovcnt   uint64
-	RemoteIov uintptr
-	Riovcnt   uint64
-	Flags     uint64
+  Pid int32
+  LocalIov uintptr
+  Liovcnt uint64
+  RemoteIov uintptr
+  Riovcnt uint64
+  Flags uint64
 }
 
 type KcmpArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid1 int32
-	Pid2 int32
-	Type int32
-	Idx1 uint64
-	Idx2 uint64
+  Pid1 int32
+  Pid2 int32
+  Type int32
+  Idx1 uint64
+  Idx2 uint64
 }
 
 type FinitModuleArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd          int32
-	ParamValues string
-	Flags       int32
+  Fd int32
+  ParamValues string
+  Flags int32
 }
 
 type SchedSetattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid   int32
-	Attr  uintptr
-	Flags uint32
+  Pid int32
+  Attr uintptr
+  Flags uint32
 }
 
 type SchedGetattrArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid   int32
-	Attr  uintptr
-	Size  uint32
-	Flags uint32
+  Pid int32
+  Attr uintptr
+  Size uint32
+  Flags uint32
 }
 
 type Renameat2Args struct {
-	internalArgs
+  internalArgs
 
-	Olddirfd int32
-	Oldpath  string
-	Newdirfd int32
-	Newpath  string
-	Flags    uint32
+  Olddirfd int32
+  Oldpath string
+  Newdirfd int32
+  Newpath string
+  Flags uint32
 }
 
 type SeccompArgs struct {
-	internalArgs
+  internalArgs
 
-	Operation uint32
-	Flags     uint32
-	Args      uintptr
+  Operation uint32
+  Flags uint32
+  Args uintptr
 }
 
 type GetrandomArgs struct {
-	internalArgs
+  internalArgs
 
-	Buf    uintptr
-	Buflen uint64
-	Flags  uint32
+  Buf uintptr
+  Buflen uint64
+  Flags uint32
 }
 
 type MemfdCreateArgs struct {
-	internalArgs
+  internalArgs
 
-	Name  string
-	Flags uint32
+  Name string
+  Flags uint32
 }
 
 type KexecFileLoadArgs struct {
-	internalArgs
+  internalArgs
 
-	KernelFd   int32
-	InitrdFd   int32
-	CmdlineLen uint64
-	Cmdline    string
-	Flags      uint64
+  KernelFd int32
+  InitrdFd int32
+  CmdlineLen uint64
+  Cmdline string
+  Flags uint64
 }
 
 type BpfArgs struct {
-	internalArgs
+  internalArgs
 
-	Cmd  int32
-	Attr uintptr
-	Size uint32
+  Cmd int32
+  Attr uintptr
+  Size uint32
 }
 
 type ExecveatArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Argv     []string
-	Envp     []string
-	Flags    int32
+  Dirfd int32
+  Pathname string
+  Argv []string
+  Envp []string
+  Flags int32
 }
 
 type UserfaultfdArgs struct {
-	internalArgs
+  internalArgs
 
-	Flags int32
+  Flags int32
 }
 
 type MembarrierArgs struct {
-	internalArgs
+  internalArgs
 
-	Cmd   int32
-	Flags int32
+  Cmd int32
+  Flags int32
 }
 
 type Mlock2Args struct {
-	internalArgs
+  internalArgs
 
-	Addr  uintptr
-	Len   uint64
-	Flags int32
+  Addr uintptr
+  Len uint64
+  Flags int32
 }
 
 type CopyFileRangeArgs struct {
-	internalArgs
+  internalArgs
 
-	FdIn   int32
-	OffIn  uintptr
-	FdOut  int32
-	OffOut uintptr
-	Len    uint64
-	Flags  uint32
+  FdIn int32
+  OffIn uintptr
+  FdOut int32
+  OffOut uintptr
+  Len uint64
+  Flags uint32
 }
 
 type Preadv2Args struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Iov    uintptr
-	Iovcnt uint64
-	PosL   uint64
-	PosH   uint64
-	Flags  int32
+  Fd int32
+  Iov uintptr
+  Iovcnt uint64
+  PosL uint64
+  PosH uint64
+  Flags int32
 }
 
 type Pwritev2Args struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Iov    uintptr
-	Iovcnt uint64
-	PosL   uint64
-	PosH   uint64
-	Flags  int32
+  Fd int32
+  Iov uintptr
+  Iovcnt uint64
+  PosL uint64
+  PosH uint64
+  Flags int32
 }
 
 type PkeyMprotectArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr uintptr
-	Len  uint64
-	Prot int32
-	Pkey int32
+  Addr uintptr
+  Len uint64
+  Prot int32
+  Pkey int32
 }
 
 type PkeyAllocArgs struct {
-	internalArgs
+  internalArgs
 
-	Flags        uint32
-	AccessRights uint64
+  Flags uint32
+  AccessRights uint64
 }
 
 type PkeyFreeArgs struct {
-	internalArgs
+  internalArgs
 
-	Pkey int32
+  Pkey int32
 }
 
 type StatxArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Flags    int32
-	Mask     uint32
-	Statxbuf uintptr
+  Dirfd int32
+  Pathname string
+  Flags int32
+  Mask uint32
+  Statxbuf uintptr
 }
 
 type IoPgeteventsArgs struct {
-	internalArgs
+  internalArgs
 
-	CtxId   uintptr
-	MinNr   int64
-	Nr      int64
-	Events  uintptr
-	Timeout float64
-	Usig    uintptr
+  CtxId uintptr
+  MinNr int64
+  Nr int64
+  Events uintptr
+  Timeout float64
+  Usig uintptr
 }
 
 type RseqArgs struct {
-	internalArgs
+  internalArgs
 
-	Rseq    uintptr
-	RseqLen uint32
-	Flags   int32
-	Sig     uint32
+  Rseq uintptr
+  RseqLen uint32
+  Flags int32
+  Sig uint32
 }
 
 type PidfdSendSignalArgs struct {
-	internalArgs
+  internalArgs
 
-	Pidfd int32
-	Sig   int32
-	Info  uintptr
-	Flags uint32
+  Pidfd int32
+  Sig int32
+  Info uintptr
+  Flags uint32
 }
 
 type IoUringSetupArgs struct {
-	internalArgs
+  internalArgs
 
-	Entries uint32
-	P       uintptr
+  Entries uint32
+  P uintptr
 }
 
 type IoUringEnterArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd          uint32
-	ToSubmit    uint32
-	MinComplete uint32
-	Flags       uint32
-	Sig         uintptr
+  Fd uint32
+  ToSubmit uint32
+  MinComplete uint32
+  Flags uint32
+  Sig uintptr
 }
 
 type IoUringRegisterArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd     uint32
-	Opcode uint32
-	Arg    uintptr
-	NrArgs uint32
+  Fd uint32
+  Opcode uint32
+  Arg uintptr
+  NrArgs uint32
 }
 
 type OpenTreeArgs struct {
-	internalArgs
+  internalArgs
 
-	Dfd      int32
-	Filename string
-	Flags    uint32
+  Dfd int32
+  Filename string
+  Flags uint32
 }
 
 type MoveMountArgs struct {
-	internalArgs
+  internalArgs
 
-	FromDfd  int32
-	FromPath string
-	ToDfd    int32
-	ToPath   string
-	Flags    uint32
+  FromDfd int32
+  FromPath string
+  ToDfd int32
+  ToPath string
+  Flags uint32
 }
 
 type FsopenArgs struct {
-	internalArgs
+  internalArgs
 
-	Fsname string
-	Flags  uint32
+  Fsname string
+  Flags uint32
 }
 
 type FsconfigArgs struct {
-	internalArgs
+  internalArgs
 
-	FsFd  uintptr
-	Cmd   uint32
-	Key   string
-	Value uintptr
-	Aux   int32
+  FsFd uintptr
+  Cmd uint32
+  Key string
+  Value uintptr
+  Aux int32
 }
 
 type FsmountArgs struct {
-	internalArgs
+  internalArgs
 
-	Fsfd    int32
-	Flags   uint32
-	MsFlags uint32
+  Fsfd int32
+  Flags uint32
+  MsFlags uint32
 }
 
 type FspickArgs struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	Flags    uint32
+  Dirfd int32
+  Pathname string
+  Flags uint32
 }
 
 type PidfdOpenArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid   int32
-	Flags uint32
+  Pid int32
+  Flags uint32
 }
 
 type Clone3Args struct {
-	internalArgs
+  internalArgs
 
-	ClArgs uintptr
-	Size   uint64
+  ClArgs uintptr
+  Size uint64
 }
 
 type CloseRangeArgs struct {
-	internalArgs
+  internalArgs
 
-	First uint32
-	Last  uint32
+  First uint32
+  Last uint32
 }
 
 type Openat2Args struct {
-	internalArgs
+  internalArgs
 
-	Dirfd    int32
-	Pathname string
-	How      uintptr
-	Size     uint64
+  Dirfd int32
+  Pathname string
+  How uintptr
+  Size uint64
 }
 
 type PidfdGetfdArgs struct {
-	internalArgs
+  internalArgs
 
-	Pidfd    int32
-	Targetfd int32
-	Flags    uint32
+  Pidfd int32
+  Targetfd int32
+  Flags uint32
 }
 
 type Faccessat2Args struct {
-	internalArgs
+  internalArgs
 
-	Fd   int32
-	Path string
-	Mode int32
-	Flag int32
+  Fd int32
+  Path string
+  Mode int32
+  Flag int32
 }
 
 type ProcessMadviseArgs struct {
-	internalArgs
+  internalArgs
 
-	Pidfd  int32
-	Addr   uintptr
-	Length uint64
-	Advice int32
-	Flags  uint64
+  Pidfd int32
+  Addr uintptr
+  Length uint64
+  Advice int32
+  Flags uint64
 }
 
 type EpollPwait2Args struct {
-	internalArgs
+  internalArgs
 
-	Fd        int32
-	Events    uintptr
-	Maxevents int32
-	Timeout   float64
-	Sigset    uintptr
+  Fd int32
+  Events uintptr
+  Maxevents int32
+  Timeout float64
+  Sigset uintptr
 }
 
 type MountSetattArgs struct {
-	internalArgs
+  internalArgs
 
-	Dfd   int32
-	Path  string
-	Flags uint32
-	Uattr uintptr
-	Usize uint64
+  Dfd int32
+  Path string
+  Flags uint32
+  Uattr uintptr
+  Usize uint64
 }
 
 type QuotactlFdArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd   uint32
-	Cmd  uint32
-	Id   uintptr
-	Addr uintptr
+  Fd uint32
+  Cmd uint32
+  Id uintptr
+  Addr uintptr
 }
 
 type LandlockCreateRulesetArgs struct {
-	internalArgs
+  internalArgs
 
-	Attr  uintptr
-	Size  uint64
-	Flags uint32
+  Attr uintptr
+  Size uint64
+  Flags uint32
 }
 
 type LandlockAddRuleArgs struct {
-	internalArgs
+  internalArgs
 
-	RulesetFd int32
-	RuleType  uintptr
-	RuleAttr  uintptr
-	Flags     uint32
+  RulesetFd int32
+  RuleType uintptr
+  RuleAttr uintptr
+  Flags uint32
 }
 
 type LandloclRestrictSetArgs struct {
-	internalArgs
+  internalArgs
 
-	RulesetFd int32
-	Flags     uint32
+  RulesetFd int32
+  Flags uint32
 }
 
 type MemfdSecretArgs struct {
-	internalArgs
+  internalArgs
 
-	Flags uint32
+  Flags uint32
 }
 
 type ProcessMreleaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Pidfd int32
-	Flags uint32
+  Pidfd int32
+  Flags uint32
 }
 
 type WaitpidArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid     int32
-	Status  uintptr
-	Options int32
+  Pid int32
+  Status uintptr
+  Options int32
 }
 
 type OldfstatArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type BreakArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type OldstatArgs struct {
-	internalArgs
+  internalArgs
 
-	Filename string
-	Statbuf  uintptr
+  Filename string
+  Statbuf uintptr
 }
 
 type UmountArgs struct {
-	internalArgs
+  internalArgs
 
-	Target string
+  Target string
 }
 
 type StimeArgs struct {
-	internalArgs
+  internalArgs
 
-	T uintptr
+  T uintptr
 }
 
 type SttyArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type GttyArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type NiceArgs struct {
-	internalArgs
+  internalArgs
 
-	Inc int32
+  Inc int32
 }
 
 type FtimeArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type ProfArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SignalArgs struct {
-	internalArgs
+  internalArgs
 
-	Signum  int32
-	Handler uintptr
+  Signum int32
+  Handler uintptr
 }
 
 type LockArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type MpxArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type UlimitArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type OldoldunameArgs struct {
-	internalArgs
+  internalArgs
 
-	Name uintptr
+  Name uintptr
 }
 
 type SigactionArgs struct {
-	internalArgs
+  internalArgs
 
-	Sig  int32
-	Act  uintptr
-	Oact uintptr
+  Sig int32
+  Act uintptr
+  Oact uintptr
 }
 
 type SgetmaskArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SsetmaskArgs struct {
-	internalArgs
+  internalArgs
 
-	Newmask int64
+  Newmask int64
 }
 
 type SigsuspendArgs struct {
-	internalArgs
+  internalArgs
 
-	Mask uintptr
+  Mask uintptr
 }
 
 type SigpendingArgs struct {
-	internalArgs
+  internalArgs
 
-	Set uintptr
+  Set uintptr
 }
 
 type OldlstatArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Statbuf  uintptr
+  Pathname string
+  Statbuf uintptr
 }
 
 type ReaddirArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd    uint32
-	Dirp  uintptr
-	Count uint32
+  Fd uint32
+  Dirp uintptr
+  Count uint32
 }
 
 type ProfilArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SocketcallArgs struct {
-	internalArgs
+  internalArgs
 
-	Call int32
-	Args uintptr
+  Call int32
+  Args uintptr
 }
 
 type OldunameArgs struct {
-	internalArgs
+  internalArgs
 
-	Buf uintptr
+  Buf uintptr
 }
 
 type IdleArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type Vm86oldArgs struct {
-	internalArgs
+  internalArgs
 
-	Info uintptr
+  Info uintptr
 }
 
 type IpcArgs struct {
-	internalArgs
+  internalArgs
 
-	Call   uint32
-	First  int32
-	Second uint64
-	Third  uint64
-	Ptr    uintptr
-	Fifth  int64
+  Call uint32
+  First int32
+  Second uint64
+  Third uint64
+  Ptr uintptr
+  Fifth int64
 }
 
 type SigreturnArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SigprocmaskArgs struct {
-	internalArgs
+  internalArgs
 
-	How    int32
-	Set    uintptr
-	Oldset uintptr
+  How int32
+  Set uintptr
+  Oldset uintptr
 }
 
 type BdflushArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type Afs_syscallArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type LlseekArgs struct {
-	internalArgs
+  internalArgs
 
-	Fd         uint32
-	OffsetHigh uint64
-	OffsetLow  uint64
-	Result     uintptr
-	Whence     uint32
+  Fd uint32
+  OffsetHigh uint64
+  OffsetLow uint64
+  Result uintptr
+  Whence uint32
 }
 
 type OldSelectArgs struct {
-	internalArgs
+  internalArgs
 
-	Nfds      int32
-	Readfds   uintptr
-	Writefds  uintptr
-	Exceptfds uintptr
-	Timeout   uintptr
+  Nfds int32
+  Readfds uintptr
+  Writefds uintptr
+  Exceptfds uintptr
+  Timeout uintptr
 }
 
 type Vm86Args struct {
-	internalArgs
+  internalArgs
 
-	Fn  uint64
-	V86 uintptr
+  Fn uint64
+  V86 uintptr
 }
 
 type OldGetrlimitArgs struct {
-	internalArgs
+  internalArgs
 
-	Resource int32
-	Rlim     uintptr
+  Resource int32
+  Rlim uintptr
 }
 
 type Mmap2Args struct {
-	internalArgs
+  internalArgs
 
-	Addr     uint64
-	Length   uint64
-	Prot     uint64
-	Flags    uint64
-	Fd       uint64
-	Pgoffset uint64
+  Addr uint64
+  Length uint64
+  Prot uint64
+  Flags uint64
+  Fd uint64
+  Pgoffset uint64
 }
 
 type Truncate64Args struct {
-	internalArgs
+  internalArgs
 
-	Path   string
-	Length uint64
+  Path string
+  Length uint64
 }
 
 type Ftruncate64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Length uint64
+  Fd int32
+  Length uint64
 }
 
 type Stat64Args struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Statbuf  uintptr
+  Pathname string
+  Statbuf uintptr
 }
 
 type Lstat64Args struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Statbuf  uintptr
+  Pathname string
+  Statbuf uintptr
 }
 
 type Fstat64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd      int32
-	Statbuf uintptr
+  Fd int32
+  Statbuf uintptr
 }
 
 type Lchown16Args struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Owner    uintptr
-	Group    uintptr
+  Pathname string
+  Owner uintptr
+  Group uintptr
 }
 
 type Getuid16Args struct {
-	internalArgs
+  internalArgs
 }
 
 type Getgid16Args struct {
-	internalArgs
+  internalArgs
 }
 
 type Geteuid16Args struct {
-	internalArgs
+  internalArgs
 }
 
 type Getegid16Args struct {
-	internalArgs
+  internalArgs
 }
 
 type Setreuid16Args struct {
-	internalArgs
+  internalArgs
 
-	Ruid uintptr
-	Euid uintptr
+  Ruid uintptr
+  Euid uintptr
 }
 
 type Setregid16Args struct {
-	internalArgs
+  internalArgs
 
-	Rgid uintptr
-	Egid uintptr
+  Rgid uintptr
+  Egid uintptr
 }
 
 type Getgroups16Args struct {
-	internalArgs
+  internalArgs
 
-	Size int32
-	List uintptr
+  Size int32
+  List uintptr
 }
 
 type Setgroups16Args struct {
-	internalArgs
+  internalArgs
 
-	Size uint64
-	List uintptr
+  Size uint64
+  List uintptr
 }
 
 type Fchown16Args struct {
-	internalArgs
+  internalArgs
 
-	Fd    uint32
-	User  uintptr
-	Group uintptr
+  Fd uint32
+  User uintptr
+  Group uintptr
 }
 
 type Setresuid16Args struct {
-	internalArgs
+  internalArgs
 
-	Ruid uintptr
-	Euid uintptr
-	Suid uintptr
+  Ruid uintptr
+  Euid uintptr
+  Suid uintptr
 }
 
 type Getresuid16Args struct {
-	internalArgs
+  internalArgs
 
-	Ruid uintptr
-	Euid uintptr
-	Suid uintptr
+  Ruid uintptr
+  Euid uintptr
+  Suid uintptr
 }
 
 type Setresgid16Args struct {
-	internalArgs
+  internalArgs
 
-	Rgid uintptr
-	Euid uintptr
-	Suid uintptr
+  Rgid uintptr
+  Euid uintptr
+  Suid uintptr
 }
 
 type Getresgid16Args struct {
-	internalArgs
+  internalArgs
 
-	Rgid uintptr
-	Egid uintptr
-	Sgid uintptr
+  Rgid uintptr
+  Egid uintptr
+  Sgid uintptr
 }
 
 type Chown16Args struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Owner    uintptr
-	Group    uintptr
+  Pathname string
+  Owner uintptr
+  Group uintptr
 }
 
 type Setuid16Args struct {
-	internalArgs
+  internalArgs
 
-	Uid uintptr
+  Uid uintptr
 }
 
 type Setgid16Args struct {
-	internalArgs
+  internalArgs
 
-	Gid uintptr
+  Gid uintptr
 }
 
 type Setfsuid16Args struct {
-	internalArgs
+  internalArgs
 
-	Fsuid uintptr
+  Fsuid uintptr
 }
 
 type Setfsgid16Args struct {
-	internalArgs
+  internalArgs
 
-	Fsgid uintptr
+  Fsgid uintptr
 }
 
 type Fcntl64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd  int32
-	Cmd int32
-	Arg uint64
+  Fd int32
+  Cmd int32
+  Arg uint64
 }
 
 type Sendfile32Args struct {
-	internalArgs
+  internalArgs
 
-	OutFd  int32
-	InFd   int32
-	Offset uintptr
-	Count  uint64
+  OutFd int32
+  InFd int32
+  Offset uintptr
+  Count uint64
 }
 
 type Statfs64Args struct {
-	internalArgs
+  internalArgs
 
-	Path string
-	Sz   uint64
-	Buf  uintptr
+  Path string
+  Sz uint64
+  Buf uintptr
 }
 
 type Fstatfs64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd  int32
-	Sz  uint64
-	Buf uintptr
+  Fd int32
+  Sz uint64
+  Buf uintptr
 }
 
 type Fadvise64_64Args struct {
-	internalArgs
+  internalArgs
 
-	Fd     int32
-	Offset uint64
-	Len    uint64
-	Advice int32
+  Fd int32
+  Offset uint64
+  Len uint64
+  Advice int32
 }
 
 type ClockGettime32Args struct {
-	internalArgs
+  internalArgs
 
-	WhichClock int32
-	Tp         uintptr
+  WhichClock int32
+  Tp uintptr
 }
 
 type ClockSettime32Args struct {
-	internalArgs
+  internalArgs
 
-	WhichClock int32
-	Tp         uintptr
+  WhichClock int32
+  Tp uintptr
 }
 
 type ClockAdjtime64Args struct {
-	internalArgs
+  internalArgs
 }
 
 type ClockGetresTime32Args struct {
-	internalArgs
+  internalArgs
 
-	WhichClock int32
-	Tp         uintptr
+  WhichClock int32
+  Tp uintptr
 }
 
 type ClockNanosleepTime32Args struct {
-	internalArgs
+  internalArgs
 
-	WhichClock int32
-	Flags      int32
-	Rqtp       uintptr
-	Rmtp       uintptr
+  WhichClock int32
+  Flags int32
+  Rqtp uintptr
+  Rmtp uintptr
 }
 
 type TimerGettime32Args struct {
-	internalArgs
+  internalArgs
 
-	TimerId int32
-	Setting uintptr
+  TimerId int32
+  Setting uintptr
 }
 
 type TimerSettime32Args struct {
-	internalArgs
+  internalArgs
 
-	TimerId int32
-	Flags   int32
-	New     uintptr
-	Old     uintptr
+  TimerId int32
+  Flags int32
+  New uintptr
+  Old uintptr
 }
 
 type TimerfdGettime32Args struct {
-	internalArgs
+  internalArgs
 
-	Ufd  int32
-	Otmr uintptr
+  Ufd int32
+  Otmr uintptr
 }
 
 type TimerfdSettime32Args struct {
-	internalArgs
+  internalArgs
 
-	Ufd   int32
-	Flags int32
-	Utmr  uintptr
-	Otmr  uintptr
+  Ufd int32
+  Flags int32
+  Utmr uintptr
+  Otmr uintptr
 }
 
 type UtimensatTime32Args struct {
-	internalArgs
+  internalArgs
 
-	Dfd      uint32
-	Filename string
-	T        uintptr
-	Flags    int32
+  Dfd uint32
+  Filename string
+  T uintptr
+  Flags int32
 }
 
 type Pselect6Time32Args struct {
-	internalArgs
+  internalArgs
 
-	N    int32
-	Inp  uintptr
-	Outp uintptr
-	Exp  uintptr
-	Tsp  uintptr
-	Sig  uintptr
+  N int32
+  Inp uintptr
+  Outp uintptr
+  Exp uintptr
+  Tsp uintptr
+  Sig uintptr
 }
 
 type PpollTime32Args struct {
-	internalArgs
+  internalArgs
 
-	Ufds       uintptr
-	Nfds       uint32
-	Tsp        uintptr
-	Sigmask    uintptr
-	Sigsetsize uint64
+  Ufds uintptr
+  Nfds uint32
+  Tsp uintptr
+  Sigmask uintptr
+  Sigsetsize uint64
 }
 
 type IoPgeteventsTime32Args struct {
-	internalArgs
+  internalArgs
 }
 
 type RecvmmsgTime32Args struct {
-	internalArgs
+  internalArgs
 
-	Fd      int32
-	Mmsg    uintptr
-	Vlen    uint32
-	Flags   uint32
-	Timeout uintptr
+  Fd int32
+  Mmsg uintptr
+  Vlen uint32
+  Flags uint32
+  Timeout uintptr
 }
 
 type MqTimedsendTime32Args struct {
-	internalArgs
+  internalArgs
 
-	Mqdes       int32
-	UMsgPtr     string
-	MsgLen      uint32
-	MsgPrio     uint32
-	UAbsTimeout uintptr
+  Mqdes int32
+  UMsgPtr string
+  MsgLen uint32
+  MsgPrio uint32
+  UAbsTimeout uintptr
 }
 
 type MqTimedreceiveTime32Args struct {
-	internalArgs
+  internalArgs
 
-	Mqdes       int32
-	UMsgPtr     string
-	MsgLen      uint32
-	UMsgPrio    uintptr
-	UAbsTimeout uintptr
+  Mqdes int32
+  UMsgPtr string
+  MsgLen uint32
+  UMsgPrio uintptr
+  UAbsTimeout uintptr
 }
 
 type RtSigtimedwaitTime32Args struct {
-	internalArgs
+  internalArgs
 
-	Uthese     uintptr
-	Uinfo      uintptr
-	Uts        uintptr
-	Sigsetsize uint64
+  Uthese uintptr
+  Uinfo uintptr
+  Uts uintptr
+  Sigsetsize uint64
 }
 
 type FutexTime32Args struct {
-	internalArgs
+  internalArgs
 
-	Uaddr  uintptr
-	Op     int32
-	Val    uint32
-	Utime  uintptr
-	Uaddr2 uintptr
-	Val3   uint32
+  Uaddr uintptr
+  Op int32
+  Val uint32
+  Utime uintptr
+  Uaddr2 uintptr
+  Val3 uint32
 }
 
 type SchedRrGetInterval32Args struct {
-	internalArgs
+  internalArgs
 
-	Pid      int32
-	Interval uintptr
+  Pid int32
+  Interval uintptr
 }
 
 type SysEnterArgs struct {
-	internalArgs
+  internalArgs
 
-	Syscall int32
+  Syscall int32
 }
 
 type SysExitArgs struct {
-	internalArgs
+  internalArgs
 
-	Syscall int32
+  Syscall int32
 }
 
 type SchedProcessForkArgs struct {
-	internalArgs
+  internalArgs
 
-	ParentTid   int32
-	ParentNsTid int32
-	ParentPid   int32
-	ParentNsPid int32
-	ChildTid    int32
-	ChildNsTid  int32
-	ChildPid    int32
-	ChildNsPid  int32
-	StartTime   uint64
+  ParentTid int32
+  ParentNsTid int32
+  ParentPid int32
+  ParentNsPid int32
+  ChildTid int32
+  ChildNsTid int32
+  ChildPid int32
+  ChildNsPid int32
+  StartTime uint64
 }
 
 type SchedProcessExecArgs struct {
-	internalArgs
+  internalArgs
 
-	Cmdpath             string
-	Pathname            string
-	Dev                 uint32
-	Inode               uint64
-	Ctime               uint64
-	InodeMode           uint16
-	InterpreterPathname string
-	InterpreterDev      uint32
-	InterpreterInode    uint64
-	InterpreterCtime    uint64
-	Argv                []string
-	Interp              string
-	StdinType           uint16
-	StdinPath           string
-	InvokedFromKernel   int32
-	Env                 []string
+  Cmdpath string
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Ctime uint64
+  InodeMode uint16
+  InterpreterPathname string
+  InterpreterDev uint32
+  InterpreterInode uint64
+  InterpreterCtime uint64
+  Argv []string
+  Interp string
+  StdinType uint16
+  StdinPath string
+  InvokedFromKernel int32
+  Env []string
 }
 
 type SchedProcessExitArgs struct {
-	internalArgs
+  internalArgs
 
-	ExitCode         int64
-	ProcessGroupExit bool
+  ExitCode int64
+  ProcessGroupExit bool
 }
 
 type SchedSwitchArgs struct {
-	internalArgs
+  internalArgs
 
-	Cpu      int32
-	PrevTid  int32
-	PrevComm string
-	NextTid  int32
-	NextComm string
+  Cpu int32
+  PrevTid int32
+  PrevComm string
+  NextTid int32
+  NextComm string
 }
 
 type ProcessOomKilledArgs struct {
-	internalArgs
+  internalArgs
 
-	ExitCode         int64
-	ProcessGroupExit bool
+  ExitCode int64
+  ProcessGroupExit bool
 }
 
 type DoExitArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type CapCapableArgs struct {
-	internalArgs
+  internalArgs
 
-	Cap int32
+  Cap int32
 }
 
 type VfsWriteArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Count    uint64
-	Pos      uint64
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Count uint64
+  Pos uint64
 }
 
 type VfsWritevArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Vlen     uint64
-	Pos      uint64
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Vlen uint64
+  Pos uint64
 }
 
 type MemProtAlertArgs struct {
-	internalArgs
+  internalArgs
 
-	Alert    uint32
-	Addr     uintptr
-	Len      uint64
-	Prot     int32
-	PrevProt int32
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Ctime    uint64
+  Alert uint32
+  Addr uintptr
+  Len uint64
+  Prot int32
+  PrevProt int32
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Ctime uint64
 }
 
 type CommitCredsArgs struct {
-	internalArgs
+  internalArgs
 
-	OldCred SlimCred
-	NewCred SlimCred
+  OldCred SlimCred
+  NewCred SlimCred
 }
 
 type SwitchTaskNSArgs struct {
-	internalArgs
+  internalArgs
 
-	Pid       int32
-	NewMnt    uint32
-	NewPid    uint32
-	NewUts    uint32
-	NewIpc    uint32
-	NewNet    uint32
-	NewCgroup uint32
+  Pid int32
+  NewMnt uint32
+  NewPid uint32
+  NewUts uint32
+  NewIpc uint32
+  NewNet uint32
+  NewCgroup uint32
 }
 
 type MagicWriteArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Bytes    []byte
-	Dev      uint32
-	Inode    uint64
+  Pathname string
+  Bytes []byte
+  Dev uint32
+  Inode uint64
 }
 
 type CgroupAttachTaskArgs struct {
-	internalArgs
+  internalArgs
 
-	CgroupPath string
-	Comm       string
-	Pid        int32
+  CgroupPath string
+  Comm string
+  Pid int32
 }
 
 type CgroupMkdirArgs struct {
-	internalArgs
+  internalArgs
 
-	CgroupId    uint64
-	CgroupPath  string
-	HierarchyId uint32
+  CgroupId uint64
+  CgroupPath string
+  HierarchyId uint32
 }
 
 type CgroupRmdirArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
+  CgroupId uint64
+  CgroupPath string
+  HierarchyId uint32
 }
 
 type SecurityFileOpenArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname        string
-	Flags           int32
-	Dev             uint32
-	Inode           uint64
-	Ctime           uint64
-	SyscallPathname string
+  Pathname string
+  Flags int32
+  Dev uint32
+  Inode uint64
+  Ctime uint64
+  SyscallPathname string
 }
 
 type SecurityInodeUnlinkArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Inode    uint64
-	Dev      uint32
-	Ctime    uint64
+  Pathname string
+  Inode uint64
+  Dev uint32
+  Ctime uint64
 }
 
 type SecuritySocketCreateArgs struct {
-	internalArgs
+  internalArgs
 
-	Family   int32
-	Type     int32
-	Protocol int32
-	Kern     int32
+  Family int32
+  Type int32
+  Protocol int32
+  Kern int32
 }
 
 type SecuritySocketListenArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd    int32
-	LocalAddr Sockaddr
-	Backlog   int32
+  Sockfd int32
+  LocalAddr Sockaddr
+  Backlog int32
 }
 
 type SecuritySocketConnectArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd     int32
-	Type       int32
-	RemoteAddr Sockaddr
+  Sockfd int32
+  Type int32
+  RemoteAddr Sockaddr
 }
 
 type SecuritySocketAcceptArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd    int32
-	LocalAddr Sockaddr
+  Sockfd int32
+  LocalAddr Sockaddr
 }
 
 type SecuritySocketBindArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd    int32
-	LocalAddr Sockaddr
+  Sockfd int32
+  LocalAddr Sockaddr
 }
 
 type SecuritySocketSetsockoptArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd    int32
-	Level     int32
-	Optname   int32
-	LocalAddr Sockaddr
+  Sockfd int32
+  Level int32
+  Optname int32
+  LocalAddr Sockaddr
 }
 
 type SecuritySbMountArgs struct {
-	internalArgs
+  internalArgs
 
-	DevName string
-	Path    string
-	Type    string
-	Flags   uint64
+  DevName string
+  Path string
+  Type string
+  Flags uint64
 }
 
 type SecurityBPFArgs struct {
-	internalArgs
+  internalArgs
 
-	Cmd int32
+  Cmd int32
 }
 
 type SecurityBPFMapArgs struct {
-	internalArgs
+  internalArgs
 
-	MapId   uint32
-	MapName string
+  MapId uint32
+  MapName string
 }
 
 type SecurityKernelReadFileArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Type     int32
-	Ctime    uint64
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Type int32
+  Ctime uint64
 }
 
 type SecurityPostReadFileArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Size     int64
-	Type     int32
+  Pathname string
+  Size int64
+  Type int32
 }
 
 type SecurityInodeMknodArgs struct {
-	internalArgs
+  internalArgs
 
-	FileName string
-	Mode     uint16
-	Dev      uint32
+  FileName string
+  Mode uint16
+  Dev uint32
 }
 
 type SecurityInodeSymlinkEventIdArgs struct {
-	internalArgs
+  internalArgs
 
-	Linkpath string
-	Target   string
+  Linkpath string
+  Target string
 }
 
 type SecurityMmapFileArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname  string
-	Flags     int32
-	Dev       uint32
-	Inode     uint64
-	Ctime     uint64
-	Prot      uint64
-	MmapFlags uint64
+  Pathname string
+  Flags int32
+  Dev uint32
+  Inode uint64
+  Ctime uint64
+  Prot uint64
+  MmapFlags uint64
 }
 
 type DoMmapArgs struct {
-	internalArgs
+  internalArgs
 
-	Addr      uintptr
-	Pathname  string
-	Flags     uint32
-	Dev       uint32
-	Inode     uint64
-	Ctime     uint64
-	Pgoff     uint64
-	Len       uint64
-	Prot      uint64
-	MmapFlags uint64
+  Addr uintptr
+  Pathname string
+  Flags uint32
+  Dev uint32
+  Inode uint64
+  Ctime uint64
+  Pgoff uint64
+  Len uint64
+  Prot uint64
+  MmapFlags uint64
 }
 
 type SecurityFileMprotectArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Prot     int32
-	Ctime    uint64
-	PrevProt int32
-	Addr     uintptr
-	Len      uint64
-	Pkey     int32
+  Pathname string
+  Prot int32
+  Ctime uint64
+  PrevProt int32
+  Addr uintptr
+  Len uint64
+  Pkey int32
 }
 
 type InitNamespacesArgs struct {
-	internalArgs
+  internalArgs
 
-	Cgroup          uint32
-	Ipc             uint32
-	Mnt             uint32
-	Net             uint32
-	Pid             uint32
-	PidForChildren  uint32
-	Time            uint32
-	TimeForChildren uint32
-	User            uint32
-	Uts             uint32
+  Cgroup uint32
+  Ipc uint32
+  Mnt uint32
+  Net uint32
+  Pid uint32
+  PidForChildren uint32
+  Time uint32
+  TimeForChildren uint32
+  User uint32
+  Uts uint32
 }
 
 type SocketDupArgs struct {
-	internalArgs
+  internalArgs
 
-	Oldfd      int32
-	Newfd      int32
-	RemoteAddr Sockaddr
+  Oldfd int32
+  Newfd int32
+  RemoteAddr Sockaddr
 }
 
 type HiddenInodesArgs struct {
-	internalArgs
+  internalArgs
 
-	HiddenProcess string
+  HiddenProcess string
 }
 
 type KernelWriteArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Count    uint64
-	Pos      uint64
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Count uint64
+  Pos uint64
 }
 
 type DirtyPipeSpliceArgs struct {
-	internalArgs
+  internalArgs
 
-	InodeIn                uint64
-	InFileType             uint16
-	InFilePath             string
-	ExposedDataStartOffset uint64
-	ExposedDataLen         uint64
-	InodeOut               uint64
-	OutPipeLastBufferFlags uint32
+  InodeIn uint64
+  InFileType uint16
+  InFilePath string
+  ExposedDataStartOffset uint64
+  ExposedDataLen uint64
+  InodeOut uint64
+  OutPipeLastBufferFlags uint32
 }
 
 type ContainerCreateArgs struct {
-	internalArgs
+  internalArgs
 
-	Runtime              string
-	ContainerId          string
-	Ctime                uint64
-	ContainerImage       string
-	ContainerImageDigest string
-	ContainerName        string
-	PodName              string
-	PodNamespace         string
-	PodUid               string
-	PodSandbox           bool
+  Runtime string
+  ContainerId string
+  Ctime uint64
+  ContainerImage string
+  ContainerImageDigest string
+  ContainerName string
+  PodName string
+  PodNamespace string
+  PodUid string
+  PodSandbox bool
 }
 
 type ContainerRemoveArgs struct {
-	internalArgs
+  internalArgs
 
-	Runtime     string
-	ContainerId string
+  Runtime string
+  ContainerId string
 }
 
 type ExistingContainerArgs struct {
-	internalArgs
+  internalArgs
 
-	Runtime              string
-	ContainerId          string
-	Ctime                uint64
-	ContainerImage       string
-	ContainerImageDigest string
-	ContainerName        string
-	PodName              string
-	PodNamespace         string
-	PodUid               string
-	PodSandbox           bool
+  Runtime string
+  ContainerId string
+  Ctime uint64
+  ContainerImage string
+  ContainerImageDigest string
+  ContainerName string
+  PodName string
+  PodNamespace string
+  PodUid string
+  PodSandbox bool
 }
 
 type ProcCreateArgs struct {
-	internalArgs
+  internalArgs
 
-	Name        string
-	ProcOpsAddr uintptr
+  Name string
+  ProcOpsAddr uintptr
 }
 
 type KprobeAttachArgs struct {
-	internalArgs
+  internalArgs
 
-	SymbolName      string
-	PreHandlerAddr  uintptr
-	PostHandlerAddr uintptr
+  SymbolName string
+  PreHandlerAddr uintptr
+  PostHandlerAddr uintptr
 }
 
 type CallUsermodeHelperArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Argv     []string
-	Envp     []string
-	Wait     int32
+  Pathname string
+  Argv []string
+  Envp []string
+  Wait int32
 }
 
 type DebugfsCreateFileArgs struct {
-	internalArgs
+  internalArgs
 
-	FileName    string
-	Path        string
-	Mode        uint32
-	ProcOpsAddr uintptr
+  FileName string
+  Path string
+  Mode uint32
+  ProcOpsAddr uintptr
 }
 
 type PrintSyscallTableArgs struct {
-	internalArgs
+  internalArgs
 
-	SyscallsAddresses []uint64
-	CallerContextId   uint64
+  SyscallsAddresses []uint64
+  CallerContextId uint64
 }
 
 type HiddenKernelModuleArgs struct {
-	internalArgs
+  internalArgs
 
-	Address    string
-	Name       string
-	Srcversion string
+  Address string
+  Name string
+  Srcversion string
 }
 
 type HiddenKernelModuleSeekerArgs struct {
-	internalArgs
+  internalArgs
 
-	Address    uint64
-	Name       []byte
-	Flags      uint32
-	Srcversion []byte
+  Address uint64
+  Name []byte
+  Flags uint32
+  Srcversion []byte
 }
 
 type HookedSyscallsArgs struct {
-	internalArgs
+  internalArgs
 
-	CheckSyscalls  uintptr
-	HookedSyscalls uintptr
+  CheckSyscalls uintptr
+  HookedSyscalls uintptr
 }
 
 type DebugfsCreateDirArgs struct {
-	internalArgs
+  internalArgs
 
-	Name string
-	Path string
+  Name string
+  Path string
 }
 
 type DeviceAddArgs struct {
-	internalArgs
+  internalArgs
 
-	Name       string
-	ParentName string
+  Name string
+  ParentName string
 }
 
 type RegisterChrdevArgs struct {
-	internalArgs
+  internalArgs
 
-	RequestedMajorNumber uint32
-	GrantedMajorNumber   uint32
-	CharDeviceName       string
-	CharDeviceFops       uintptr
+  RequestedMajorNumber uint32
+  GrantedMajorNumber uint32
+  CharDeviceName string
+  CharDeviceFops uintptr
 }
 
 type SharedObjectLoadedArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Flags    int32
-	Dev      uint32
-	Inode    uint64
-	Ctime    uint64
+  Pathname string
+  Flags int32
+  Dev uint32
+  Inode uint64
+  Ctime uint64
 }
 
 type SymbolsLoadedArgs struct {
-	internalArgs
+  internalArgs
 
-	LibraryPath string
-	Symbols     []string
+  LibraryPath string
+  Symbols []string
 }
 
 type SymbolsCollisionArgs struct {
-	internalArgs
+  internalArgs
 
-	LoadedPath    string
-	CollisionPath string
-	Symbols       []string
+  LoadedPath string
+  CollisionPath string
+  Symbols []string
 }
 
 type CaptureFileWriteArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type CaptureFileReadArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type CaptureExecArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type CaptureModuleArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type CaptureMemArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type CaptureBpfArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type DoInitModuleArgs struct {
-	internalArgs
+  internalArgs
 
-	Name       string
-	Version    string
-	SrcVersion string
+  Name string
+  Version string
+  SrcVersion string
 }
 
 type ModuleLoadArgs struct {
-	internalArgs
+  internalArgs
 
-	Name       string
-	Version    string
-	SrcVersion string
+  Name string
+  Version string
+  SrcVersion string
 }
 
 type ModuleFreeArgs struct {
-	internalArgs
+  internalArgs
 
-	Name       string
-	Version    string
-	SrcVersion string
+  Name string
+  Version string
+  SrcVersion string
 }
 
 type SocketAcceptArgs struct {
-	internalArgs
+  internalArgs
 
-	Sockfd     int32
-	LocalAddr  Sockaddr
-	RemoteAddr Sockaddr
+  Sockfd int32
+  LocalAddr Sockaddr
+  RemoteAddr Sockaddr
 }
 
 type LoadElfPhdrsArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-}
-
-type HookedProcFopsArgs struct {
-	internalArgs
-
-	HookedFopsPointers uintptr
+  Pathname string
+  Dev uint32
+  Inode uint64
 }
 
 type PrintNetSeqOpsArgs struct {
-	internalArgs
+  internalArgs
 
-	NetSeqOps       []uint64
-	CallerContextId uint64
+  NetSeqOps []uint64
+  CallerContextId uint64
 }
 
 type HookedSeqOpsArgs struct {
-	internalArgs
+  internalArgs
 
-	HookedSeqOps uintptr
+  HookedSeqOps uintptr
 }
 
 type TaskRenameArgs struct {
-	internalArgs
+  internalArgs
 
-	OldName string
-	NewName string
+  OldName string
+  NewName string
 }
 
 type SecurityInodeRenameArgs struct {
-	internalArgs
+  internalArgs
 
-	OldPath string
-	NewPath string
+  OldPath string
+  NewPath string
 }
 
 type DoSigactionArgs struct {
-	internalArgs
+  internalArgs
 
-	Sig                int32
-	IsSaInitialized    bool
-	SaFlags            uint64
-	SaMask             uint64
-	SaHandleMethod     uint8
-	SaHandler          uintptr
-	IsOldSaInitialized bool
-	OldSaFlags         uint64
-	OldSaMask          uint64
-	OldSaHandleMethod  uint8
-	OldSaHandler       uintptr
+  Sig int32
+  IsSaInitialized bool
+  SaFlags uint64
+  SaMask uint64
+  SaHandleMethod uint8
+  SaHandler uintptr
+  IsOldSaInitialized bool
+  OldSaFlags uint64
+  OldSaMask uint64
+  OldSaHandleMethod uint8
+  OldSaHandler uintptr
 }
 
 type BpfAttachArgs struct {
-	internalArgs
+  internalArgs
 
-	ProgType    int32
-	ProgName    string
-	ProgId      uint32
-	ProgHelpers []uint64
-	SymbolName  string
-	SymbolAddr  uint64
-	AttachType  int32
+  ProgType int32
+  ProgName string
+  ProgId uint32
+  ProgHelpers []uint64
+  SymbolName string
+  SymbolAddr uint64
+  AttachType int32
 }
 
 type KallsymsLookupNameArgs struct {
-	internalArgs
+  internalArgs
 
-	SymbolName    string
-	SymbolAddress uintptr
+  SymbolName string
+  SymbolAddress uintptr
 }
 
 type PrintMemDumpArgs struct {
-	internalArgs
+  internalArgs
 
-	Bytes           []byte
-	Address         uintptr
-	Length          uint64
-	CallerContextId uint64
-	Arch            string
-	SymbolName      string
-	SymbolOwner     string
+  Bytes []byte
+  Address uintptr
+  Length uint64
+  CallerContextId uint64
+  Arch string
+  SymbolName string
+  SymbolOwner string
 }
 
 type VfsReadArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Count    uint64
-	Pos      uint64
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Count uint64
+  Pos uint64
 }
 
 type VfsReadvArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Vlen     uint64
-	Pos      uint64
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Vlen uint64
+  Pos uint64
 }
 
 type VfsUtimesArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Dev      uint32
-	Inode    uint64
-	Atime    uint64
-	Mtime    uint64
+  Pathname string
+  Dev uint32
+  Inode uint64
+  Atime uint64
+  Mtime uint64
 }
 
 type DoTruncateArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Inode    uint64
-	Dev      uint32
-	Length   uint64
+  Pathname string
+  Inode uint64
+  Dev uint32
+  Length uint64
 }
 
 type FileModificationArgs struct {
-	internalArgs
+  internalArgs
 
-	FilePath string
-	Dev      uint32
-	Inode    uint64
-	OldCtime uint64
-	NewCtime uint64
+  FilePath string
+  Dev uint32
+  Inode uint64
+  OldCtime uint64
+  NewCtime uint64
 }
 
 type InotifyWatchArgs struct {
-	internalArgs
+  internalArgs
 
-	Pathname string
-	Inode    uint64
-	Dev      uint32
+  Pathname string
+  Inode uint64
+  Dev uint32
 }
 
 type ProcessExecuteFailedArgs struct {
-	internalArgs
+  internalArgs
 
-	Path              string
-	BinaryPath        string
-	BinaryDeviceId    uint32
-	BinaryInodeNumber uint64
-	BinaryCtime       uint64
-	BinaryInodeMode   uint16
-	InterpreterPath   string
-	StdinType         uint16
-	StdinPath         string
-	KernelInvoked     int32
-	BinaryArguments   []string
-	Environment       []string
+  Path string
+  BinaryPath string
+  BinaryDeviceId uint32
+  BinaryInodeNumber uint64
+  BinaryCtime uint64
+  BinaryInodeMode uint16
+  InterpreterPath string
+  StdinType uint16
+  StdinPath string
+  KernelInvoked int32
+  BinaryArguments []string
+  Environment []string
 }
 
 type NetPacketBaseArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type NetPacketIPBaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type NetPacketIPv4Args struct {
-	internalArgs
+  internalArgs
 
-	Src       string
-	Dst       string
-	ProtoIpv4 uintptr
+  Src string
+  Dst string
+  ProtoIpv4 uintptr
 }
 
 type NetPacketIPv6Args struct {
-	internalArgs
+  internalArgs
 
-	Src       string
-	Dst       string
-	ProtoIpv6 uintptr
+  Src string
+  Dst string
+  ProtoIpv6 uintptr
 }
 
 type NetPacketTCPBaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type NetPacketTCPArgs struct {
-	internalArgs
+  internalArgs
 
-	Src      string
-	Dst      string
-	SrcPort  uint16
-	DstPort  uint16
-	ProtoTcp uintptr
+  Src string
+  Dst string
+  SrcPort uint16
+  DstPort uint16
+  ProtoTcp uintptr
 }
 
 type NetPacketUDPBaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type NetPacketUDPArgs struct {
-	internalArgs
+  internalArgs
 
-	Src      string
-	Dst      string
-	SrcPort  uint16
-	DstPort  uint16
-	ProtoUdp uintptr
+  Src string
+  Dst string
+  SrcPort uint16
+  DstPort uint16
+  ProtoUdp uintptr
 }
 
 type NetPacketICMPBaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type NetPacketICMPArgs struct {
-	internalArgs
+  internalArgs
 
-	Src       string
-	Dst       string
-	ProtoIcmp uintptr
+  Src string
+  Dst string
+  ProtoIcmp uintptr
 }
 
 type NetPacketICMPv6BaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type NetPacketICMPv6Args struct {
-	internalArgs
+  internalArgs
 
-	Src         string
-	Dst         string
-	ProtoIcmpv6 uintptr
+  Src string
+  Dst string
+  ProtoIcmpv6 uintptr
 }
 
 type NetPacketDNSBaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type NetPacketDNSArgs struct {
-	internalArgs
+  internalArgs
 
-	Src      string
-	Dst      string
-	SrcPort  uint16
-	DstPort  uint16
-	ProtoDns uintptr
+  Src string
+  Dst string
+  SrcPort uint16
+  DstPort uint16
+  ProtoDns uintptr
 }
 
 type NetPacketDNSRequestArgs struct {
-	internalArgs
+  internalArgs
 
-	Metadata     uintptr
-	DnsQuestions uintptr
+  Metadata uintptr
+  DnsQuestions uintptr
 }
 
 type NetPacketDNSResponseArgs struct {
-	internalArgs
+  internalArgs
 
-	Metadata    uintptr
-	DnsResponse uintptr
+  Metadata uintptr
+  DnsResponse uintptr
 }
 
 type NetPacketHTTPBaseArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type NetPacketHTTPArgs struct {
-	internalArgs
+  internalArgs
 
-	Src       string
-	Dst       string
-	SrcPort   uint16
-	DstPort   uint16
-	ProtoHttp uintptr
+  Src string
+  Dst string
+  SrcPort uint16
+  DstPort uint16
+  ProtoHttp uintptr
 }
 
 type NetPacketHTTPRequestArgs struct {
-	internalArgs
+  internalArgs
 
-	Metadata    uintptr
-	HttpRequest uintptr
+  Metadata uintptr
+  HttpRequest uintptr
 }
 
 type NetPacketHTTPResponseArgs struct {
-	internalArgs
+  internalArgs
 
-	Metadata     uintptr
-	HttpResponse uintptr
+  Metadata uintptr
+  HttpResponse uintptr
 }
 
 type NetPacketCaptureArgs struct {
-	internalArgs
+  internalArgs
 
-	Payload []byte
+  Payload []byte
 }
 
 type CaptureNetPacketArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type SockSetStateArgs struct {
-	internalArgs
+  internalArgs
 
-	OldState uint32
-	NewState uint32
-	Tuple    AddrTuple
+  OldState uint32
+  NewState uint32
+  Tuple AddrTuple
 }
 
 type TrackSyscallStatsArgs struct {
-	internalArgs
+  internalArgs
 }
 
 type TestEventArgs struct {
-	internalArgs
+  internalArgs
+}
+
+type SignalCgroupMkdirArgs struct {
+  internalArgs
+
+  CgroupId uint64
+  CgroupPath string
+  HierarchyId uint32
+}
+
+type SignalCgroupRmdirArgs struct {
+  internalArgs
+
+  CgroupId uint64
+  CgroupPath string
+  HierarchyId uint32
 }

--- a/pkg/ebpftracer/types/protocol.go
+++ b/pkg/ebpftracer/types/protocol.go
@@ -21,7 +21,7 @@ const (
 
 // PLEASE NOTE, YOU MUST UPDATE THE DECODER IF ANY CHANGE TO THIS STRUCT IS DONE.
 type SignalContext struct {
-	EventID         events.ID // uint32
+	EventID events.ID // uint32
 }
 
 func (SignalContext) GetSizeBytes() int {

--- a/pkg/ebpftracer/types/protocol.go
+++ b/pkg/ebpftracer/types/protocol.go
@@ -20,6 +20,15 @@ const (
 )
 
 // PLEASE NOTE, YOU MUST UPDATE THE DECODER IF ANY CHANGE TO THIS STRUCT IS DONE.
+type SignalContext struct {
+	EventID         events.ID // uint32
+}
+
+func (SignalContext) GetSizeBytes() int {
+	return 4
+}
+
+// PLEASE NOTE, YOU MUST UPDATE THE DECODER IF ANY CHANGE TO THIS STRUCT IS DONE.
 
 // EventContext struct contains common metadata that is collected for all types of events
 // it is used to unmarshal binary data and therefore should match (bit by bit) to the `context_t` struct in the ebpf code.
@@ -44,7 +53,7 @@ type EventContext struct {
 	UtsName         [16]byte
 	Flags           uint32
 	_               [4]byte   // padding
-	EventID         events.ID // int32
+	EventID         events.ID // uint32
 	Syscall         int32
 	MatchedPolicies uint64
 	Retval          int64

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -78,4 +78,9 @@ var (
 		Name: "kvisor_agent_dns_packets_total",
 		Help: "Counter for tracking the total number of DNS events we received to process",
 	})
+
+	AgentFindCgroupFS = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "kvisor_find_cgroup_from_filesystem",
+		Help: "Counter for keeping track how often we fall back to finding cgroups via the filesystem",
+	})
 )

--- a/tools/codegen/generator.go
+++ b/tools/codegen/generator.go
@@ -95,8 +95,8 @@ package %s
 import (
   "errors"
 
-  "github.com/castai/kvisord/pkg/ebpftracer/events"
-  "github.com/castai/kvisord/pkg/ebpftracer/types"
+  "github.com/castai/kvisor/pkg/ebpftracer/events"
+  "github.com/castai/kvisor/pkg/ebpftracer/types"
 )
 
 var (

--- a/tools/codegen/generator_test.go
+++ b/tools/codegen/generator_test.go
@@ -170,8 +170,8 @@ package parser
 import (
   "errors"
 
-  "github.com/castai/kvisord/pkg/ebpftracer/events"
-  "github.com/castai/kvisord/pkg/ebpftracer/types"
+  "github.com/castai/kvisor/pkg/ebpftracer/events"
+  "github.com/castai/kvisor/pkg/ebpftracer/types"
 )
 
 var (
@@ -317,8 +317,8 @@ package parser
 import (
   "errors"
 
-  "github.com/castai/kvisord/pkg/ebpftracer/events"
-  "github.com/castai/kvisord/pkg/ebpftracer/types"
+  "github.com/castai/kvisor/pkg/ebpftracer/events"
+  "github.com/castai/kvisor/pkg/ebpftracer/types"
 )
 
 var (


### PR DESCRIPTION
There is now a second perf buffer for so called "control plane" events.
This means that the chances of them being dropped should be
significantly lower. The reason for this change is, that events such as
`cgroup rmdir` will trigger the cleanup of cgroup related caches.

Additionally we now leverage the path found in the `cgroup mkdir` event
to prepopulate a cache in the cgroup client, which means that the costly
filesystem scan to figure out the path of a cgroup should be triggered
far less often.

With the handling of `cgroup rmdir` event out of sync with the rest of
the events from ebpf, the cgroup related cleanup logic has also been
changed. Instead of performing the cleanup straight away, it is delayed
by a minute. This should give the rest of the system enough time to
handle any events still targeted at the removed cgroup.
