### PR TITLE
Ignore already existing cgroupv2 mount point

### DIFF
--- a/pkg/ebpftracer/module_linux.go
+++ b/pkg/ebpftracer/module_linux.go
@@ -10,7 +10,7 @@ import (
 
 func mountCgroup2(mountPoint string) error {
 	err := os.Mkdir(mountPoint, 0755)
-	if err != nil {
+	if err != nil && !os.IsExist(err){
 		return fmt.Errorf("creating directory at %q: %w", mountPoint, err)
 	}
 	// https://docs.kernel.org/admin-guide/cgroup-v2.html#mounting


### PR DESCRIPTION
When the process in an container gets restarted, they reuse the same filesystem. This means that the mount point we need for mounting cgroupv2 already exists and we should not fail.