### PR TITLE
Do not allow privilege escalation on kvisor-agent

### DIFF
--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -66,8 +66,8 @@ agent:
 
   containerSecurityContext:
     privileged: false
-    allowPrivilegeEscalation: true
     runAsNonRoot: false
+    allowPrivilegeEscalation: false
     capabilities:
       add:
         - SYS_ADMIN


### PR DESCRIPTION
kvisor-agent runs as root so setting `allowPrivilegeEscalation: true` does not take any effect. Let's set it to `false` to make it compliant with `kubelinter.PrivilegeEscalationContainer` check.