### PR TITLE
Add envFrom support to helm charts

### DIFF
--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -72,18 +72,21 @@ spec:
             - "--clickhouse-username={{.Values.clickhouse.auth.username}}"
           {{- end }}
             - "--kube-api-service-addr={{ include "kvisor.controller.fullname" .}}.{{.Release.Namespace}}:{{ .Values.controller.kubeAPIListenPort }}"
-        {{- range $key, $value := .Values.agent.extraArgs }}
+          {{- range $key, $value := .Values.agent.extraArgs }}
             - "--{{ $key }}={{ $value }}"
-        {{- end }}
+          {{- end }}
           envFrom:
-        {{- if .Values.castai.enabled }}
+          {{- with .Values.agent.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.castai.enabled }}
             - secretRef:
                 name: {{ include "kvisor.castaiSecretName" . }}
-        {{- end }}
-        {{- if.Values.clickhouse.enabled }}
+          {{- end }}
+          {{- if.Values.clickhouse.enabled }}
             - secretRef:
                 name:  {{ include "kvisor.clickhouse.fullname" . }}
-        {{- end }}
+          {{- end }}
           env:
             {{- include "GOMEMLIMITEnv" .Values.agent.resources.limits.memory | nindent 12 }}
             - name: NODE_NAME

--- a/charts/kvisor/templates/controller.yaml
+++ b/charts/kvisor/templates/controller.yaml
@@ -107,8 +107,11 @@ spec:
             - name: {{ $key }}
               value: {{ $value }}
           {{- end }}
-          {{- if .Values.castai.enabled }}
           envFrom:
+          {{- with .Values.controller.envFrom }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- if .Values.castai.enabled }}
             - secretRef:
                 name: {{ include "kvisor.castaiSecretName" . }}
           {{- end }}

--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -137,6 +137,9 @@ agent:
   # Additional environment variables for the agent container.
   additionalEnv: {}
 
+  # Additional environment variables for the agent container via configMaps or secrets.
+  envFrom: []
+
 controller:
   enabled: true
 
@@ -201,6 +204,9 @@ controller:
 
   # Additional environment variables for the controller container.
   additionalEnv: {}
+
+  # Additional environment variables for the controller container via configMaps or secrets.
+  envFrom: []
 
   # Deprecated: use additionalEnv instead.
   extraEnv: {}


### PR DESCRIPTION
The change has been tested using the following command:
```sh
$ helm template castai-kvisor charts/kvisor -f - <<EOF
castai:
  enabled: true
  apiKey: foo
  clusterID: foo
controller:
  envFrom:
    - secretRef:
        name: testing-secret
agent:
  enabled: true
  envFrom:
    - secretRef:
        name: testing-secret
EOF
```

And verifying the `envFrom` data is added to the controller and agent deployments:
```yaml
---
kind: Deployment
metadata:
  name: castai-kvisor-controller
spec:
  template:
    spec:
      containers:
        - name: controller
          envFrom:
            - secretRef:
                name: testing-secret
            - secretRef:
                name: castai-kvisor

---
kind: DaemonSet
metadata:
  name: castai-kvisor-agent
spec:
  template:
    spec:
      containers:
        - name: kvisor
          envFrom:
            - secretRef:
                name: testing-secret
            - secretRef:
                name: castai-kvisor
```