### PR TITLE
Fix cluster ip info details

### DIFF
--- a/cmd/controller/kube/client.go
+++ b/cmd/controller/kube/client.go
@@ -318,6 +318,9 @@ func (c *Client) GetClusterInfo() (*ClusterInfo, error) {
 			}
 		}
 	}
+	if res.PodCidr == "" && res.ServiceCidr == "" {
+		return nil, fmt.Errorf("no pod cidr or service cidr found")
+	}
 	c.clusterInfo = &res
 	return &res, nil
 }

--- a/cmd/controller/kube/client.go
+++ b/cmd/controller/kube/client.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/netip"
 	"os"
 	"reflect"
@@ -226,7 +227,7 @@ func (c *Client) GetIPInfo(ip netip.Addr) (IPInfo, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
-	val, found := c.index.podsInfoByIP[ip]
+	val, found := c.index.ipsDetails[ip]
 	return val, found
 }
 
@@ -261,34 +262,64 @@ type ClusterInfo struct {
 	ServiceCidr string
 }
 
-func (c *Client) GetClusterInfo() (*ClusterInfo, bool) {
+func (c *Client) GetClusterInfo() (*ClusterInfo, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	if c.clusterInfo != nil {
-		return c.clusterInfo, true
+		return c.clusterInfo, nil
 	}
 
 	var res ClusterInfo
+	// Try to find pods cidr from nodes.
 	for _, node := range c.index.nodesByName {
-		subnet, err := netip.ParsePrefix(node.Spec.PodCIDR)
-		if err != nil {
-			return nil, false
+		if node.Spec.PodCIDR != "" {
+			subnet, err := netip.ParsePrefix(node.Spec.PodCIDR)
+			if err != nil {
+				return nil, fmt.Errorf("parse node pod cidr: %w", err)
+			}
+			res.PodCidr = netip.PrefixFrom(subnet.Addr(), 16).String()
+			break
 		}
-		res.PodCidr = netip.PrefixFrom(subnet.Addr(), 16).String()
-		break
 	}
 
-	for _, info := range c.index.podsInfoByIP {
+	for _, info := range c.index.ipsDetails {
+		// Find service cidr from clusterIP services.
 		if svc := info.Service; svc != nil && svc.Spec.Type == corev1.ServiceTypeClusterIP {
-			addr, err := netip.ParseAddr(svc.Spec.ClusterIP)
-			if err != nil {
-				return nil, false
+			if svc.Spec.ClusterIP != "" {
+				addr, err := netip.ParseAddr(svc.Spec.ClusterIP)
+				if err != nil {
+					return nil, fmt.Errorf("parse service cluster ip: %w", err)
+				}
+				cidr, err := addr.Prefix(16)
+				if err != nil {
+					return nil, fmt.Errorf("get cluster ip prefix: %w", err)
+				}
+				res.ServiceCidr = cidr.String()
+				if res.PodCidr != "" {
+					break
+				}
 			}
-			res.ServiceCidr = netip.PrefixFrom(addr, 16).String()
+		}
+		// Find pod cidr from pod if not found from nodes.
+		if res.PodCidr == "" {
+			if pod := info.PodInfo; pod != nil && pod.Pod != nil && pod.Pod.Status.PodIP != "" {
+				addr, err := netip.ParseAddr(pod.Pod.Status.PodIP)
+				if err != nil {
+					return nil, fmt.Errorf("parse pod addr: %w", err)
+				}
+				cidr, err := addr.Prefix(16)
+				if err != nil {
+					return nil, fmt.Errorf("get pod ip prefix: %w", err)
+				}
+				res.PodCidr = cidr.String()
+				if res.ServiceCidr != "" {
+					break
+				}
+			}
 		}
 	}
 	c.clusterInfo = &res
-	return &res, false
+	return &res, nil
 }
 
 type ImageDetails struct {

--- a/cmd/controller/kube/index.go
+++ b/cmd/controller/kube/index.go
@@ -12,22 +12,22 @@ import (
 
 func NewIndex() *Index {
 	return &Index{
-		podsInfoByIP: make(map[netip.Addr]IPInfo),
-		replicaSets:  make(map[types.UID]metav1.ObjectMeta),
-		jobs:         make(map[types.UID]metav1.ObjectMeta),
-		deployments:  make(map[types.UID]*appsv1.Deployment),
-		pods:         make(map[types.UID]*PodInfo),
-		nodesByName:  make(map[string]*corev1.Node),
+		ipsDetails:  make(map[netip.Addr]IPInfo),
+		replicaSets: make(map[types.UID]metav1.ObjectMeta),
+		jobs:        make(map[types.UID]metav1.ObjectMeta),
+		deployments: make(map[types.UID]*appsv1.Deployment),
+		pods:        make(map[types.UID]*PodInfo),
+		nodesByName: make(map[string]*corev1.Node),
 	}
 }
 
 type Index struct {
-	podsInfoByIP map[netip.Addr]IPInfo
-	replicaSets  map[types.UID]metav1.ObjectMeta
-	jobs         map[types.UID]metav1.ObjectMeta
-	deployments  map[types.UID]*appsv1.Deployment
-	pods         map[types.UID]*PodInfo
-	nodesByName  map[string]*corev1.Node
+	ipsDetails  map[netip.Addr]IPInfo
+	replicaSets map[types.UID]metav1.ObjectMeta
+	jobs        map[types.UID]metav1.ObjectMeta
+	deployments map[types.UID]*appsv1.Deployment
+	pods        map[types.UID]*PodInfo
+	nodesByName map[string]*corev1.Node
 }
 
 func (i *Index) addFromPod(pod *corev1.Pod) {
@@ -45,7 +45,7 @@ func (i *Index) addFromPod(pod *corev1.Pod) {
 			PodInfo: podInfo,
 		}
 		if addr, err := netip.ParseAddr(pod.Status.PodIP); err == nil {
-			i.podsInfoByIP[addr] = ipInfo
+			i.ipsDetails[addr] = ipInfo
 		}
 	}
 }
@@ -62,7 +62,7 @@ func (i *Index) addFromEndpoints(v *corev1.Endpoints) {
 			if err != nil {
 				continue
 			}
-			i.podsInfoByIP[addr] = IPInfo{Endpoint: &IPEndpoint{
+			i.ipsDetails[addr] = IPInfo{Endpoint: &IPEndpoint{
 				ID:        string(v.UID),
 				Name:      v.Name,
 				Namespace: v.Namespace,
@@ -83,7 +83,7 @@ func (i *Index) addFromService(v *corev1.Service) {
 		if err != nil {
 			continue
 		}
-		i.podsInfoByIP[addr] = IPInfo{Service: v}
+		i.ipsDetails[addr] = IPInfo{Service: v}
 	}
 }
 
@@ -96,7 +96,7 @@ func (i *Index) addFromNode(v *corev1.Node) {
 			if err != nil {
 				continue
 			}
-			i.podsInfoByIP[addr] = IPInfo{Node: v}
+			i.ipsDetails[addr] = IPInfo{Node: v}
 			return
 		}
 	}
@@ -110,7 +110,7 @@ func (i *Index) deleteFromPod(v *corev1.Pod) {
 		if err != nil {
 			return
 		}
-		delete(i.podsInfoByIP, addr)
+		delete(i.ipsDetails, addr)
 	}
 }
 
@@ -124,7 +124,7 @@ func (i *Index) deleteFromEndpoints(v *corev1.Endpoints) {
 			if err != nil {
 				continue
 			}
-			delete(i.podsInfoByIP, addr)
+			delete(i.ipsDetails, addr)
 		}
 	}
 }
@@ -140,7 +140,7 @@ func (i *Index) deleteFromService(v *corev1.Service) {
 		if err != nil {
 			continue
 		}
-		delete(i.podsInfoByIP, addr)
+		delete(i.ipsDetails, addr)
 	}
 }
 
@@ -153,7 +153,7 @@ func (i *Index) deleteByNode(v *corev1.Node) {
 			if err != nil {
 				continue
 			}
-			delete(i.podsInfoByIP, addr)
+			delete(i.ipsDetails, addr)
 		}
 	}
 }

--- a/cmd/controller/kube/server.go
+++ b/cmd/controller/kube/server.go
@@ -57,9 +57,9 @@ func (s *Server) GetIPInfo(ctx context.Context, req *kubepb.GetIPInfoRequest) (*
 }
 
 func (s *Server) GetClusterInfo(ctx context.Context, req *kubepb.GetClusterInfoRequest) (*kubepb.GetClusterInfoResponse, error) {
-	info, found := s.client.GetClusterInfo()
-	if !found {
-		return nil, status.Errorf(codes.NotFound, "cluster info not found")
+	info, err := s.client.GetClusterInfo()
+	if err != nil {
+		return nil, status.Errorf(codes.NotFound, "cluster info not found: %v", err)
 	}
 	return &kubepb.GetClusterInfoResponse{
 		PodsCidr:    info.PodCidr,


### PR DESCRIPTION
We need cluster ip info for netflows to know global cluster pod cidr and service cidr. If dst ip is part of these ranges we will try to enrich k8s info.

Now it fails on first wrong parse. Fixed by parsing valid nodes, services, pods only.