### PR TITLE
feat: use `scheduling.cast.ai/spot` toleration for image scan jobs

### DIFF
--- a/cmd/controller/state/imagescan/scanner.go
+++ b/cmd/controller/state/imagescan/scanner.go
@@ -240,8 +240,8 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 
 	tolerations := []corev1.Toleration{
 		{
-			Effect:   corev1.TaintEffectNoSchedule,
 			Operator: corev1.TolerationOpExists,
+			Key:    "scheduling.cast.ai/spot",
 		},
 	}
 

--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -119,8 +119,8 @@ func TestScanner(t *testing.T) {
 						},
 						Tolerations: []corev1.Toleration{
 							{
-								Effect:   corev1.TaintEffectNoSchedule,
 								Operator: corev1.TolerationOpExists,
+								Key:   "scheduling.cast.ai/spot",
 							},
 						},
 						AutomountServiceAccountToken: lo.ToPtr(false),


### PR DESCRIPTION
The `NoSchedule` toleration is causing some unwanted side effects with node rebalancing. Since the toleration is anyway no longer required for the imagescan job to work, it has been replaced by `scheduling.cast.ai/spot`, which at least makes the job schedulable on spot instances.