### PR TITLE
Update renovate config to bundle updates into single PRs

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,6 +22,23 @@
       ],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
+    },
+    {
+      "matchDatasources": [
+        "docker",
+      ],
+      "matchUpdateTypes": [
+        "digest",
+      ],
+      "groupName": "all image digest updates",
+      "groupSlug": "all-image-digest-updates"
+    }
+    {
+      "matchManagers": [
+        "github-actions",
+      ],
+      "groupName": "github actions",
+      "groupSlug": "github-actions"
     }
   ]
 }


### PR DESCRIPTION
To remove the amount of PRs we are receiving from renovate, the config has been updated to bundle all docker image digest updats into a single PR. Additionally, all github action updates are now also in a single PR.