### PR TITLE
Various small fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ CMD_DOCKER_BUILDER_LOCAL=docker run --rm -it --privileged --cap-add SYS_ADMIN --
 	-v $$(pwd)/.cache/go-build:/home/.cache/go-build \
 	-v $$(pwd)/.cache/go-mod:/home/go/pkg/mod \
 	-v $$(pwd):/app \
+	-v /sys/kernel/debug:/sys/kernel/debug \
 	-w /app ghcr.io/castai/kvisor/kvisor-builder:latest
 
 .PHONY: gen-args-types

--- a/pkg/ebpftracer/tracer_syscall_stats.go
+++ b/pkg/ebpftracer/tracer_syscall_stats.go
@@ -94,8 +94,10 @@ func (t *Tracer) cleanupSyscallStatsKernel(obsoleteStatsKeys []rawSyscallStatsKe
 	// The ebpf batch helpers are available since kernel version 5.6.
 	if kernelVersion.Major > 5 || (kernelVersion.Major == 5 && kernelVersion.Minor >= 6) {
 		_, err = t.module.objects.SyscallStatsMap.BatchDelete(obsoleteStatsKeys, &ebpf.BatchOptions{})
-		if !errors.Is(err, ebpf.ErrKeyNotExist) {
-			return fmt.Errorf("got error while trying to delete syscall stats: %w", err)
+		if err != nil {
+			if !errors.Is(err, ebpf.ErrKeyNotExist) {
+				return fmt.Errorf("got error while trying to delete syscall stats: %w", err)
+			}
 		}
 	} else {
 		for _, key := range obsoleteStatsKeys {


### PR DESCRIPTION
This PR contains a few small fixes:

* Mounting debugfs when using `make builder-image-enter`
* Fixing a error log on `nil` error