### PR TITLE
Fix cidr retrieval from pods ips when nodes cidr is missing

### DIFF
--- a/cmd/controller/kube/client.go
+++ b/cmd/controller/kube/client.go
@@ -292,7 +292,7 @@ func (c *Client) GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 				if err != nil {
 					return nil, err
 				}
-				if len(res.PodCidr) > 0 {
+				if len(podCidr) > 0 {
 					res.PodCidr = podCidr
 					break
 				}
@@ -307,7 +307,7 @@ func (c *Client) GetClusterInfo(ctx context.Context) (*ClusterInfo, error) {
 	}
 	res.ServiceCidr = serviceCidr
 
-	if len(res.PodCidr) == 0 && len(res.ServiceCidr) == 0 {
+	if len(res.PodCidr) == 0 || len(res.ServiceCidr) == 0 {
 		return nil, fmt.Errorf("no pod cidr or service cidr found")
 	}
 	c.clusterInfo = &res


### PR DESCRIPTION
Fix missing `pod_cidr=[]` in clusters where nodes do not have `spec.podcidr` set.