### PR TITLE
Allow image scanner to read write /tmp directory

### DIFF
--- a/cmd/controller/state/imagescan/scanner.go
+++ b/cmd/controller/state/imagescan/scanner.go
@@ -89,7 +89,19 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 	}
 
 	jobName := genJobName(params.ImageName)
-	vols := volumesAndMounts{}
+	vols := volumesAndMounts{
+		volumes: []corev1.Volume{{ // required by image-analyzer during layer tar walking
+			Name: "tmp",
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		}},
+		mounts: []corev1.VolumeMount{{
+			Name:      "tmp",
+			ReadOnly:  false,
+			MountPath: "/tmp",
+		}},
+	}
 	mode := imagescanconfig.Mode(params.Mode)
 	containerRuntime := params.ContainerRuntime
 

--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -221,6 +221,11 @@ func TestScanner(t *testing.T) {
 										},
 										VolumeMounts: []corev1.VolumeMount{
 											{
+												Name:      "tmp",
+												ReadOnly:  false,
+												MountPath: "/tmp",
+											},
+											{
 												Name:      "containerd-content",
 												ReadOnly:  true,
 												MountPath: "/var/lib/containerd/io.containerd.content.v1.content",
@@ -245,6 +250,12 @@ func TestScanner(t *testing.T) {
 									},
 								},
 								Volumes: []corev1.Volume{
+									{
+										Name: "tmp",
+										VolumeSource: corev1.VolumeSource{
+											EmptyDir: &corev1.EmptyDirVolumeSource{},
+										},
+									},
 									{
 										Name: "containerd-content",
 										VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
image-analyzer library used by the scanner creates temporary directories as part of the layer analysis and emptyDir volume is required when read only filesystem setting is enabled