### PR TITLE
Make `exec_binprm` probe optinoal for now

### DIFF
--- a/pkg/ebpftracer/events.go
+++ b/pkg/ebpftracer/events.go
@@ -5273,7 +5273,7 @@ func newEventsDefinitionSet(objs *tracerObjects) map[events.ID]definition {
 			name:    "sched_process_exec",
 			dependencies: dependencies{
 				probes: []EventProbe{
-					{handle: ProbeExecBinprm, required: true},
+					{handle: ProbeExecBinprm, required: false},
 					{handle: ProbeSchedProcessExec, required: true},
 					{handle: ProbeLoadElfPhdrs, required: false},
 				},


### PR DESCRIPTION
Apparently newer kernel versions will inline this function. In order to not break any existing kvisor installations, the new probe is now declared optional for now.