### PR TITLE
Handle missing Pod termination statuses

### DIFF
--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -345,6 +345,11 @@ func TestScanner(t *testing.T) {
 				},
 				ContainerStatuses: []corev1.ContainerStatus{
 					{
+						State: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{
+								Reason: "QuotaReached",
+							},
+						},
 						LastTerminationState: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{
 								Reason: "QuotaReached",


### PR DESCRIPTION
With the previous implementation the status would be empty, if the Pod was not in a crash loop.