### PR TITLE
Fallback to host architecture if image architecture is not set

### DIFF
--- a/cmd/imagescan/collector/collector.go
+++ b/cmd/imagescan/collector/collector.go
@@ -95,11 +95,18 @@ func (c *Collector) Collect(ctx context.Context) error {
 		return fmt.Errorf("extract manifest digest: %w", err)
 	}
 
+	arch := arRef.ConfigFile.Architecture
+	// There are rare cases where the Architecture of an image is not set (even though this doesn't appear to be
+	// neither OCI nor docker image spec conform). This is not a 100% solution, but should be good enough.
+	if strings.TrimSpace(arch) == "" {
+		arch = c.hostFsConfig.Platform.Architecture
+	}
+
 	metadata := &castaipb.ImageMetadata{
 		ImageName:    c.cfg.ImageName,
 		ImageId:      c.cfg.ImageID,
 		ImageDigest:  digest.String(),
-		Architecture: arRef.ConfigFile.Architecture,
+		Architecture: arch,
 		ResourceIds:  strings.Split(c.cfg.ResourceIDs, ","),
 	}
 	if arRef.OsInfo != nil {


### PR DESCRIPTION
There can be cases, where the architecture of an image is not set, even though both the Docker Image spec and OCI Image spec require this field. A nice workaround is to fallback to the platform of the underlying host, the container running was observed. This will probably not be 100% correct in all cases, but this would make it an edge case of an edge case, meaning it is good enough.