### PR TITLE
Remove fetching pids from containerd

### DIFF
--- a/charts/kvisor/values-local.yaml
+++ b/charts/kvisor/values-local.yaml
@@ -24,7 +24,7 @@ agent:
     netflow-enabled: true
     netflow-sample-submit-interval-seconds: 1
     netflow-export-interval: 5s
-    ebpf-events-stdio-exporter-enabled: false
+    ebpf-events-stdio-exporter-enabled: true
     process-tree-enabled: true
     ebpf-events-include-pod-labels: 'helm.sh/chart,app.kubernetes.io/name'
     ebpf-events-include-pod-annotations: 'cast.ai'

--- a/cmd/agent/daemon/state/container_stats_pipeline.go
+++ b/cmd/agent/daemon/state/container_stats_pipeline.go
@@ -46,6 +46,7 @@ func (c *Controller) scrapeContainersResourceStats(batch *castpb.ContainerStatsB
 			continue
 		}
 
+		// TODO: This is now never filled. For some reasons some calls to containerd returns context deadline errors.
 		if len(cont.PIDs) == 0 {
 			continue
 		}

--- a/cmd/agent/daemon/state/controller_test.go
+++ b/cmd/agent/daemon/state/controller_test.go
@@ -51,47 +51,46 @@ func TestController(t *testing.T) {
 		}
 	})
 
-	t.Run("container stats pipeline", func(t *testing.T) {
-		r := require.New(t)
-		ctrl := newTestController()
-		exporter := &mockContainerStatsExporter{events: make(chan *castaipb.ContainerStatsBatch, 10)}
-		ctrl.exporters.ContainerStats = append(ctrl.exporters.ContainerStats, exporter)
-		ctrl.tracer.(*mockEbpfTracer).syscallStats = map[ebpftracer.SyscallStatsKeyCgroupID][]ebpftracer.SyscallStats{
-			1: {
-				{ID: ebpftracer.SyscallID(2), Count: 3},
-			},
-		}
-		ctrl.containersClient.(*mockContainersClient).list = []*containers.Container{
-			{
-				ID:           "c1",
-				Name:         "cont",
-				CgroupID:     1,
-				PodNamespace: "ns1",
-				PodUID:       "p1",
-				PodName:      "p1",
-				Cgroup:       nil,
-				PIDs:         []uint32{1},
-			},
-		}
-
-		ctrlerr := make(chan error, 1)
-		go func() {
-			ctrlerr <- ctrl.Run(ctx)
-		}()
-
-		select {
-		case e := <-exporter.events:
-			r.Len(e.Items, 1)
-			r.Len(e.Items[0].Stats, 1)
-			r.Equal(1, int(e.Items[0].Stats[0].Group))
-			r.Equal(2, int(e.Items[0].Stats[0].Subgroup))
-			r.GreaterOrEqual(1, int(e.Items[0].Stats[0].Value))
-		case err := <-ctrlerr:
-			t.Fatal(err)
-		case <-time.After(time.Second):
-			t.Fatal("timed out waiting for data")
-		}
-	})
+	//t.Run("container stats pipeline", func(t *testing.T) {
+	//	r := require.New(t)
+	//	ctrl := newTestController()
+	//	exporter := &mockContainerStatsExporter{events: make(chan *castaipb.ContainerStatsBatch, 10)}
+	//	ctrl.exporters.ContainerStats = append(ctrl.exporters.ContainerStats, exporter)
+	//	ctrl.tracer.(*mockEbpfTracer).syscallStats = map[ebpftracer.SyscallStatsKeyCgroupID][]ebpftracer.SyscallStats{
+	//		1: {
+	//			{ID: ebpftracer.SyscallID(2), Count: 3},
+	//		},
+	//	}
+	//	ctrl.containersClient.(*mockContainersClient).list = []*containers.Container{
+	//		{
+	//			ID:           "c1",
+	//			Name:         "cont",
+	//			CgroupID:     1,
+	//			PodNamespace: "ns1",
+	//			PodUID:       "p1",
+	//			PodName:      "p1",
+	//			Cgroup:       nil,
+	//		},
+	//	}
+	//
+	//	ctrlerr := make(chan error, 1)
+	//	go func() {
+	//		ctrlerr <- ctrl.Run(ctx)
+	//	}()
+	//
+	//	select {
+	//	case e := <-exporter.events:
+	//		r.Len(e.Items, 1)
+	//		r.Len(e.Items[0].Stats, 1)
+	//		r.Equal(1, int(e.Items[0].Stats[0].Group))
+	//		r.Equal(2, int(e.Items[0].Stats[0].Subgroup))
+	//		r.GreaterOrEqual(1, int(e.Items[0].Stats[0].Value))
+	//	case err := <-ctrlerr:
+	//		t.Fatal(err)
+	//	case <-time.After(time.Second):
+	//		t.Fatal("timed out waiting for data")
+	//	}
+	//})
 
 	t.Run("netflow pipeline", func(t *testing.T) {
 		r := require.New(t)

--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -112,10 +112,9 @@ func run(ctx context.Context) error {
 	srv.netflowsAsserted = true
 	srv.netflows = nil
 
+	// TODO: Fix container assert stats once pids are fixed.
 	fmt.Println("🙏waiting for container stats")
-	if err := srv.assertContainerStats(ctx); err != nil {
-		return fmt.Errorf("assert container stats: %w", err)
-	}
+	_ = srv.assertContainerStats
 	srv.containerStatsAsserted = true
 	srv.containerStats = nil
 

--- a/pkg/containers/container_client.go
+++ b/pkg/containers/container_client.go
@@ -1,13 +1,9 @@
 package containers
 
 import (
-	"context"
 	"time"
 
 	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/api/services/tasks/v1"
-	"github.com/containerd/containerd/api/types/task"
-	"github.com/samber/lo"
 )
 
 func newContainerClient(address string) (*containerClient, error) {
@@ -23,14 +19,4 @@ func newContainerClient(address string) (*containerClient, error) {
 // containerClient wraps container runtime specific implementations. For we support only containerd.
 type containerClient struct {
 	client *containerd.Client
-}
-
-func (c *containerClient) getContainerPids(ctx context.Context, containerID string) ([]uint32, error) {
-	res, err := c.client.TaskService().ListPids(ctx, &tasks.ListPidsRequest{ContainerID: containerID})
-	if err != nil {
-		return nil, err
-	}
-	return lo.Map(res.GetProcesses(), func(item *task.ProcessInfo, index int) uint32 {
-		return item.GetPid()
-	}), nil
 }

--- a/pkg/ebpftracer/tracer_decode.go
+++ b/pkg/ebpftracer/tracer_decode.go
@@ -150,7 +150,7 @@ func (t *Tracer) handleCgroupMkdirEvent(eventCtx *types.EventContext, parsedArgs
 			}
 			return nil
 		}
-		t.log.Errorf("cannot add container to cgroup %d: %b", args.CgroupId, err)
+		t.log.Errorf("cannot add container to cgroup %d: %v", args.CgroupId, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Disable fetching pids. They are needed only for container stats. For some reasons we are randomly getting context deadlines while trying to fetch them from containerd.