### PR TITLE
Disable unused post-analyzer scanners

### DIFF
--- a/cmd/imagescan/collector/collector.go
+++ b/cmd/imagescan/collector/collector.go
@@ -78,9 +78,22 @@ func (c *Collector) Collect(ctx context.Context) error {
 	defer cleanup()
 
 	disabledAnalyzers := []fanalyzer.Type{
+		// License
 		fanalyzer.TypeLicenseFile,
 		fanalyzer.TypeDpkgLicense,
+
+		// Structured config
+		fanalyzer.TypeAzureARM,
+		fanalyzer.TypeCloudFormation,
+		fanalyzer.TypeDockerfile,
 		fanalyzer.TypeHelm,
+		fanalyzer.TypeKubernetes,
+		fanalyzer.TypeTerraform,
+		fanalyzer.TypeTerraformPlanJSON,
+		fanalyzer.TypeTerraformPlanSnapshot,
+
+		// Java
+		fanalyzer.TypeJar, // Jar analyzer needs trivy-java-db, disable it until it is implemented in kvisor
 	}
 
 	for _, a := range c.cfg.DisabledAnalyzers {

--- a/cmd/imagescan/collector/collector_test.go
+++ b/cmd/imagescan/collector/collector_test.go
@@ -174,7 +174,6 @@ func TestCollectorPackageAnalyzers(t *testing.T) {
 			r.NotEmpty(pkgs[0].InstalledFiles)
 		})
 	}
-
 }
 
 func TestCollectorWithIngressNginx(t *testing.T) {


### PR DESCRIPTION
Post-analyzers were enabled on https://github.com/castai/image-analyzer/pull/53 to support scanning `deb` packages. However some of them are not really used and `jar` is causing problems when scanning java applications:

```
post analysis error: post analysis error: Unable to initialize the Java DB: Java DB update failed: Java DB client not initialized"
``` 

The full list of analyzers type can be found here https://github.com/aquasecurity/trivy/blob/main/pkg/fanal/analyzer/const.go#L9