### PR TITLE
Allow cast api key to be specified via API_KEY and CAST_API_KEY env 

### DIFF
--- a/charts/kvisor/templates/secret.yaml
+++ b/charts/kvisor/templates/secret.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     {{- include "kvisor.labels" . | nindent 4}}
 data:
-  CASTAI_API_KEY: {{ required "castai.apiKey must be provided" .Values.castai.apiKey | b64enc | quote }}
+  API_KEY: {{ required "castai.apiKey must be provided" .Values.castai.apiKey | b64enc | quote }}
 {{- end }}

--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -8,7 +8,7 @@ castai:
 
   # Name of secret with Token to be used for authorizing agent access to the API
   # apiKey and apiKeySecretRef are mutually exclusive
-  # The referenced secret must provide the token in .data["CASTAI_API_KEY"]
+  # The referenced secret must provide the token in .data["API_KEY"]
   apiKeySecretRef: ""
 
   # CASTAI grpc public api address.

--- a/cmd/agent/daemon/daemon.go
+++ b/cmd/agent/daemon/daemon.go
@@ -52,6 +52,20 @@ var (
 	kubeconfigPath = pflag.String("kubeconfig", "", "Kubeconfig file")
 )
 
+func lookupConfigVariable(name string) (string, error) {
+	key, found := os.LookupEnv("CASTAI_" + name)
+	if found {
+		return key, nil
+	}
+
+	key, found = os.LookupEnv(name)
+	if found {
+		return key, nil
+	}
+
+	return "", fmt.Errorf("environment variable missing: please provide either `CAST_%s` or `%s`", name, name)
+}
+
 func NewCommand(version string) *cobra.Command {
 	command := &cobra.Command{
 		Use: "daemon",
@@ -75,10 +89,27 @@ func NewCommand(version string) *cobra.Command {
 				os.Exit(1)
 			}
 
+			castaiGRPCAddress, found := os.LookupEnv("CASTAI_API_GRPC_ADDR")
+			if !found {
+				slog.Error("missing required environment variable: CASTAI_API_GRPC_ADDR")
+				os.Exit(1)
+			}
+			castaiClusterID, found := os.LookupEnv("CASTAI_CLUSTER_ID")
+			if !found {
+				slog.Error("missing required environment variable: CASTAI_CLUSTER_ID")
+				os.Exit(1)
+			}
+
+			apiKey, err := lookupConfigVariable("API_KEY")
+			if err != nil {
+				slog.Error(err.Error())
+				os.Exit(1)
+			}
+
 			castaiClientCfg := castai.Config{
-				APIKey:      os.Getenv("CASTAI_API_KEY"),
-				APIGrpcAddr: os.Getenv("CASTAI_API_GRPC_ADDR"),
-				ClusterID:   os.Getenv("CASTAI_CLUSTER_ID"),
+				APIKey:      apiKey,
+				APIGrpcAddr: castaiGRPCAddress,
+				ClusterID:   castaiClusterID,
 				Insecure:    *castaiServerInsecure,
 			}
 


### PR DESCRIPTION
To get kvisor in line with the rest of the cast setup, it is now also supported to pass in the API key via the API_KEY env variable.