### PR TITLE
Fix container cache cleanup

### DIFF
--- a/pkg/cgroup/client.go
+++ b/pkg/cgroup/client.go
@@ -436,10 +436,6 @@ func (c *Client) LoadCgroup(id ID, path string) {
 	c.cgroupMu.Lock()
 	defer c.cgroupMu.Unlock()
 
-	if _, found := c.cgroupCacheByID[id]; found {
-		return
-	}
-
 	c.cgroupCacheByID[id] = sync.OnceValue(func() *Cgroup {
 		cgroup := c.getCgroupForIDAndPath(id, path)
 		return cgroup

--- a/pkg/containers/client.go
+++ b/pkg/containers/client.go
@@ -110,7 +110,7 @@ func (c *Client) ListContainers() []*Container {
 	})
 }
 
-func (c *Client) addContainerByCgroupID(ctx context.Context, cgroupID cgroup.ID) (cont *Container, rerrr error) {
+func (c *Client) AddContainerByCgroupID(ctx context.Context, cgroupID cgroup.ID) (cont *Container, rerrr error) {
 	defer func() {
 		if rerrr != nil {
 			// TODO: This is quick fix to prevent constant search for invalid containers.
@@ -190,7 +190,7 @@ func (c *Client) GetContainerForCgroup(ctx context.Context, cgroup uint64) (*Con
 
 	if !found {
 		metrics.AgentLoadContainerByCgroup.Inc()
-		return c.addContainerByCgroupID(ctx, cgroup)
+		return c.AddContainerByCgroupID(ctx, cgroup)
 	}
 
 	return container, nil

--- a/pkg/ebpftracer/tracer.go
+++ b/pkg/ebpftracer/tracer.go
@@ -38,6 +38,7 @@ type ActualDestinationGetter interface {
 
 type ContainerClient interface {
 	GetContainerForCgroup(ctx context.Context, cgroup cgroup.ID) (*containers.Container, error)
+	AddContainerByCgroupID(ctx context.Context, cgroupID cgroup.ID) (cont *containers.Container, rerrr error)
 	CleanupCgroup(cgroup cgroup.ID)
 }
 
@@ -626,6 +627,10 @@ func (t *Tracer) cgroupCleanupLoop(ctx context.Context) error {
 			return item.cgroupID
 		})
 		t.removeCgroups(cgroupsToCleanup)
+
+		t.removedCgroupsMu.Lock()
+		t.removedCgroups = map[uint64]struct{}{}
+		t.removedCgroupsMu.Unlock()
 	}
 }
 

--- a/pkg/ebpftracer/tracer_decode.go
+++ b/pkg/ebpftracer/tracer_decode.go
@@ -42,6 +42,32 @@ func (t *Tracer) decodeAndExportEvent(ctx context.Context, ebpfMsgDecoder *decod
 		return fmt.Errorf("cannot parse event type %d: %w", eventId, err)
 	}
 
+	// Process special events for cgroup creation and removal.
+	// These are system events which are not send down via events pipeline.
+	switch eventId {
+	case events.CgroupMkdir:
+		args := parsedArgs.(types.CgroupMkdirArgs)
+		// We we only care about events from the default cgroup, as cgroup v1 does not have unified cgroups.
+		if !t.cfg.CgroupClient.IsDefaultHierarchy(args.HierarchyId) {
+			return nil
+		}
+		t.cfg.CgroupClient.LoadCgroup(args.CgroupId, args.CgroupPath)
+		if _, err := t.cfg.ContainerClient.AddContainerByCgroupID(context.Background(), args.CgroupId); err != nil {
+			t.log.Errorf("cannot add container to cgroup %d: %b", args.CgroupId, err)
+		}
+		return nil
+	case events.CgroupRmdir:
+		args := parsedArgs.(types.CgroupRmdirArgs)
+
+		t.queueCgroupForRemoval(args.CgroupId)
+		err := t.UnmuteEventsFromCgroup(args.CgroupId)
+		if err != nil {
+			return fmt.Errorf("cannot remove cgroup %d from mute map: %w", args.CgroupId, err)
+		}
+		return nil
+	default:
+	}
+
 	container, err := t.cfg.ContainerClient.GetContainerForCgroup(ctx, eventCtx.CgroupID)
 	if err != nil {
 		// We ignore any event not belonging to a container for now.
@@ -127,25 +153,7 @@ func (t *Tracer) decodeAndExportEvent(ctx context.Context, ebpfMsgDecoder *decod
 				processtree.ToProcessKeyNs(proc.PID(forkArgs.ChildNsPid), forkArgs.ChildStartTime),
 			)
 		}
-
-	case events.CgroupMkdir:
-		args := parsedArgs.(types.CgroupMkdirArgs)
-
-		// We we only care about events from the default cgroup, as cgroup v1 does not have unified cgroups.
-		if !t.cfg.CgroupClient.IsDefaultHierarchy(args.HierarchyId) {
-			return nil
-		}
-
-		t.cfg.CgroupClient.LoadCgroup(args.CgroupId, args.CgroupPath)
-
-	case events.CgroupRmdir:
-		args := parsedArgs.(types.CgroupRmdirArgs)
-
-		t.queueCgroupForRemoval(args.CgroupId)
-		err := t.UnmuteEventsFromCgroup(args.CgroupId)
-		if err != nil {
-			return fmt.Errorf("cannot remove cgroup %d from mute map: %w", args.CgroupId, err)
-		}
+	default:
 	}
 
 	if _, found := t.signatureEventMap[eventId]; found {

--- a/pkg/ebpftracer/tracer_filter_test.go
+++ b/pkg/ebpftracer/tracer_filter_test.go
@@ -127,6 +127,10 @@ type MockContainerClient struct {
 	CgroupCleaner   func(cgroup uint64)
 }
 
+func (c *MockContainerClient) AddContainerByCgroupID(ctx context.Context, cgroupID cgroup.ID) (cont *containers.Container, rerrr error) {
+	return nil, nil
+}
+
 func (c *MockContainerClient) GetContainerForCgroup(ctx context.Context, cgroup uint64) (*containers.Container, error) {
 	if c.ContainerGetter == nil {
 		return nil, nil


### PR DESCRIPTION
We should always create new container internal structures during cgroup mkdir. If we miss cgroup rmdir event old container cache will be used with previous metadata. This is especially bad since cgroups ids can be reused quite often.