### PR TITLE
Reduce memory churn on module load by reusing kernel BTF spec

### DIFF
--- a/pkg/ebpftracer/module.go
+++ b/pkg/ebpftracer/module.go
@@ -58,10 +58,19 @@ func (m *module) load(cfg Config) error {
 	}
 
 	var kernelTypes *btf.Spec
-	if cfg.BTFPath != "" {
+
+	// If the given `BTFPath` points to the kernels, we also want to load
+	// it via the `btf.LoadKernelSpec` function, as otherwise the kernel
+	// BTF will get parsed twice, causing quite the memory churn.
+	if cfg.BTFPath != "" && cfg.BTFPath != "/sys/kernel/btf/vmlinux" {
 		kernelTypes, err = btf.LoadSpec(cfg.BTFPath)
 		if err != nil {
 			return fmt.Errorf("loading custom btf: %w", err)
+		}
+	} else {
+		kernelTypes, err = btf.LoadKernelSpec()
+		if err != nil {
+			return fmt.Errorf("loading kernel btf: %w", err)
 		}
 	}
 

--- a/pkg/ebpftracer/tracer_decode_benchmark_test.go
+++ b/pkg/ebpftracer/tracer_decode_benchmark_test.go
@@ -44,3 +44,37 @@ func BenchmarkFilterDecodeAndExportEvent(b *testing.B) {
 		})
 	}
 }
+
+func BenchmarkModuleLoad(b *testing.B) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		mo := newModule(logging.NewTestLog())
+		if err := mo.load(Config{
+			BTFPath:                            "/sys/kernel/btf/vmlinux",
+			SignalEventsRingBufferSize:         4096,
+			EventsRingBufferSize:               4096,
+			SkbEventsRingBufferSize:            4096,
+			EventsOutputChanSize:               4096,
+			DefaultCgroupsVersion:              "",
+			DebugEnabled:                       false,
+			AutomountCgroupv2:                  false,
+			ContainerClient:                    nil,
+			CgroupClient:                       &MockCgroupClient{},
+			SignatureEngine:                    nil,
+			MountNamespacePIDStore:             nil,
+			HomePIDNS:                          0,
+			AllowAnyEvent:                      false,
+			NetflowSampleSubmitIntervalSeconds: 0,
+			NetflowGrouping:                    0,
+			TrackSyscallStats:                  false,
+			ProcessTreeCollector:               nil,
+			MetricsReporting:                   MetricsReportingConfig{},
+			PodName:                            "",
+		}); err != nil {
+			b.Fatal(err)
+		}
+		mo.close()
+	}
+}


### PR DESCRIPTION
Before this change we always parsed the given BTFPath spec. In 99% of the cases, the path pointed to the default kernel BTF location. Due to the way the cilium/ebpf library handles passing BTF spec, this caused the kernels BTF spec to be effectively parsed twice, causing quite the memory churn.

The docs mention that not passing `KernelTypes` for the  program option will implicitly use the kernel BTF spec. While this is true, it also causes a lot of memory churn in the process, as each time the `btf.LoadKernelSpec` function gets called, the spec is copied.

To work around this, kvisor detects if the given `BTFPath` is the default BTF location, parses the kernel BTF spec once and passes it to the ebpf lib via the `KernelTypes` option.

Running benchmarks, this change allows to cut the number of allocations by ~1/3.

  Benchmark before optimization
  > 5  224041936 ns/op 111770155 B/op 1213041 allocs/op

  Benchmark after optimization
  > 6  173737552 ns/op  73678120 B/op  848361 allocs/op