### PR TITLE
Add a note for EU grpAddr for EU customers

### DIFF
--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -14,6 +14,7 @@ castai:
   apiKeySecretRef: ""
 
   # CASTAI grpc public api address.
+  # Note: If your cluster is in the EU region, update the grpcAddr to: https://kvisor.prod-eu.cast.ai:443
   grpcAddr: "kvisor.prod-master.cast.ai:443"
 
   # clusterID and clusterIdSecretKeyRef are mutually exclusive


### PR DESCRIPTION
Some EU customers don't know which grpAddr to use when installing the Kvsor..so adding this as a nite will help ..i have also suggested an edit to add the note on public docs