### PR TITLE
Add netflows send retry

### DIFF
--- a/cmd/agent/daemon/app/app.go
+++ b/cmd/agent/daemon/app/app.go
@@ -173,7 +173,7 @@ func (a *App) Run(ctx context.Context) error {
 			exporters.Stats = append(exporters.Stats, state.NewCastaiStatsExporter(log, castaiClient, a.cfg.ExportersQueueSize))
 		}
 		if cfg.Netflow.Enabled {
-			exporters.Netflow = append(exporters.Netflow, state.NewCastaiNetflowExporter(log, castaiClient, a.cfg.ExportersQueueSize))
+			exporters.Netflow = append(exporters.Netflow, state.NewCastaiNetflowExporter(log, castaiClient.GRPC, a.cfg.ExportersQueueSize))
 		}
 		if cfg.ProcessTree.Enabled {
 			exporter := state.NewCastaiProcessTreeExporter(log, castaiClient, a.cfg.ExportersQueueSize)

--- a/cmd/agent/daemon/state/castai_events_exporter.go
+++ b/cmd/agent/daemon/state/castai_events_exporter.go
@@ -78,7 +78,6 @@ func (s *eventSender) send(e *castpb.Event, retry bool) {
 
 			return
 		}
-
 		s.sendErrorMetric.Inc()
 		return
 	}

--- a/cmd/agent/daemon/state/castai_netflow_exporter_test.go
+++ b/cmd/agent/daemon/state/castai_netflow_exporter_test.go
@@ -1,0 +1,155 @@
+package state
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	castaipb "github.com/castai/kvisor/api/v1/runtime"
+	"github.com/castai/kvisor/pkg/logging"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestNewCastaiNetflowExporter(t *testing.T) {
+	t.Run("send netflows", func(t *testing.T) {
+		r := require.New(t)
+
+		netflowStream := &netflowMockStream{}
+		exporter := NewCastaiNetflowExporter(logging.NewTestLog(), netflowStream, 100)
+
+		go func() {
+			if err := exporter.Run(context.Background()); err != nil {
+				panic(err)
+			}
+		}()
+		for range 100 {
+			exporter.Enqueue(&castaipb.Netflow{PodName: "p1"})
+		}
+
+		r.Eventually(func() bool {
+			netflowStream.mu.Lock()
+			streams := netflowStream.streams
+			netflowStream.mu.Unlock()
+			if len(streams) != 1 {
+				return false
+			}
+			stream := streams[0]
+			stream.mu.Lock()
+			flows := stream.flows
+			stream.mu.Unlock()
+			if len(flows) != 100 {
+				return false
+			}
+			r.Equal("p1", flows[0].PodName)
+			return true
+		}, 1*time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("retry netflows", func(t *testing.T) {
+		r := require.New(t)
+
+		netflowStream := &netflowMockStream{firstSendError: true}
+		exporter := NewCastaiNetflowExporter(logging.NewTestLog(), netflowStream, 100)
+		exporter.writeStreamCreateRetryDelay = 1 * time.Millisecond
+
+		go func() {
+			if err := exporter.Run(context.Background()); err != nil {
+				panic(err)
+			}
+		}()
+		exporter.Enqueue(&castaipb.Netflow{PodName: "p1"})
+
+		r.Eventually(func() bool {
+			netflowStream.mu.Lock()
+			streams := netflowStream.streams
+			netflowStream.mu.Unlock()
+			if len(streams) != 1 {
+				return false
+			}
+			stream := streams[0]
+			stream.mu.Lock()
+			flows := stream.flows
+			stream.mu.Unlock()
+			if len(flows) != 1 {
+				return false
+			}
+			r.Equal("p1", flows[0].PodName)
+			return true
+		}, 1*time.Second, 10*time.Millisecond)
+	})
+}
+
+type netflowMockStream struct {
+	mu             sync.Mutex
+	streams        []*mockNetflowStreamClient
+	firstSendError bool
+}
+
+func (n *netflowMockStream) NetflowWriteStream(ctx context.Context, opts ...grpc.CallOption) (castaipb.RuntimeSecurityAgentAPI_NetflowWriteStreamClient, error) {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	if n.firstSendError {
+		n.firstSendError = false
+	}
+	s := &mockNetflowStreamClient{firstSendError: n.firstSendError}
+	n.streams = append(n.streams, s)
+	return s, nil
+}
+
+type mockNetflowStreamClient struct {
+	mu sync.Mutex
+
+	flows          []*castaipb.Netflow
+	firstSendError bool
+}
+
+func (m *mockNetflowStreamClient) SendMsg(msg any) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.firstSendError {
+		m.firstSendError = false
+		return errors.New("can't send")
+	}
+
+	m.flows = append(m.flows, msg.(*castaipb.Netflow))
+	return nil
+}
+
+func (m *mockNetflowStreamClient) CloseSend() error {
+	return nil
+}
+
+func (m *mockNetflowStreamClient) Send(netflow *castaipb.Netflow) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockNetflowStreamClient) CloseAndRecv() (*castaipb.WriteStreamResponse, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockNetflowStreamClient) Header() (metadata.MD, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockNetflowStreamClient) Trailer() metadata.MD {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockNetflowStreamClient) Context() context.Context {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m *mockNetflowStreamClient) RecvMsg(msg any) error {
+	//TODO implement me
+	panic("implement me")
+}

--- a/cmd/agent/daemon/state/castai_stats_exporter.go
+++ b/cmd/agent/daemon/state/castai_stats_exporter.go
@@ -18,6 +18,7 @@ func NewCastaiStatsExporter(log *logging.Logger, apiClient *castai.Client, queue
 		apiClient:                   apiClient,
 		queue:                       make(chan *castpb.StatsBatch, queueSize),
 		writeStreamCreateRetryDelay: 1 * time.Second,
+		drainTimeout:                5 * time.Second,
 	}
 }
 
@@ -26,11 +27,15 @@ type CastaiStatsExporter struct {
 	apiClient                   *castai.Client
 	queue                       chan *castpb.StatsBatch
 	writeStreamCreateRetryDelay time.Duration
+	drainTimeout                time.Duration
 }
 
-func (c *CastaiStatsExporter) Run(ctx context.Context) error {
+func (c *CastaiStatsExporter) Run(rootCtx context.Context) error {
 	c.log.Info("running export loop")
 	defer c.log.Info("export loop done")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	ws := castai.NewWriteStream[*castpb.StatsBatch, *castpb.WriteStreamResponse](ctx, func(ctx context.Context) (grpc.ClientStream, error) {
 		return c.apiClient.GRPC.StatsWriteStream(ctx, grpc.UseCompressor(gzip.Name))
@@ -52,10 +57,25 @@ func (c *CastaiStatsExporter) Run(ctx context.Context) error {
 		sendErrorMetric.Inc()
 	}
 
+	// Drain and send remaining data.
+	defer func() {
+		drainCtx, cancel := context.WithTimeout(context.Background(), c.drainTimeout)
+		defer cancel()
+		for len(c.queue) > 0 {
+			select {
+			case <-drainCtx.Done():
+				return
+			default:
+			}
+			sendWithRetry(<-c.queue)
+		}
+		cancel()
+	}()
+
 	for {
 		select {
-		case <-ctx.Done():
-			return ctx.Err()
+		case <-rootCtx.Done():
+			return rootCtx.Err()
 		case e := <-c.queue:
 			sendWithRetry(e)
 		}


### PR DESCRIPTION
Currently call to Send is not retried for container stats and netflows. Adding retry with 2 calls because second call will reopen stream.