### PR TITLE
Use nanoseconds precision for events process_start_time

### DIFF
--- a/cmd/agent/daemon/state/events_pipeline.go
+++ b/cmd/agent/daemon/state/events_pipeline.go
@@ -65,7 +65,7 @@ func (c *Controller) toProtoEvent(e *ebpftypes.Event) *castpb.Event {
 		HostPid:       e.Context.HostPid,
 		ProcessIdentity: &castpb.ProcessIdentity{
 			Pid:       e.Context.Pid,
-			StartTime: uint64((time.Duration(e.Context.StartTime) * time.Nanosecond).Truncate(time.Second).Seconds()), // nolint:gosec
+			StartTime: uint64((time.Duration(e.Context.StartTime) * time.Nanosecond).Truncate(time.Second).Nanoseconds()), // nolint:gosec
 		},
 	}
 


### PR DESCRIPTION
We want to store nanoseconds in the `events` table as we are doing in the `process_tree_events` table.