### PR TITLE
Redact passwords encoded in git clone URL

### DIFF
--- a/cmd/agent/daemon/daemon.go
+++ b/cmd/agent/daemon/daemon.go
@@ -86,11 +86,12 @@ func NewRunCommand(version string) *cobra.Command {
 
 		fileHashEnrichedEnabled = command.Flags().Bool("file-hash-enricher-enabled", false, "Enables the file has event enricher for exec events")
 
-		signatureEngineInputEventChanSize  = command.Flags().Int("signature-engine-input-queue-size", 1000, "Input queue size for the signature engine")
-		signatureEngineOutputEventChanSize = command.Flags().Int("signature-engine-output-queue-size", 1000, "Output queue size for the signature engine")
-		socks5DetectionSignatureEnabled    = command.Flags().Bool("signature-socks5-detection-enabled", false, "Enables the socks5 detection signature")
-		socks5DetectionSignatureCacheSize  = command.Flags().Uint32("signature-socks5-detection-cache-size", 1024, "Configures the amount of state machine cache entries to detect socks5 information")
-		gitCloneDetectionSignatureEnabled  = command.Flags().Bool("signature-git-clone-detection-enabled", false, "Enables the git clone detection signature")
+		signatureEngineInputEventChanSize         = command.Flags().Int("signature-engine-input-queue-size", 1000, "Input queue size for the signature engine")
+		signatureEngineOutputEventChanSize        = command.Flags().Int("signature-engine-output-queue-size", 1000, "Output queue size for the signature engine")
+		socks5DetectionSignatureEnabled           = command.Flags().Bool("signature-socks5-detection-enabled", false, "Enables the socks5 detection signature")
+		socks5DetectionSignatureCacheSize         = command.Flags().Uint32("signature-socks5-detection-cache-size", 1024, "Configures the amount of state machine cache entries to detect socks5 information")
+		gitCloneDetectionSignatureEnabled         = command.Flags().Bool("signature-git-clone-detection-enabled", false, "Enables the git clone detection signature")
+		gitCloneDetectionSignatureRedactPasswords = command.Flags().Bool("signature-git-clone-detection-redact-password", true, "If enabled, any password passed via the URL gets redacted")
 
 		netflowEnabled                     = command.Flags().Bool("netflow-enabled", false, "Enables netflow tracking")
 		netflowSampleSubmitIntervalSeconds = command.Flags().Uint64("netflow-sample-submit-interval-seconds", 15, "Netflow sample submit interval")
@@ -188,6 +189,9 @@ func NewRunCommand(version string) *cobra.Command {
 						CacheSize: *socks5DetectionSignatureCacheSize,
 					},
 					GitCloneDetectedSignatureEnabled: *gitCloneDetectionSignatureEnabled,
+					GitCloneDetectedSignatureConfig: signature.GitCloneSignatureConfig{
+						RedactPasswords: *gitCloneDetectionSignatureRedactPasswords,
+					},
 				},
 			},
 			Castai: castaiClientCfg,

--- a/pkg/ebpftracer/signature/signature_rules.go
+++ b/pkg/ebpftracer/signature/signature_rules.go
@@ -6,6 +6,7 @@ type DefaultSignatureConfig struct {
 	SOCKS5DetectedSignatureEnabled   bool                           `json:"SOCKS5DetectedSignatureEnabled"`
 	SOCKS5DetectedSignatureConfig    SOCKS5DetectionSignatureConfig `json:"SOCKS5DetectedSignatureConfig"`
 	GitCloneDetectedSignatureEnabled bool                           `json:"GitCloneSignatureEnabled"`
+	GitCloneDetectedSignatureConfig  GitCloneSignatureConfig        `json:"GitCloneSignatureConfig"`
 }
 
 func DefaultSignatures(log *logging.Logger, cfg SignatureEngineConfig) ([]Signature, error) {
@@ -19,7 +20,7 @@ func DefaultSignatures(log *logging.Logger, cfg SignatureEngineConfig) ([]Signat
 	}
 
 	if cfg.DefaultSignatureConfig.GitCloneDetectedSignatureEnabled {
-		result = append(result, NewGitCloneDetectedSignature(log))
+		result = append(result, NewGitCloneDetectedSignature(log, cfg.DefaultSignatureConfig.GitCloneDetectedSignatureConfig))
 	}
 
 	return result, nil


### PR DESCRIPTION
In order to not leak password by sending them to cast backend, the git clone signature by default redacts passwords encoded in the git clone URL. This behaviour can be disabled by providing the following CLI arg `signature-git-clone-detection-redact-password=false`.