### PR TITLE
Use right timestamp for signature events

### DIFF
--- a/pkg/ebpftracer/signature/signature.go
+++ b/pkg/ebpftracer/signature/signature.go
@@ -123,7 +123,7 @@ func (e *SignatureEngine) handleEvent(event *types.Event) {
 
 		e.eventsChan <- &castpb.Event{
 			EventType:     castpb.EventType_EVENT_SIGNATURE,
-			Timestamp:     uint64(time.Now().UTC().Nanosecond()),
+			Timestamp:     uint64(time.Now().UTC().UnixNano()),
 			ProcessName:   string(bytes.TrimRight(event.Context.Comm[:], "\x00")),
 			Namespace:     event.Container.PodNamespace,
 			PodName:       event.Container.PodName,


### PR DESCRIPTION
This fixes a bug where the wrong method for retrieving nanoseconds was used, causing signature events to be discarded.