### PR TITLE
Fix cgroups path for metrics scraping

### DIFF
--- a/cmd/agent/daemon/state/stats_pipeline.go
+++ b/cmd/agent/daemon/state/stats_pipeline.go
@@ -70,7 +70,11 @@ func (c *Controller) scrapeContainerResourcesStats(cont *containers.Container, b
 	cgStats, err := c.containersClient.GetCgroupStats(cont)
 	if err != nil {
 		if c.log.IsEnabled(slog.LevelDebug) {
-			c.log.Errorf("getting cgroup stats, container=%s(%s), cgroup_path=%s: %v", cont.Name, cont.ID, err)
+			var cgPath string
+			if cont.Cgroup != nil {
+				cgPath = cont.Cgroup.Path
+			}
+			c.log.Warnf("getting cgroup stats, container=%s(%s), cgroup_path=%s: %v", cont.Name, cont.ID, cgPath, err)
 		}
 		if !errors.Is(err, cgroup.ErrStatsNotFound) {
 			metrics.AgentStatsScrapeErrorsTotal.WithLabelValues("container").Inc()

--- a/cmd/agent/daemon/state/stats_pipeline.go
+++ b/cmd/agent/daemon/state/stats_pipeline.go
@@ -69,13 +69,12 @@ func (c *Controller) scrapeContainersResourceStats(batch *castaipb.StatsBatch) {
 func (c *Controller) scrapeContainerResourcesStats(cont *containers.Container, batch *castaipb.StatsBatch) {
 	cgStats, err := c.containersClient.GetCgroupStats(cont)
 	if err != nil {
-		if errors.Is(err, cgroup.ErrStatsNotFound) {
-			return
-		}
 		if c.log.IsEnabled(slog.LevelDebug) {
-			c.log.Errorf("getting cgroup stats for container %q: %v", cont.Name, err)
+			c.log.Errorf("getting cgroup stats, container=%s(%s), cgroup_path=%s: %v", cont.Name, cont.ID, err)
 		}
-		metrics.AgentStatsScrapeErrorsTotal.WithLabelValues("container").Inc()
+		if !errors.Is(err, cgroup.ErrStatsNotFound) {
+			metrics.AgentStatsScrapeErrorsTotal.WithLabelValues("container").Inc()
+		}
 		return
 	}
 

--- a/pkg/castai/prommetrics_exporter_test.go
+++ b/pkg/castai/prommetrics_exporter_test.go
@@ -37,7 +37,7 @@ func TestPrometheusExporter(t *testing.T) {
 	exp := NewPromMetricsExporter(log, logsExp, prometheus.DefaultGatherer, PromMetricsExporterConfig{
 		MetricsPrefix:  "kvisor_test",
 		PodName:        "pod1",
-		ExportInterval: time.Millisecond,
+		ExportInterval: 10 * time.Millisecond,
 	})
 	ctx, cancel := context.WithCancel(context.Background())
 	go exp.Run(ctx)
@@ -46,7 +46,7 @@ func TestPrometheusExporter(t *testing.T) {
 		logsExp.mu.Lock()
 		defer logsExp.mu.Unlock()
 		return len(logsExp.logs) == 2
-	}, time.Second, time.Millisecond)
+	}, time.Second, 1*time.Millisecond)
 
 	cancel()
 

--- a/pkg/cgroup/cgroup.go
+++ b/pkg/cgroup/cgroup.go
@@ -24,6 +24,7 @@ type Cgroup struct {
 	Id               uint64
 	ContainerRuntime ContainerRuntimeID
 	ContainerID      string
+	Path             string
 
 	statsGetterFunc func(stats *Stats) error
 }

--- a/pkg/cgroup/client.go
+++ b/pkg/cgroup/client.go
@@ -171,6 +171,7 @@ func (c *Client) getCgroupForIDAndPath(cgroupID ID, cgroupPath string) *Cgroup {
 		Id:               cgroupID,
 		ContainerID:      containerID,
 		ContainerRuntime: containerRuntime,
+		Path:             cgroupPath,
 		statsGetterFunc:  newCgroupStatsGetterFunc(c.version, c.psiEnabled, c.cgRoot, cgroupPath),
 	}
 }

--- a/pkg/cgroup/client.go
+++ b/pkg/cgroup/client.go
@@ -167,12 +167,6 @@ func (c *Client) LoadCgroupByContainerID(containerID string) (*Cgroup, error) {
 func (c *Client) loadCgroupForIDAndPath(cgroupID ID, cgroupPath string) *Cgroup {
 	containerID, containerRuntime := GetContainerIdFromCgroup(cgroupPath)
 
-	// If cgroup is loaded by received eBPF cgroup mkdir event it's path may not always point to full cgroup path on the filesystem.
-	// We always need to have full path since it's used for container stats scraping.
-	if !strings.HasPrefix(cgroupPath, c.cgRoot) {
-		cgroupPath = filepath.Join(c.cgRoot, cgroupPath)
-	}
-
 	return &Cgroup{
 		Id:               cgroupID,
 		ContainerID:      containerID,
@@ -407,16 +401,6 @@ func GetContainerIdFromCgroup(cgroupPath string) (string, ContainerRuntimeID) {
 
 	// cgroup dirs unrelated to containers provides empty (containerId, runtime)
 	return "", UnknownRuntime
-}
-
-func (c *Client) LoadCgroup(id ID, path string) {
-	c.cgroupMu.Lock()
-	defer c.cgroupMu.Unlock()
-
-	c.cgroupCacheByID[id] = sync.OnceValue(func() *Cgroup {
-		cgroup := c.loadCgroupForIDAndPath(id, path)
-		return cgroup
-	})
 }
 
 func (c *Client) cacheCgroup(cgroup *Cgroup) {

--- a/pkg/cgroup/client.go
+++ b/pkg/cgroup/client.go
@@ -164,6 +164,20 @@ func (c *Client) LoadCgroupByContainerID(containerID string) (*Cgroup, error) {
 	return cgroup, nil
 }
 
+func (c *Client) LoadCgroup(id ID, path string) {
+	c.cgroupMu.Lock()
+	defer c.cgroupMu.Unlock()
+
+	if !strings.HasPrefix(path, c.cgRoot) {
+		path = filepath.Join(c.cgRoot, path)
+	}
+
+	c.cgroupCacheByID[id] = sync.OnceValue(func() *Cgroup {
+		cgroup := c.loadCgroupForIDAndPath(id, path)
+		return cgroup
+	})
+}
+
 func (c *Client) loadCgroupForIDAndPath(cgroupID ID, cgroupPath string) *Cgroup {
 	containerID, containerRuntime := GetContainerIdFromCgroup(cgroupPath)
 

--- a/pkg/containers/client.go
+++ b/pkg/containers/client.go
@@ -196,7 +196,7 @@ func (c *Client) AddContainerByCgroupID(ctx context.Context, cgroupID cgroup.ID)
 		}
 	}()
 
-	cg, err := c.cgroupClient.GetCgroupByID(cgroupID)
+	cg, err := c.cgroupClient.LoadCgroupByID(cgroupID)
 	// The found cgroup is not a container.
 	if err != nil || cg.ContainerID == "" {
 		return nil, ErrContainerNotFound
@@ -222,7 +222,7 @@ func (c *Client) AddContainerByCgroupID(ctx context.Context, cgroupID cgroup.ID)
 }
 
 func (c *Client) addContainer(cont *criapi.Container) error {
-	cg, err := c.cgroupClient.GetCgroupByContainerID(cont.Id)
+	cg, err := c.cgroupClient.LoadCgroupByContainerID(cont.Id)
 	if err != nil || cg.ContainerID == "" {
 		if errors.Is(err, cgroup.ErrCgroupNotFound) {
 			return ErrContainerNotFound

--- a/pkg/ebpftracer/tracer.go
+++ b/pkg/ebpftracer/tracer.go
@@ -39,7 +39,6 @@ type ContainerClient interface {
 
 type CgroupClient interface {
 	GetCgroupsRootPath() string
-	LoadCgroup(id cgroup.ID, path string)
 	CleanupCgroup(cgroup cgroup.ID)
 	IsDefaultHierarchy(uint32) bool
 }

--- a/pkg/ebpftracer/tracer.go
+++ b/pkg/ebpftracer/tracer.go
@@ -39,6 +39,7 @@ type ContainerClient interface {
 
 type CgroupClient interface {
 	GetCgroupsRootPath() string
+	LoadCgroup(id cgroup.ID, path string)
 	CleanupCgroup(cgroup cgroup.ID)
 	IsDefaultHierarchy(uint32) bool
 }

--- a/pkg/ebpftracer/tracer_decode.go
+++ b/pkg/ebpftracer/tracer_decode.go
@@ -133,6 +133,7 @@ func (t *Tracer) handleCgroupMkdirEvent(eventCtx *types.EventContext, parsedArgs
 	if !t.cfg.CgroupClient.IsDefaultHierarchy(args.HierarchyId) {
 		return nil
 	}
+	t.log.Infof("handling cgroup mkdir event for cgroup=%d, path=%s", args.CgroupId, args.CgroupPath)
 
 	if _, err := t.cfg.ContainerClient.AddContainerByCgroupID(context.Background(), args.CgroupId); err != nil {
 		if errors.Is(err, containers.ErrContainerNotFound) {

--- a/pkg/ebpftracer/tracer_decode.go
+++ b/pkg/ebpftracer/tracer_decode.go
@@ -133,8 +133,8 @@ func (t *Tracer) handleCgroupMkdirEvent(eventCtx *types.EventContext, parsedArgs
 	if !t.cfg.CgroupClient.IsDefaultHierarchy(args.HierarchyId) {
 		return nil
 	}
-	t.log.Infof("handling cgroup mkdir event for cgroup=%d, path=%s", args.CgroupId, args.CgroupPath)
 
+	t.cfg.CgroupClient.LoadCgroup(args.CgroupId, args.CgroupPath)
 	if _, err := t.cfg.ContainerClient.AddContainerByCgroupID(context.Background(), args.CgroupId); err != nil {
 		if errors.Is(err, containers.ErrContainerNotFound) {
 			err := t.MuteEventsFromCgroup(eventCtx.CgroupID, "container not found during cgroup mkdir event")

--- a/pkg/ebpftracer/tracer_decode.go
+++ b/pkg/ebpftracer/tracer_decode.go
@@ -133,7 +133,7 @@ func (t *Tracer) handleCgroupMkdirEvent(eventCtx *types.EventContext, parsedArgs
 	if !t.cfg.CgroupClient.IsDefaultHierarchy(args.HierarchyId) {
 		return nil
 	}
-	t.cfg.CgroupClient.LoadCgroup(args.CgroupId, args.CgroupPath)
+
 	if _, err := t.cfg.ContainerClient.AddContainerByCgroupID(context.Background(), args.CgroupId); err != nil {
 		if errors.Is(err, containers.ErrContainerNotFound) {
 			err := t.MuteEventsFromCgroup(eventCtx.CgroupID, "container not found during cgroup mkdir event")


### PR DESCRIPTION
eBPF cgroup mkdir event's path doesn't always point to correct cgroup path on the file system. This leads to some metrics being skipped.