### PR TITLE
Fix stats overflow

### DIFF
--- a/cmd/agent/daemon/state/stats_pipeline.go
+++ b/cmd/agent/daemon/state/stats_pipeline.go
@@ -100,7 +100,7 @@ func (c *Controller) scrapeContainerResourcesStats(cont *containers.Container, b
 		ContainerName: cont.Name,
 		PodUid:        cont.PodUID,
 		ContainerId:   cont.ID,
-		CpuStats:      getCPUStatsDiff(nil, prevScrape.cpuStat, currScrape.cpuStat),
+		CpuStats:      getCPUStatsDiff(c.log, prevScrape.cpuStat, currScrape.cpuStat),
 		MemoryStats:   getMemoryStatsDiff(prevScrape.memStat, currScrape.memStat),
 		PidsStats:     cgStats.PidsStats,
 		IoStats:       getIOStatsDiff(prevScrape.ioStat, currScrape.ioStat),

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -1,6 +1,7 @@
 package cgroup
 
 import (
+	"errors"
 	"os"
 	"path"
 	"strings"
@@ -9,6 +10,8 @@ import (
 )
 
 const UnifiedMountpoint = "/sys/fs/cgroup"
+
+var ErrStatsNotFound = errors.New("stats not found")
 
 type Stats struct {
 	CpuStats    *castaipb.CpuStats
@@ -34,7 +37,8 @@ func (cg *Cgroup) GetStats() (Stats, error) {
 	}
 	if err := cg.statsGetterFunc(&res); err != nil {
 		if os.IsNotExist(err) {
-			return res, nil
+			// Most likely container was deleted.
+			return res, ErrStatsNotFound
 		}
 		return res, err
 	}


### PR DESCRIPTION
If during scrape container was removed we there returning empty stats. Since we do diff it would overflow with previous value. 