### PR TITLE
Move configs to different packages

### DIFF
--- a/cmd/agent/daemon/config/config.go
+++ b/cmd/agent/daemon/config/config.go
@@ -1,0 +1,76 @@
+package config
+
+import (
+	"regexp"
+	"time"
+
+	"github.com/castai/kvisor/cmd/agent/daemon/state"
+	"github.com/castai/kvisor/pkg/castai"
+	"github.com/castai/kvisor/pkg/ebpftracer"
+	"github.com/castai/kvisor/pkg/ebpftracer/signature"
+)
+
+type EBPFMetricsConfig struct {
+	TracerMetricsEnabled  bool `json:"TracerMetricsEnabled"`
+	ProgramMetricsEnabled bool `json:"ProgramMetricsEnabled"`
+}
+
+type Config struct {
+	LogLevel                       string                          `json:"logLevel"`
+	LogRateInterval                time.Duration                   `json:"logRateInterval"`
+	LogRateBurst                   int                             `json:"logRateBurst"`
+	SendLogsLevel                  string                          `json:"sendLogsLevel"`
+	PromMetricsExportEnabled       bool                            `json:"promMetricsExportEnabled"`
+	PromMetricsExportInterval      time.Duration                   `json:"promMetricsExportInterval"`
+	Version                        string                          `json:"version"`
+	BTFPath                        string                          `json:"BTFPath"`
+	ContainerdSockPath             string                          `json:"containerdSockPath"`
+	HostCgroupsDir                 string                          `json:"hostCgroupsDir"`
+	MetricsHTTPListenPort          int                             `json:"metricsHTTPListenPort"`
+	State                          state.Config                    `json:"state"`
+	StatsEnabled                   bool                            `json:"statsEnabled"`
+	EBPFEventsEnabled              bool                            `json:"EBPFEventsEnabled"`
+	EBPFEventsOutputChanSize       int                             `validate:"required" json:"EBPFEventsOutputChanSize"`
+	EBPFEventsStdioExporterEnabled bool                            `json:"EBPFEventsStdioExporterEnabled"`
+	EBPFMetrics                    EBPFMetricsConfig               `json:"EBPFMetrics"`
+	EBPFEventsPolicyConfig         ebpftracer.EventsPolicyConfig   `json:"EBPFEventsPolicyConfig"`
+	EBPFSignalEventsRingBufferSize uint32                          `json:"EBPFSignalEventsRingBufferSize"`
+	EBPFEventsRingBufferSize       uint32                          `json:"EBPFEventsRingBufferSize"`
+	EBPFSkbEventsRingBufferSize    uint32                          `json:"EBPFSkbEventsRingBufferSize"`
+	MutedNamespaces                []string                        `json:"mutedNamespaces"`
+	SignatureEngineConfig          signature.SignatureEngineConfig `json:"signatureEngineConfig"`
+	Castai                         castai.Config                   `json:"castai"`
+	EnricherConfig                 EnricherConfig                  `json:"enricherConfig"`
+	Netflow                        NetflowConfig                   `json:"netflow"`
+	ProcessTree                    ProcessTreeConfig               `json:"processTree"`
+	Clickhouse                     ClickhouseConfig                `json:"clickhouse"`
+	KubeAPIServiceAddr             string                          `json:"kubeAPIServiceAddr"`
+	ExportersQueueSize             int                             `validate:"required" json:"exportersQueueSize"`
+	AutomountCgroupv2              bool                            `json:"automountCgroupv2"`
+	CRIEndpoint                    string                          `json:"criEndpoint"`
+	EventLabels                    []string                        `json:"eventLabels"`
+	EventAnnotations               []string                        `json:"eventAnnotations"`
+	ContainersRefreshInterval      time.Duration                   `json:"containersRefreshInterval"`
+}
+
+type EnricherConfig struct {
+	EnableFileHashEnricher     bool           `json:"enableFileHashEnricher"`
+	RedactSensitiveValuesRegex *regexp.Regexp `json:"redactSensitiveValuesRegex"`
+}
+
+type NetflowConfig struct {
+	Enabled                     bool                       `json:"enabled"`
+	SampleSubmitIntervalSeconds uint64                     `json:"sampleSubmitIntervalSeconds"`
+	Grouping                    ebpftracer.NetflowGrouping `json:"grouping"`
+}
+
+type ClickhouseConfig struct {
+	Addr     string `json:"addr"`
+	Database string `json:"database"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+}
+
+type ProcessTreeConfig struct {
+	Enabled bool `json:"enabled"`
+}

--- a/cmd/agent/daemon/daemon.go
+++ b/cmd/agent/daemon/daemon.go
@@ -151,26 +151,25 @@ func NewRunCommand(version string) *cobra.Command {
 			}
 		}
 
-		_ = state.Config{
-			StatsScrapeInterval:   *statsScrapeInterval,
-			NetflowExportInterval: *netflowExportInterval,
-			EventsBatchSize:       *eventsBatchSize,
-			EventsFlushInterval:   *eventsFlushInterval,
-		}
-
 		if err := app.New(&config.Config{
-			LogLevel:                       *logLevel,
-			LogRateInterval:                *logRateInterval,
-			LogRateBurst:                   *logRateBurst,
-			SendLogsLevel:                  *sendLogLevel,
-			PromMetricsExportEnabled:       *promMetricsExportEnabled,
-			PromMetricsExportInterval:      *promMetricsExportInterval,
-			Version:                        version,
-			BTFPath:                        *btfPath,
-			ContainerdSockPath:             *containerdSockPath,
-			HostCgroupsDir:                 *hostCgroupsDir,
-			MetricsHTTPListenPort:          *metricsHTTPListenPort,
-			StatsEnabled:                   *statsEnabled,
+			LogLevel:                  *logLevel,
+			LogRateInterval:           *logRateInterval,
+			LogRateBurst:              *logRateBurst,
+			SendLogsLevel:             *sendLogLevel,
+			PromMetricsExportEnabled:  *promMetricsExportEnabled,
+			PromMetricsExportInterval: *promMetricsExportInterval,
+			Version:                   version,
+			BTFPath:                   *btfPath,
+			ContainerdSockPath:        *containerdSockPath,
+			HostCgroupsDir:            *hostCgroupsDir,
+			MetricsHTTPListenPort:     *metricsHTTPListenPort,
+			StatsEnabled:              *statsEnabled,
+			State: state.Config{
+				StatsScrapeInterval:   *statsScrapeInterval,
+				NetflowExportInterval: *netflowExportInterval,
+				EventsBatchSize:       *eventsBatchSize,
+				EventsFlushInterval:   *eventsFlushInterval,
+			},
 			EBPFEventsEnabled:              *ebpfEventsEnabled,
 			EBPFEventsStdioExporterEnabled: *ebpfEventsStdioExporterEnabled,
 			EBPFEventsOutputChanSize:       *ebpfEventsOutputChanSize,

--- a/cmd/agent/daemon/daemon.go
+++ b/cmd/agent/daemon/daemon.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/castai/kvisor/cmd/agent/daemon/app"
+	"github.com/castai/kvisor/cmd/agent/daemon/config"
 	"github.com/castai/kvisor/cmd/agent/daemon/state"
 	"github.com/castai/kvisor/pkg/castai"
 	"github.com/castai/kvisor/pkg/ebpftracer"
@@ -150,29 +151,30 @@ func NewRunCommand(version string) *cobra.Command {
 			}
 		}
 
-		if err := app.New(&app.Config{
-			LogLevel:                  *logLevel,
-			LogRateInterval:           *logRateInterval,
-			LogRateBurst:              *logRateBurst,
-			SendLogsLevel:             *sendLogLevel,
-			PromMetricsExportEnabled:  *promMetricsExportEnabled,
-			PromMetricsExportInterval: *promMetricsExportInterval,
-			Version:                   version,
-			BTFPath:                   *btfPath,
-			ContainerdSockPath:        *containerdSockPath,
-			HostCgroupsDir:            *hostCgroupsDir,
-			MetricsHTTPListenPort:     *metricsHTTPListenPort,
-			StatsEnabled:              *statsEnabled,
-			State: state.Config{
-				StatsScrapeInterval:   *statsScrapeInterval,
-				NetflowExportInterval: *netflowExportInterval,
-				EventsBatchSize:       *eventsBatchSize,
-				EventsFlushInterval:   *eventsFlushInterval,
-			},
+		_ = state.Config{
+			StatsScrapeInterval:   *statsScrapeInterval,
+			NetflowExportInterval: *netflowExportInterval,
+			EventsBatchSize:       *eventsBatchSize,
+			EventsFlushInterval:   *eventsFlushInterval,
+		}
+
+		if err := app.New(&config.Config{
+			LogLevel:                       *logLevel,
+			LogRateInterval:                *logRateInterval,
+			LogRateBurst:                   *logRateBurst,
+			SendLogsLevel:                  *sendLogLevel,
+			PromMetricsExportEnabled:       *promMetricsExportEnabled,
+			PromMetricsExportInterval:      *promMetricsExportInterval,
+			Version:                        version,
+			BTFPath:                        *btfPath,
+			ContainerdSockPath:             *containerdSockPath,
+			HostCgroupsDir:                 *hostCgroupsDir,
+			MetricsHTTPListenPort:          *metricsHTTPListenPort,
+			StatsEnabled:                   *statsEnabled,
 			EBPFEventsEnabled:              *ebpfEventsEnabled,
 			EBPFEventsStdioExporterEnabled: *ebpfEventsStdioExporterEnabled,
 			EBPFEventsOutputChanSize:       *ebpfEventsOutputChanSize,
-			EBPFMetrics: app.EBPFMetricsConfig{
+			EBPFMetrics: config.EBPFMetricsConfig{
 				TracerMetricsEnabled:  *ebpfTracerMetricsEnabled,
 				ProgramMetricsEnabled: *ebpfProgramMetricsEnabled,
 			},
@@ -198,22 +200,22 @@ func NewRunCommand(version string) *cobra.Command {
 				},
 			},
 			Castai: castaiClientCfg,
-			EnricherConfig: app.EnricherConfig{
+			EnricherConfig: config.EnricherConfig{
 				EnableFileHashEnricher:     *fileHashEnrichedEnabled,
 				RedactSensitiveValuesRegex: redactSensitiveValuesRegex,
 			},
-			Netflow: app.NetflowConfig{
+			Netflow: config.NetflowConfig{
 				Enabled:                     *netflowEnabled,
 				SampleSubmitIntervalSeconds: *netflowSampleSubmitIntervalSeconds,
 				Grouping:                    netflowGrouping,
 			},
-			Clickhouse: app.ClickhouseConfig{
+			Clickhouse: config.ClickhouseConfig{
 				Addr:     *clickhouseAddr,
 				Database: *clickhouseDatabase,
 				Username: *clickhouseUsername,
 				Password: os.Getenv("CLICKHOUSE_PASSWORD"),
 			},
-			ProcessTree: app.ProcessTreeConfig{
+			ProcessTree: config.ProcessTreeConfig{
 				Enabled: *processTreeEnabled,
 			},
 			KubeAPIServiceAddr:        *kubeAPIServiceAddr,

--- a/cmd/controller/app/app.go
+++ b/cmd/controller/app/app.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	kubepb "github.com/castai/kvisor/api/v1/kube"
+	"github.com/castai/kvisor/cmd/controller/config"
 	"github.com/castai/kvisor/cmd/controller/kube"
 	"github.com/castai/kvisor/cmd/controller/state"
 	"github.com/castai/kvisor/cmd/controller/state/imagescan"
@@ -34,42 +35,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
-type Config struct {
-	// Logging configuration.
-	LogLevel        string        `json:"logLevel"`
-	LogRateInterval time.Duration `json:"logRateInterval"`
-	LogRateBurst    int           `json:"logRateBurst"`
-
-	PromMetricsExportEnabled  bool          `json:"promMetricsExportEnabled"`
-	PromMetricsExportInterval time.Duration `json:"promMetricsExportInterval"`
-
-	// Built binary version.
-	Version      string `json:"version"`
-	ChartVersion string `json:"chartVersion"`
-
-	// Current running pod metadata.
-	PodNamespace string `validate:"required" json:"podNamespace"`
-	PodName      string `validate:"required" json:"podName"`
-
-	// HTTPListenPort is internal http servers listen port.
-	HTTPListenPort        int `validate:"required" json:"HTTPListenPort"`
-	MetricsHTTPListenPort int `json:"metricsHTTPListenPort"`
-	KubeServerListenPort  int `validate:"required" json:"kubeServerListenPort"`
-
-	CastaiController state.CastaiConfig      `json:"castaiController"`
-	CastaiEnv        castai.Config           `json:"castaiEnv"`
-	ImageScan        imagescan.Config        `json:"imageScan"`
-	Linter           kubelinter.Config       `json:"linter"`
-	KubeBench        kubebench.Config        `json:"kubeBench"`
-	JobsCleanup      state.JobsCleanupConfig `json:"jobsCleanup"`
-	AgentConfig      AgentConfig             `json:"agentConfig"`
-}
-
-type AgentConfig struct {
-	Enabled bool `json:"enabled"`
-}
-
-func New(cfg Config, clientset kubernetes.Interface) *App {
+func New(cfg config.Config, clientset kubernetes.Interface) *App {
 	if err := validator.New().Struct(cfg); err != nil {
 		panic(fmt.Errorf("invalid config: %w", err).Error())
 	}
@@ -77,7 +43,7 @@ func New(cfg Config, clientset kubernetes.Interface) *App {
 }
 
 type App struct {
-	cfg Config
+	cfg config.Config
 
 	kubeClient kubernetes.Interface
 }

--- a/cmd/controller/config/config.go
+++ b/cmd/controller/config/config.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"time"
+
+	"github.com/castai/kvisor/cmd/controller/state"
+	"github.com/castai/kvisor/cmd/controller/state/imagescan"
+	"github.com/castai/kvisor/cmd/controller/state/kubebench"
+	"github.com/castai/kvisor/cmd/controller/state/kubelinter"
+	"github.com/castai/kvisor/pkg/castai"
+)
+
+type Config struct {
+	// Logging configuration.
+	LogLevel        string        `json:"logLevel"`
+	LogRateInterval time.Duration `json:"logRateInterval"`
+	LogRateBurst    int           `json:"logRateBurst"`
+
+	PromMetricsExportEnabled  bool          `json:"promMetricsExportEnabled"`
+	PromMetricsExportInterval time.Duration `json:"promMetricsExportInterval"`
+
+	// Built binary version.
+	Version      string `json:"version"`
+	ChartVersion string `json:"chartVersion"`
+
+	// Current running pod metadata.
+	PodNamespace string `validate:"required" json:"podNamespace"`
+	PodName      string `validate:"required" json:"podName"`
+
+	// HTTPListenPort is internal http servers listen port.
+	HTTPListenPort        int `validate:"required" json:"HTTPListenPort"`
+	MetricsHTTPListenPort int `json:"metricsHTTPListenPort"`
+	KubeServerListenPort  int `validate:"required" json:"kubeServerListenPort"`
+
+	CastaiController state.CastaiConfig      `json:"castaiController"`
+	CastaiEnv        castai.Config           `json:"castaiEnv"`
+	ImageScan        imagescan.Config        `json:"imageScan"`
+	Linter           kubelinter.Config       `json:"linter"`
+	KubeBench        kubebench.Config        `json:"kubeBench"`
+	JobsCleanup      state.JobsCleanupConfig `json:"jobsCleanup"`
+	AgentConfig      AgentConfig             `json:"agentConfig"`
+}
+
+type AgentConfig struct {
+	Enabled bool `json:"enabled"`
+}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/castai/kvisor/cmd/controller/config"
 	"github.com/castai/kvisor/cmd/controller/state/imagescan"
 	"github.com/castai/kvisor/cmd/controller/state/kubebench"
 	"github.com/castai/kvisor/cmd/controller/state/kubelinter"
@@ -161,7 +162,7 @@ func main() {
 	if podName == "" {
 		podName = "localenv"
 	}
-	appInstance := app.New(app.Config{
+	appInstance := app.New(config.Config{
 		LogLevel:                  *logLevel,
 		LogRateInterval:           *logRateInterval,
 		LogRateBurst:              *logRateBurst,
@@ -221,7 +222,7 @@ func main() {
 			CleanupJobAge:   *jobsCleanupJobAge,
 			Namespace:       podNs,
 		},
-		AgentConfig: app.AgentConfig{
+		AgentConfig: config.AgentConfig{
 			Enabled: *agentEnabled,
 		},
 	},


### PR DESCRIPTION
Currently we have global app config in the app package. It's not possible to reuse specific sub configs in our controllers.
For example I can't access NetflowConfig struct from netflow pipeline. We used to have a workaround by creating a state.Config struct. By moving to separate package we can reuse subconfigs in controllers.