### PR TITLE
Disable SecretAnalyzer scanner by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,7 +223,7 @@ kvisor-scanners-docker:
 	make kvisor-agent
 
 .PHONY: kvisor-scanners-docker-image
-kvisor-scanners-docker-image: clean-kvisor-image-scanner kvisor-image-scanner clean-kvisor-linter kivsor-linter
+kvisor-scanners-docker-image: clean-kvisor-image-scanner kvisor-image-scanner clean-kvisor-linter kvisor-linter
 	docker build -t $(IMAGE_REPO)-scanners:$(IMAGE_TAG) . -f Dockerfile.scanners
 
 .PHONY: kvisor-scanners-push-deploy

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -71,6 +71,8 @@ var (
 	imageScanBlobsCacheURL         = pflag.String("image-scan-blobs-cache-url", "http://castai-kvisor-controller.castai-agent", "Image scan blobs cache server url")
 	imageScanIgnoredNamespaces     = pflag.StringSlice("image-scan-ignored-namespaces", []string{},
 		"Image scan ignored namespaces. For example: --image-scan-ignored-namespaces=kube-system,my-namespace")
+	imageScanDisabledAnalyzers = pflag.StringSlice("image-scan-disabled-analyzers", []string{"secret"},
+		"Image scan disabled scanners. For example: image-scan-disabled-analyzers=secret") // secret analyzer is disabled by default for performance reasons, see https://github.com/castai/kvisor/pull/343
 
 	kubeBenchEnabled            = pflag.Bool("kube-bench-enabled", false, "Kube Bench enabled")
 	kubeBenchScanInterval       = pflag.Duration("kube-bench-scan-interval", 5*time.Minute, "Kube bench scan interval")
@@ -206,6 +208,7 @@ func main() {
 			ImageScanBlobsCacheURL:    *imageScanBlobsCacheURL,
 			CloudProvider:             cloudProviderVal,
 			IgnoredNamespaces:         *imageScanIgnoredNamespaces,
+			DisabledAnalyzers:         *imageScanDisabledAnalyzers,
 		},
 		Linter: kubelinter.Config{
 			Enabled:      *kubeLinterEnabled,

--- a/cmd/controller/state/imagescan/controller.go
+++ b/cmd/controller/state/imagescan/controller.go
@@ -48,6 +48,7 @@ type Config struct {
 	ImageScanBlobsCacheURL    string        `json:"imageScanBlobsCacheURL"`
 	CloudProvider             string        `json:"cloudProvider"`
 	IgnoredNamespaces         []string      `json:"ignoredNamespaces"`
+	DisabledAnalyzers         []string      `json:"disabledAnalyzers"`
 }
 
 type ImageScanImage struct {

--- a/cmd/controller/state/imagescan/scanner.go
+++ b/cmd/controller/state/imagescan/scanner.go
@@ -181,7 +181,11 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 		},
 		{
 			Name:  "COLLECTOR_TIMEOUT",
-			Value: "5m",
+			Value: "20m",
+		},
+		{
+			Name:  "COLLECTOR_PARALLEL",
+			Value: "5",
 		},
 		{
 			Name:  "COLLECTOR_MODE",

--- a/cmd/controller/state/imagescan/scanner.go
+++ b/cmd/controller/state/imagescan/scanner.go
@@ -180,14 +180,6 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 			Value: params.ImageName,
 		},
 		{
-			Name:  "COLLECTOR_TIMEOUT",
-			Value: "20m",
-		},
-		{
-			Name:  "COLLECTOR_PARALLEL",
-			Value: "5",
-		},
-		{
 			Name:  "COLLECTOR_MODE",
 			Value: string(mode),
 		},
@@ -214,6 +206,14 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 		{
 			Name:  "CASTAI_CLUSTER_ID",
 			Value: s.cfg.CastaiClusterID,
+		},
+		{
+			Name:  "COLLECTOR_TIMEOUT",
+			Value: "5m",
+		},
+		{
+			Name:  "COLLECTOR_DISABLED_ANALYZERS",
+			Value: strings.Join(s.cfg.DisabledAnalyzers, ","),
 		},
 	}
 

--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -179,7 +179,11 @@ func TestScanner(t *testing.T) {
 											},
 											{
 												Name:  "COLLECTOR_TIMEOUT",
-												Value: "5m",
+												Value: "20m",
+											},
+											{
+												Name:  "COLLECTOR_PARALLEL",
+												Value: "5",
 											},
 											{
 												Name:  "COLLECTOR_MODE",

--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -58,6 +58,7 @@ func TestScanner(t *testing.T) {
 					CastaiGRPCAddress:   "api.cast.ai:443",
 					CastaiClusterID:     "abcd",
 					CloudProvider:       testCase.cloudProvider,
+					DisabledAnalyzers:   []string{"secret", "pip"},
 				}, ns)
 				scanner.jobCheckInterval = 1 * time.Microsecond
 
@@ -178,14 +179,6 @@ func TestScanner(t *testing.T) {
 												Value: "test-image",
 											},
 											{
-												Name:  "COLLECTOR_TIMEOUT",
-												Value: "20m",
-											},
-											{
-												Name:  "COLLECTOR_PARALLEL",
-												Value: "5",
-											},
-											{
 												Name:  "COLLECTOR_MODE",
 												Value: "hostfs",
 											},
@@ -212,6 +205,14 @@ func TestScanner(t *testing.T) {
 											{
 												Name:  "CASTAI_CLUSTER_ID",
 												Value: "abcd",
+											},
+											{
+												Name:  "COLLECTOR_TIMEOUT",
+												Value: "5m",
+											},
+											{
+												Name:  "COLLECTOR_DISABLED_ANALYZERS",
+												Value: "secret,pip",
 											},
 											{
 												Name:  "COLLECTOR_PPROF_ADDR",

--- a/cmd/imagescan/collector/collector.go
+++ b/cmd/imagescan/collector/collector.go
@@ -69,6 +69,9 @@ func (c *Collector) Collect(ctx context.Context) error {
 	}
 	defer cleanup()
 
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	defer cancel()
+
 	artifact, err := analyzer.NewArtifact(img, c.log, c.cache, analyzer.ArtifactOption{
 		Offline:  true,
 		Parallel: c.cfg.Parallel,

--- a/cmd/imagescan/collector/collector.go
+++ b/cmd/imagescan/collector/collector.go
@@ -72,14 +72,23 @@ func (c *Collector) Collect(ctx context.Context) error {
 	}
 	defer cleanup()
 
+	disabledAnalyzers := []fanalyzer.Type{
+		fanalyzer.TypeLicenseFile,
+		fanalyzer.TypeDpkgLicense,
+		fanalyzer.TypeHelm,
+	}
+
+	for _, a := range c.cfg.DisabledAnalyzers {
+		if a == "" {
+			continue
+		}
+		disabledAnalyzers = append(disabledAnalyzers, fanalyzer.Type(a))
+	}
+
 	artifact, err := analyzer.NewArtifact(img, c.log, c.cache, analyzer.ArtifactOption{
-		Offline:  true,
-		Parallel: c.cfg.Parallel,
-		DisabledAnalyzers: []fanalyzer.Type{
-			fanalyzer.TypeLicenseFile,
-			fanalyzer.TypeDpkgLicense,
-			fanalyzer.TypeHelm,
-		},
+		Offline:           true,
+		Parallel:          c.cfg.Parallel,
+		DisabledAnalyzers: disabledAnalyzers,
 	})
 	if err != nil {
 		return err

--- a/cmd/imagescan/collector/collector.go
+++ b/cmd/imagescan/collector/collector.go
@@ -63,14 +63,14 @@ type ImageInfo struct {
 }
 
 func (c *Collector) Collect(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
+	defer cancel()
+
 	img, cleanup, err := c.getImage(ctx)
 	if err != nil {
 		return fmt.Errorf("getting image: %w", err)
 	}
 	defer cleanup()
-
-	ctx, cancel := context.WithTimeout(ctx, c.cfg.Timeout)
-	defer cancel()
 
 	artifact, err := analyzer.NewArtifact(img, c.log, c.cache, analyzer.ArtifactOption{
 		Offline:  true,

--- a/cmd/imagescan/collector/collector_test.go
+++ b/cmd/imagescan/collector/collector_test.go
@@ -57,6 +57,7 @@ func TestCollector(t *testing.T) {
 				ImageArchitecture: "amd64",
 				ImageOS:           "linux",
 				Parallel:          1,
+				DisabledAnalyzers: []string{"secret"},
 			},
 			ingestClient,
 			mockCache,
@@ -164,12 +165,13 @@ func TestCollectorLargeImageDockerRemote(t *testing.T) {
 	ingestClient := &mockIngestClient{}
 
 	c := New(log, config.Config{
-		ImageID:   imgID,
-		ImageName: imgName,
-		Timeout:   10 * time.Minute,
-		Mode:      config.ModeRemote,
-		Runtime:   config.RuntimeDocker,
-		Parallel:  5,
+		ImageID:           imgID,
+		ImageName:         imgName,
+		Timeout:           5 * time.Minute,
+		Mode:              config.ModeRemote,
+		Runtime:           config.RuntimeDocker,
+		Parallel:          5,
+		DisabledAnalyzers: []string{"secret"},
 	}, ingestClient, mockCache, nil)
 
 	startCPUProfile("cpu.pprof")

--- a/cmd/imagescan/collector/collector_test.go
+++ b/cmd/imagescan/collector/collector_test.go
@@ -94,7 +94,7 @@ func TestCollector(t *testing.T) {
 	})
 }
 
-func TestCollectorLargeImageDocker(t *testing.T) {
+func TestCollectorLargeImageDockerTar(t *testing.T) {
 	// Skip this test by default. Uncomment to run locally.
 	if os.Getenv("LOCAL_IMAGE") == "" {
 		t.Skip()
@@ -142,8 +142,40 @@ func TestCollectorLargeImageDocker(t *testing.T) {
 	}()
 
 	r.NoError(c.Collect(ctx))
-	writeMemProfile("heap.prof")
+	writeMemProfile("heap.pprof")
 	r.NoError(os.WriteFile("metadata.json", receivedMetaBytes, 0600))
+}
+
+func TestCollectorLargeImageDockerRemote(t *testing.T) {
+	// Skip this test by default. Set LOCAL_IMAGE to run locally.
+	imgName := os.Getenv("LOCAL_IMAGE")
+	if imgName == "" {
+		t.Skip()
+	}
+	imgID := imgName
+
+	r := require.New(t)
+	ctx := context.Background()
+	log := logrus.New()
+	log.SetLevel(logrus.DebugLevel)
+	//debug.SetGCPercent(-1)
+	mockCache := mockblobcache.MockClient{}
+
+	ingestClient := &mockIngestClient{}
+
+	c := New(log, config.Config{
+		ImageID:   imgID,
+		ImageName: imgName,
+		Timeout:   10 * time.Minute,
+		Mode:      config.ModeRemote,
+		Runtime:   config.RuntimeDocker,
+		Parallel:  5,
+	}, ingestClient, mockCache, nil)
+
+	startCPUProfile("cpu.pprof")
+	r.NoError(c.Collect(ctx))
+	pprof.StopCPUProfile()
+	writeMemProfile("heap.pprof")
 }
 
 func printMemStats() {
@@ -161,6 +193,16 @@ func writeMemProfile(name string) {
 	defer f.Close() // error handling omitted for example
 	if err := pprof.WriteHeapProfile(f); err != nil {
 		logrus.Fatalf("could not write memory profile: %v", err)
+	}
+}
+
+func startCPUProfile(name string) {
+	f, err := os.Create(name)
+	if err != nil {
+		logrus.Fatalf("could not create CPU profile: %v", err)
+	}
+	if err := pprof.StartCPUProfile(f); err != nil {
+		logrus.Fatalf("could not start CPU profile: %v", err)
 	}
 }
 

--- a/cmd/imagescan/config/config.go
+++ b/cmd/imagescan/config/config.go
@@ -52,6 +52,7 @@ type Config struct {
 	DockerOptionPath  string        `envconfig:"COLLECTOR_DOCKER_OPTION_PATH" default:""`
 	PprofAddr         string        `envconfig:"COLLECTOR_PPROF_ADDR" default:""`
 	Parallel          int           `envconfig:"COLLECTOR_PARALLEL" default:"1"`
+	DisabledAnalyzers []string      `envconfig:"COLLECTOR_DISABLED_ANALYZERS" default:""`
 	// ImageLocalTarPath is used only with ModeTarArchive for local dev.
 	ImageLocalTarPath string
 }

--- a/cmd/imagescan/imgscan.go
+++ b/cmd/imagescan/imgscan.go
@@ -68,9 +68,6 @@ func run(ctx context.Context, version string) error {
 	}
 	c := collector.New(log, cfg, ingestClient.GRPC, blobsCache, h)
 
-	ctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
-	defer cancel()
-
 	if cfg.PprofAddr != "" {
 		mux := http.NewServeMux()
 		addPprofHandlers(mux)


### PR DESCRIPTION
We are seeing some timeous in the collector jobs when scanning large images (> 3Gi):

```
time=2024-07-18T10:10:17.699Z level=ERROR msg="image artifacts collection failed: analyze error: timeout: context deadline exceeded"
```

This is caused by the `SecretAnalyzer` scanner in Trivy which takes a lot of time to complete as we can see in the following flamegraph:

![image](https://github.com/user-attachments/assets/9994f049-39db-4859-b7a8-a38849e19ae1)

[cpu_imgscan.pprof.gz](https://github.com/user-attachments/files/16948077/cpu_imgscan.pprof.gz)

The most expensive functions are `MatchKeywords` and `FindLocations` in the `Scan` method:

https://github.com/aquasecurity/trivy/blob/dd0a64a1cf0cd76e6f81e3ff55fa6ccb95ce3c3d/pkg/fanal/secret/scanner.go#L376

We are not currently using this scanner so we can safely disable it by default.

### Testing

Tested in the dev environment with a large image (~10Gi and 31 layers):

```shell
$ skopeo inspect --raw docker://us-east4-docker.pkg.dev/castai-hub/kubecast/ml-airflow@sha256:e3240bde3bbe9e9c9515311d460cbd4af1f877c9855035267e59b9e9e85a32d7 | jq '.layers | sort_by(.size) | reverse'
[
  {
    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
    "size": "3.23 GB",
    "digest": "sha256:2469b0197f29a206a1388529c1d2c2911147ef18c1c5c512d580be7270d89ca0"
  },
  {
    "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
    "size": "326.7 MB",
    "digest": "sha256:5d1dff04c5a22e8b8d60bdec3db2c934bc17cb21b1617138736dc069a4527b8e"
  },
...
]
```

The scan completes now in < 5 min:

```
$ k logs -n castai-agent job/castai-imgscan-ml-airflow -f
time="2024-09-11T14:54:36Z" level=debug msg="found 0 cached layers, 31 layers will be inspected"
time="2024-09-11T14:54:36Z" level=debug msg="missing diff ID in cache: sha256:74c0af6e02274b54b88f851843ae69880a234694dede8ff9fb93bfa076af45ed"
...

$ k get job castai-imgscan-ml-airflow -n castai-agent
NAME                        COMPLETIONS   DURATION   AGE
castai-imgscan-ml-airflow   1/1           2m53s      2m53s
```