### PR TITLE
Fix process name

### DIFF
--- a/cmd/agent/daemon/state/events_pipeline.go
+++ b/cmd/agent/daemon/state/events_pipeline.go
@@ -1,7 +1,6 @@
 package state
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"net/netip"
@@ -10,6 +9,7 @@ import (
 	castpb "github.com/castai/kvisor/api/v1/runtime"
 	"github.com/castai/kvisor/cmd/agent/daemon/enrichment"
 	"github.com/castai/kvisor/cmd/agent/daemon/metrics"
+	"github.com/castai/kvisor/pkg/ebpftracer/decoder"
 	ebpftypes "github.com/castai/kvisor/pkg/ebpftracer/types"
 	"github.com/cespare/xxhash/v2"
 	"github.com/elastic/go-freelru"
@@ -55,7 +55,7 @@ func (c *Controller) toProtoEvent(e *ebpftypes.Event) *castpb.Event {
 	event := &castpb.Event{
 		EventType:     0,
 		Timestamp:     e.Context.Ts,
-		ProcessName:   string(bytes.TrimRight(e.Context.Comm[:], "\x00")),
+		ProcessName:   decoder.ProcessNameString(e.Context.Comm[:]),
 		Namespace:     e.Container.PodNamespace,
 		PodUid:        e.Container.PodUID,
 		PodName:       e.Container.PodName,

--- a/pkg/ebpftracer/decoder/decoder.go
+++ b/pkg/ebpftracer/decoder/decoder.go
@@ -20,6 +20,7 @@ import (
 	"github.com/castai/kvisor/pkg/net/packet"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"golang.org/x/sys/unix"
 )
 
 type Decoder struct {
@@ -602,11 +603,7 @@ func (decoder *Decoder) ReadProtoDNS() (*types.ProtoDNS, error) {
 // ProcessNameString converts raw process name to readable string.
 // Since it's a C-like string it can contain NUL byte.
 func ProcessNameString(raw []byte) string {
-	nulByteIndex := bytes.IndexByte(raw[:], 0)
-	if nulByteIndex == -1 {
-		return string(raw)
-	}
-	return string(raw[:nulByteIndex])
+	return unix.ByteSliceToString(raw)
 }
 
 func ToProtoDNS(details *packet.PacketDetails, dnsPacketParser *layers.DNS) *castpb.DNS {

--- a/pkg/ebpftracer/decoder/decoder.go
+++ b/pkg/ebpftracer/decoder/decoder.go
@@ -599,6 +599,16 @@ func (decoder *Decoder) ReadProtoDNS() (*types.ProtoDNS, error) {
 	return ToProtoDNS(&details, dnsPacketParser), nil
 }
 
+// ProcessNameString converts raw process name to readable string.
+// Since it's a C-like string it can contain NUL byte.
+func ProcessNameString(raw []byte) string {
+	nulByteIndex := bytes.IndexByte(raw[:], 0)
+	if nulByteIndex == -1 {
+		return string(raw)
+	}
+	return string(raw[:nulByteIndex])
+}
+
 func ToProtoDNS(details *packet.PacketDetails, dnsPacketParser *layers.DNS) *castpb.DNS {
 	pbDNS := &castpb.DNS{
 		Answers: make([]*castpb.DNSAnswers, len(dnsPacketParser.Answers)),

--- a/pkg/ebpftracer/decoder/decoder_test.go
+++ b/pkg/ebpftracer/decoder/decoder_test.go
@@ -760,6 +760,30 @@ func TestDecodeContext(t *testing.T) {
 	}, eventCtx)
 }
 
+func TestProcessNameString(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    []byte
+		expected string
+	}{
+		{
+			name:     "no null terminator",
+			value:    []byte("curl"),
+			expected: "curl",
+		},
+		{
+			name:     "truncate at first null terminator",
+			value:    []byte{116, 101, 115, 116, 0, 120, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			expected: "test",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, ProcessNameString(test.value))
+		})
+	}
+}
+
 var sshRequestData = []byte{
 	// Payload size
 	0x5e, 0x00, 0x00, 0x00,

--- a/pkg/ebpftracer/signature/signature.go
+++ b/pkg/ebpftracer/signature/signature.go
@@ -1,11 +1,11 @@
 package signature
 
 import (
-	"bytes"
 	"context"
 	"time"
 
 	castpb "github.com/castai/kvisor/api/v1/runtime"
+	"github.com/castai/kvisor/pkg/ebpftracer/decoder"
 	"github.com/castai/kvisor/pkg/ebpftracer/events"
 	"github.com/castai/kvisor/pkg/ebpftracer/types"
 	"github.com/castai/kvisor/pkg/logging"
@@ -127,7 +127,7 @@ func (e *SignatureEngine) handleEvent(event *types.Event) {
 		e.eventsChan <- &castpb.Event{
 			EventType:     castpb.EventType_EVENT_SIGNATURE,
 			Timestamp:     uint64(time.Now().UTC().UnixNano()), // nolint:gosec
-			ProcessName:   string(bytes.Trim(event.Context.Comm[:], "\x00")),
+			ProcessName:   decoder.ProcessNameString(event.Context.Comm[:]),
 			Namespace:     event.Container.PodNamespace,
 			PodName:       event.Container.PodName,
 			ContainerName: event.Container.Name,

--- a/pkg/ebpftracer/tracer_playground_test.go
+++ b/pkg/ebpftracer/tracer_playground_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/castai/kvisor/pkg/cgroup"
 	"github.com/castai/kvisor/pkg/containers"
 	"github.com/castai/kvisor/pkg/ebpftracer"
+	"github.com/castai/kvisor/pkg/ebpftracer/decoder"
 	"github.com/castai/kvisor/pkg/ebpftracer/events"
 	"github.com/castai/kvisor/pkg/ebpftracer/signature"
 	"github.com/castai/kvisor/pkg/ebpftracer/types"
@@ -278,7 +279,7 @@ var ingoredProcesses = map[string]struct{}{
 
 func printEvent(tr *ebpftracer.Tracer, e *types.Event) {
 	eventName := tr.GetEventName(e.Context.EventID)
-	procName := string(bytes.TrimRight(e.Context.Comm[:], "\x00"))
+	procName := decoder.ProcessNameString(e.Context.Comm[:])
 	if _, ignored := ingoredProcesses[procName]; ignored {
 		return
 	}


### PR DESCRIPTION
We used `string(bytes.TrimRight(e.Context.Comm[:], "\x00"))` to trim nul terminator char, but this is not fully correct. 
Process name can contain garbage data after the first NUL byte. This is why we sometime see process name with random suffixes. 