### PR TITLE
Added ReadOnlyRootFilesystem flag to image scan jobs

### DIFF
--- a/cmd/controller/state/imagescan/scanner.go
+++ b/cmd/controller/state/imagescan/scanner.go
@@ -463,6 +463,7 @@ func scanJobSpec(
 							SecurityContext: &corev1.SecurityContext{
 								RunAsUser:                lo.ToPtr(nonRootUserID),
 								RunAsNonRoot:             lo.ToPtr(true),
+								ReadOnlyRootFilesystem:   lo.ToPtr(true),
 								AllowPrivilegeEscalation: lo.ToPtr(false),
 							},
 							Name:  "collector",

--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -239,6 +239,7 @@ func TestScanner(t *testing.T) {
 										SecurityContext: &corev1.SecurityContext{
 											RunAsUser:                lo.ToPtr(nonRootUserID),
 											RunAsNonRoot:             lo.ToPtr(true),
+											ReadOnlyRootFilesystem:   lo.ToPtr(true),
 											AllowPrivilegeEscalation: lo.ToPtr(false),
 										},
 									},


### PR DESCRIPTION
Added `ReadOnlyRootFilesystem` flag as `true` to image scan jobs.

E2E Testing results:
`kubectl get job castai-imgscan-98975ceee61f729c132e88f5915dbed8 -o json -n kvisor-e2e | jq '.spec.template.spec.containers[0].securityContext'`
```
{
  "allowPrivilegeEscalation": false,
  "readOnlyRootFilesystem": true,
  "runAsNonRoot": true,
  "runAsUser": 65532
}
```