### PR TITLE
Allow setting additional environment variables

### DIFF
--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -126,6 +126,10 @@ spec:
             - name: KVISOR_EBPF_DEBUG
               value: "1"
           {{- end }}
+          {{- range $k, $v := .Values.agent.additionalEnv }}
+            - name: {{ $k }}
+              value: "{{ $v }}"
+          {{- end }}
           ports:
             - containerPort: {{.Values.agent.metricsHTTPListenPort}}
               name: metrics

--- a/charts/kvisor/templates/controller.yaml
+++ b/charts/kvisor/templates/controller.yaml
@@ -81,7 +81,7 @@ spec:
                      {{- else -}}
                        {{ .Values.castai.grpcAddr | quote }}
                      {{- end }}
-        {{- if .Values.castai.clusterIdSecretKeyRef.name }}
+          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
           {{- if ne .Values.castai.clusterID "" }}
           {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
           {{- end }}
@@ -99,15 +99,19 @@ spec:
               value: {{ .Values.castai.clusterID | quote }}
           {{- end }}
           {{- end }}
-        {{- range $key, $value := .Values.controller.extraEnv }}
+          {{- range $k, $v := .Values.controller.additionalEnv }}
+            - name: {{ $k }}
+              value: "{{ $v }}"
+          {{- end }}
+          {{- range $key, $value := .Values.controller.extraEnv }}
             - name: {{ $key }}
               value: {{ $value }}
-        {{- end }}
-        {{- if .Values.castai.enabled }}
+          {{- end }}
+          {{- if .Values.castai.enabled }}
           envFrom:
             - secretRef:
                 name: {{ include "kvisor.castaiSecretName" . }}
-        {{- end }}
+          {{- end }}
           ports:
             - name: http-server
               containerPort: {{ .Values.controller.httpListenPort }}

--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -133,6 +133,9 @@ agent:
   debug:
     ebpf: false
 
+  # Additional environment variables for the agent container.
+  additionalEnv: {}
+
 controller:
   enabled: true
 
@@ -194,6 +197,12 @@ controller:
 
   prometheusScrape:
     enabled: true
+
+  # Additional environment variables for the controller container.
+  additionalEnv: {}
+
+  # Deprecated: use additionalEnv instead.
+  extraEnv: {}
 
 eventGenerator:
   enabled: false


### PR DESCRIPTION
Deprecate `extraEnv` over `additionalEnv` for consistency with the rest of Cast components. For example https://github.com/castai/helm-charts/blob/main/charts/castai-agent/templates/deployment.yaml#L115-L118