### PR TITLE
Refactor netflows collector return types

### DIFF
--- a/cmd/agent/daemon/state/controller.go
+++ b/cmd/agent/daemon/state/controller.go
@@ -57,7 +57,7 @@ type ebpfTracer interface {
 	UnmuteEventsFromCgroups(cgroups []uint64) error
 	IsCgroupMuted(cgroup uint64) bool
 	ReadSyscallStats() (map[ebpftracer.SyscallStatsKeyCgroupID][]ebpftracer.SyscallStats, error)
-	CollectNetworkSummary() (map[ebpftracer.TrafficKey]ebpftracer.TrafficSummary, error)
+	CollectNetworkSummary() ([]ebpftracer.TrafficKey, []ebpftracer.TrafficSummary, error)
 	GetEventName(id events.ID) string
 }
 

--- a/pkg/ebpftracer/network_tracer.go
+++ b/pkg/ebpftracer/network_tracer.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"slices"
 
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
@@ -37,54 +38,54 @@ func buildNetworkSummaryBufferMap(originalSpec *ebpf.MapSpec) (*ebpf.Map, error)
 type TrafficSummary tracerTrafficSummary
 type TrafficKey tracerIpKey
 
-func (t *Tracer) CollectNetworkSummary() (map[TrafficKey]TrafficSummary, error) {
+func (t *Tracer) CollectNetworkSummary() ([]TrafficKey, []TrafficSummary, error) {
 	var config tracerConfigT
 
 	zero := uint32(0)
 
 	err := t.module.objects.ConfigMap.Lookup(zero, &config)
 	if err != nil {
-		return nil, fmt.Errorf("error while config lookup: %w", err)
+		return nil, nil, fmt.Errorf("error while config lookup: %w", err)
 	}
 
 	numEntries := t.module.objects.NetworkTrafficBufferMap.MaxEntries()
 	indexToCollect := config.SummaryMapIndex
 
-  config.SummaryMapIndex = (config.SummaryMapIndex + 1) % int32(numEntries) // nolint:gosec
+	config.SummaryMapIndex = (config.SummaryMapIndex + 1) % int32(numEntries) // nolint:gosec
 
 	err = t.module.objects.ConfigMap.Update(zero, &config, ebpf.UpdateExist)
 	if err != nil {
-		return nil, fmt.Errorf("error while updating config: %w", err)
+		return nil, nil, fmt.Errorf("error while updating config: %w", err)
 	}
 
 	innerMapSpec := t.module.networkTrafficSummaryMapSpec.InnerMap.Copy()
 	if innerMapSpec == nil {
-		return nil, errors.New("error: no inner map spec for `networkTrafficSummary`")
+		return nil, nil, errors.New("error: no inner map spec for `networkTrafficSummary`")
 	}
 	innerMapSpec.Name = fmt.Sprintf("nt_sum_%d", indexToCollect)
 
 	newMap, err := ebpf.NewMap(innerMapSpec)
 	if err != nil {
-		return nil, fmt.Errorf("error while creating new inner map: %w", err)
+		return nil, nil, fmt.Errorf("error while creating new inner map: %w", err)
 	}
 	defer newMap.Close()
 
 	var summaryMap *ebpf.Map
 	err = t.module.objects.NetworkTrafficBufferMap.Lookup(indexToCollect, &summaryMap)
 	if err != nil {
-		return nil, fmt.Errorf("error while getting existing map: %w", err)
+		return nil, nil, fmt.Errorf("error while getting existing map: %w", err)
 	}
 	defer summaryMap.Close()
 
 	err = t.module.objects.NetworkTrafficBufferMap.Update(indexToCollect, newMap, ebpf.UpdateAny)
 	if err != nil {
-		return nil, fmt.Errorf("error while replacing existing map: %w", err)
+		return nil, nil, fmt.Errorf("error while replacing existing map: %w", err)
 	}
 
 	batchSize := startingChunkSize(int(summaryMap.MaxEntries()))
 	const maxRetries = 3
 	for i := 0; i < maxRetries; i++ {
-		result, err := collectEntriesBatch(summaryMap, batchSize)
+		resKeys, resVals, err := collectEntriesBatch(summaryMap, batchSize)
 
 		if err != nil {
 			// Lookup batch on LRU hash map may fail if the buffer passed is not big enough to
@@ -101,7 +102,7 @@ func (t *Tracer) CollectNetworkSummary() (map[TrafficKey]TrafficSummary, error) 
 			}
 		}
 
-		return result, nil
+		return resKeys, resVals, nil
 	}
 
 	t.log.Error("collecting network summary in batch was not successful, falling back to slower iterator approach.")
@@ -110,47 +111,54 @@ func (t *Tracer) CollectNetworkSummary() (map[TrafficKey]TrafficSummary, error) 
 	return collectEntriesIterator(summaryMap)
 }
 
-func collectEntriesBatch(summaryMap *ebpf.Map, batchSize int) (map[TrafficKey]TrafficSummary, error) {
+func collectEntriesBatch(summaryMap *ebpf.Map, batchSize int) ([]TrafficKey, []TrafficSummary, error) {
 	kout := make([]TrafficKey, batchSize)
 	vout := make([]TrafficSummary, batchSize)
-	result := map[TrafficKey]TrafficSummary{}
+
+	resKeys := make([]TrafficKey, 0)
+	resVals := make([]TrafficSummary, 0)
 
 	var cursor ebpf.MapBatchCursor
 
 	for {
 		count, err := summaryMap.BatchLookup(&cursor, kout, vout, nil)
 
+		resKeys = slices.Grow(resKeys, count)
+		resVals = slices.Grow(resVals, count)
 		for i := 0; i < count; i++ {
-			result[kout[i]] = vout[i]
+			resKeys = append(resKeys, kout[i])
+			resVals = append(resVals, vout[i])
 		}
 
 		if err != nil {
 			// When the iteration is done, BatchLookup will return a ErrKeyNotExist.
 			if errors.Is(err, ebpf.ErrKeyNotExist) {
-				return result, nil
+				return resKeys, resVals, nil
 			}
 
-			return nil, err
+			return nil, nil, err
 		}
 	}
 }
 
-func collectEntriesIterator(summaryMap *ebpf.Map) (map[TrafficKey]TrafficSummary, error) {
+func collectEntriesIterator(summaryMap *ebpf.Map) ([]TrafficKey, []TrafficSummary, error) {
 	iter := summaryMap.Iterate()
 	var ipKey TrafficKey
 	var trafficSummary TrafficSummary
 
-	result := map[TrafficKey]TrafficSummary{}
+	resKeys := make([]TrafficKey, 0)
+	resVals := make([]TrafficSummary, 0)
 
 	for iter.Next(&ipKey, &trafficSummary) {
-		result[ipKey] = trafficSummary
+		resKeys = append(resKeys, ipKey)
+		resVals = append(resVals, trafficSummary)
 	}
 
 	if err := iter.Err(); err != nil {
-		return nil, fmt.Errorf("iterator finished with error: %w", err)
+		return nil, nil, fmt.Errorf("iterator finished with error: %w", err)
 	}
 
-	return result, nil
+	return resKeys, resVals, nil
 }
 
 func startingChunkSize(maxEntries int) int {

--- a/pkg/ebpftracer/tracer_playground_test.go
+++ b/pkg/ebpftracer/tracer_playground_test.go
@@ -169,18 +169,19 @@ func printNetworkTracerSummary(ctx context.Context, log *logging.Logger, t *ebpf
 		case <-ctx.Done():
 			return nil
 		case <-ticker.C:
-			data, err := t.CollectNetworkSummary()
+			keys, vals, err := t.CollectNetworkSummary()
 			if err != nil {
 				log.Errorf("error while collecting network traffic summary: %v", err)
 				continue
 			}
 
 			fmt.Println("=== Network Summary")
-			for tk, ts := range data {
+			for i, tk := range keys {
 				var (
 					daddr netip.Addr
 					saddr netip.Addr
 				)
+				ts := vals[i]
 
 				switch tk.Tuple.Family {
 				case uint16(types.AF_INET):


### PR DESCRIPTION
Few reasons to return keys and values as two slices:
1. Testing more complicated if flow return order is important for tests cases. There are tests cases in progress there I want to aggregate flows if it reaches certain public ips contain. I need to have stable order for mocks.
2. Returning a map adds more overhead since we hash already unique flows again to key val. On micro benchmarks two slices also uses less cpu.