### PR TITLE
Fix GOROOT not being set in devbox shell environment

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -13,6 +13,9 @@
     "kind@0.27.0",
     "kubectl@1.32.2"
   ],
+  "env": {
+    "GOROOT": "$PWD/.devbox/nix/profile/default/share/go"
+  },
   "shell": {
     "init_hook": [
       "echo 'Welcome to devbox!' > /dev/null"


### PR DESCRIPTION
When you don't have a global installation of go toolchain and rely only on the one provided by devbox, there is no GOROOT variable set, so even though the go binary is in PATH, none of its commands work and fail with GOROOT not found.