### PR TITLE
Set default `priorityClassName` to `kvisor-agent` pod

### DIFF
--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -58,7 +58,7 @@ agent:
       maxUnavailable: 10
 
   # Allow to set priority class like system-node-critical.
-  priorityClass: ""
+  priorityClass: "system-node-critical"
 
   podAnnotations: {}
 


### PR DESCRIPTION
to `system-node-critical`.

So that it is scheduled with higher priority.