### PR TITLE
Update documentation on how to deploy kvisor builds and releases usin…

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -154,7 +154,7 @@ jobs:
           echo "ghcr.io/castai/kvisor/kvisor-scanners:${{ env.head_commit_sha }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Upgrade with helm:**" >> $GITHUB_STEP_SUMMARY
-          echo "helm upgrade castai-kvisor castai-helm/kvisor -n castai-agent --reuse-values --set image.tag=${{ env.head_commit_sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "helm upgrade castai-kvisor castai-helm/castai-kvisor -n castai-agent --reuse-values --set image.tag=${{ env.head_commit_sha }}" >> $GITHUB_STEP_SUMMARY
 
   # TODO: we might want to run the tests both in ubuntu-22.04, as well as ubuntu-20.04 to test
   # if we everything is working with cgroups v1 and v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -210,6 +210,11 @@ jobs:
           git commit -m "[Release] Update Chart.yaml"
           git push
 
+      - name: Summary
+        run: |
+          echo "**Upgrade with helm:**" >> $GITHUB_STEP_SUMMARY
+          echo "helm repo update && helm upgrade castai-kvisor castai-helm/castai-kvisor -n castai-agent --reset-then-reuse-values" >> $GITHUB_STEP_SUMMARY
+
 # TODO: Enable this step to sync chart content into helm-charts repo
 #      - name: Sync chart with helm-charts github
 #        run: |


### PR DESCRIPTION
…g helm

Release command is different, because it unsets any custom image tags and makes sure that chart upgrade also upgrades an image