### PR TITLE
Fix normalize docker config hosts for dockerhub registries

### DIFF
--- a/cmd/imagescan/collector/collector.go
+++ b/cmd/imagescan/collector/collector.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"runtime"
 	"sort"
 	"strings"
@@ -256,13 +257,17 @@ func findRegistryAuth(cfg image.DockerConfig, imgRef name.Reference, log logrus.
 	return "", image.RegistryAuth{}, false
 }
 
+var (
+	dockerHubMatcherRegex = regexp.MustCompile("(/v1|/v2)$")
+)
+
 // normalize registryKey from the pull secret to follow the resolved image repo format
 func normalize(registryKey string) string {
 	trimmed := strings.TrimPrefix(registryKey, "http://")
 	trimmed = strings.TrimPrefix(trimmed, "https://")
 	trimmed = strings.TrimSuffix(trimmed, "/")
 	if strings.HasPrefix(trimmed, "docker.io") || strings.HasPrefix(trimmed, "index.docker.io") {
-		trimmed = strings.TrimSuffix(trimmed, "/v2")
+		trimmed = dockerHubMatcherRegex.ReplaceAllString(trimmed, "")
 	}
 	return trimmed
 }

--- a/cmd/imagescan/collector/collector_test.go
+++ b/cmd/imagescan/collector/collector_test.go
@@ -301,6 +301,18 @@ func TestFindRegistryAuth(t *testing.T) {
 			expectedAuth:  registryAuth,
 		},
 		{
+			name: "default docker registry with index and version v1",
+			cfg: image.DockerConfig{
+				Auths: map[string]image.RegistryAuth{
+					"index.docker.io/v1": registryAuth,
+				},
+			},
+			imageRef:      name.MustParseReference("nginx:latest"),
+			expectedFound: true,
+			expectedKey:   "index.docker.io/v1",
+			expectedAuth:  registryAuth,
+		},
+		{
 			name: "default docker registry with index and version",
 			cfg: image.DockerConfig{
 				Auths: map[string]image.RegistryAuth{


### PR DESCRIPTION
Dockerhub also offers a `v1` of its API, meaning if you configure a pull secret to be for `v1` instead of `v2`, our matching logic would not work. To fix this, we now also strip any `v1` string from the of the auth key.