### PR TITLE
Support setting apiKey and clusterID from envFrom

### DIFF
--- a/charts/kvisor/templates/_helpers.tpl
+++ b/charts/kvisor/templates/_helpers.tpl
@@ -39,6 +39,39 @@ Create chart name and version as used by the chart label.
 {{- end }}
 {{- end }}
 
+{{- define "kvisor.apiKeyEnvFrom" -}}
+{{- $envFrom := .envFrom -}}
+{{- if and .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
+  {{- fail "apiKey and apiKeySecretRef are mutually exclusive" }}
+{{- else if .Values.castai.apiKey }}
+- secretRef:
+    name: {{ .Release.Name }}
+{{- else if .Values.castai.apiKeySecretRef }}
+- secretRef:
+    name: {{ .Values.castai.apiKeySecretRef }}
+{{- else if not $envFrom }}
+  {{- fail "castai.apiKey or castai.apiKeySecretRef must be provided" }}
+{{- end }}
+{{- end }}
+
+{{- define "kvisor.clusterIDEnv" -}}
+{{- $envFrom := .envFrom -}}
+{{- if and .Values.castai.clusterID .Values.castai.clusterIdSecretKeyRef.name }}
+  {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
+{{- else if .Values.castai.clusterID }}
+- name: CASTAI_CLUSTER_ID
+  value: {{ .Values.castai.clusterID | quote }}
+{{- else if .Values.castai.clusterIdSecretKeyRef.name }}
+- name: CASTAI_CLUSTER_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
+      key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
+{{- else if not $envFrom }}
+  {{- fail "castai.clusterID or castai.clusterIdSecretKeyRef must be provided" }}
+{{- end }}
+{{- end }}
+
 {{/*
 Common labels
 */}}

--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -80,8 +80,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.castai.enabled }}
+          {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
             - secretRef:
                 name: {{ include "kvisor.castaiSecretName" . }}
+          {{- else if not .Values.agent.envFrom }}
+            {{- fail "castai.apiKey or castai.apiKeySecretRef must be provided" }}
+          {{- end }}
           {{- end }}
           {{- if.Values.clickhouse.enabled }}
             - secretRef:
@@ -107,23 +111,19 @@ spec:
                      {{- else -}}
                        {{ .Values.castai.grpcAddr | quote }}
                      {{- end }}
-          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
-          {{- if ne .Values.castai.clusterID "" }}
-          {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
-          {{- end }}
+          {{- if and .Values.castai.clusterID .Values.castai.clusterIdSecretKeyRef.name }}
+            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
+          {{- else if .Values.castai.clusterID }}
+            - name: CASTAI_CLUSTER_ID
+              value: {{ .Values.castai.clusterID | quote }}
+          {{- else if .Values.castai.clusterIdSecretKeyRef.name }}
             - name: CASTAI_CLUSTER_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "clusterID or clusterIdSecretKeyRef must be provided" .Values.castai.clusterIdSecretKeyRef.name }}
+                  name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
                   key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
-          {{- else }}
-          {{- if not .Values.castai.clusterID }}
-          {{- fail "either clusterID or clusterIdSecretKeyRef must be provided" }}
-          {{- end }}
-          {{- if .Values.castai.clusterID }}
-            - name: CASTAI_CLUSTER_ID
-              value: {{ .Values.castai.clusterID | quote }}
-          {{- end }}
+          {{- else if not .Values.agent.envFrom }}
+            {{- fail "castai.clusterID or castai.clusterIdSecretKeyRef must be provided" }}
           {{- end }}
           {{- if .Values.agent.debug.ebpf }}
             - name: KVISOR_EBPF_DEBUG

--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -80,12 +80,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.castai.enabled }}
-          {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
-            - secretRef:
-                name: {{ include "kvisor.castaiSecretName" . }}
-          {{- else if not .Values.agent.envFrom }}
-            {{- fail "castai.apiKey or castai.apiKeySecretRef must be provided" }}
-          {{- end }}
+          {{- include "kvisor.apiKeyEnvFrom" (set (deepCopy .) "envFrom" .Values.agent.envFrom) | nindent 12 }}
           {{- end }}
           {{- if.Values.clickhouse.enabled }}
             - secretRef:
@@ -111,20 +106,7 @@ spec:
                      {{- else -}}
                        {{ .Values.castai.grpcAddr | quote }}
                      {{- end }}
-          {{- if and .Values.castai.clusterID .Values.castai.clusterIdSecretKeyRef.name }}
-            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
-          {{- else if .Values.castai.clusterID }}
-            - name: CASTAI_CLUSTER_ID
-              value: {{ .Values.castai.clusterID | quote }}
-          {{- else if .Values.castai.clusterIdSecretKeyRef.name }}
-            - name: CASTAI_CLUSTER_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
-                  key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
-          {{- else if not .Values.agent.envFrom }}
-            {{- fail "castai.clusterID or castai.clusterIdSecretKeyRef must be provided" }}
-          {{- end }}
+          {{- include "kvisor.clusterIDEnv" (set (deepCopy .) "envFrom" .Values.agent.envFrom) | nindent 12 }}
           {{- if .Values.agent.debug.ebpf }}
             - name: KVISOR_EBPF_DEBUG
               value: "1"

--- a/charts/kvisor/templates/controller.yaml
+++ b/charts/kvisor/templates/controller.yaml
@@ -81,20 +81,7 @@ spec:
                      {{- else -}}
                        {{ .Values.castai.grpcAddr | quote }}
                      {{- end }}
-          {{- if and .Values.castai.clusterID .Values.castai.clusterIdSecretKeyRef.name }}
-            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
-          {{- else if .Values.castai.clusterID }}
-            - name: CASTAI_CLUSTER_ID
-              value: {{ .Values.castai.clusterID | quote }}
-          {{- else if .Values.castai.clusterIdSecretKeyRef.name }}
-            - name: CASTAI_CLUSTER_ID
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
-                  key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
-          {{- else if not .Values.controller.envFrom }}
-            {{- fail "castai.clusterID or castai.clusterIdSecretKeyRef must be provided" }}
-          {{- end }}
+          {{- include "kvisor.clusterIDEnv" (set (deepCopy .) "envFrom" .Values.controller.envFrom) | nindent 12 }}
           {{- range $k, $v := .Values.controller.additionalEnv }}
             - name: {{ $k }}
               value: "{{ $v }}"
@@ -108,12 +95,7 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.castai.enabled }}
-          {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
-            - secretRef:
-                name: {{ include "kvisor.castaiSecretName" . }}
-          {{- else if not .Values.controller.envFrom }}
-            {{- fail "castai.apiKey or castai.apiKeySecretRef must be provided" }}
-          {{- end }}
+          {{- include "kvisor.apiKeyEnvFrom" (set (deepCopy .) "envFrom" .Values.controller.envFrom) | nindent 12 }}
           {{- end }}
           ports:
             - name: http-server

--- a/charts/kvisor/templates/controller.yaml
+++ b/charts/kvisor/templates/controller.yaml
@@ -81,23 +81,19 @@ spec:
                      {{- else -}}
                        {{ .Values.castai.grpcAddr | quote }}
                      {{- end }}
-          {{- if .Values.castai.clusterIdSecretKeyRef.name }}
-          {{- if ne .Values.castai.clusterID "" }}
-          {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
-          {{- end }}
+          {{- if and .Values.castai.clusterID .Values.castai.clusterIdSecretKeyRef.name }}
+            {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
+          {{- else if .Values.castai.clusterID }}
+            - name: CASTAI_CLUSTER_ID
+              value: {{ .Values.castai.clusterID | quote }}
+          {{- else if .Values.castai.clusterIdSecretKeyRef.name }}
             - name: CASTAI_CLUSTER_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ required "clusterID or clusterIdSecretKeyRef must be provided" .Values.castai.clusterIdSecretKeyRef.name }}
+                  name: {{ .Values.castai.clusterIdSecretKeyRef.name }}
                   key: {{ .Values.castai.clusterIdSecretKeyRef.key }}
-          {{- else }}
-          {{- if not .Values.castai.clusterID }}
-          {{- fail "either clusterID or clusterIdSecretKeyRef must be provided" }}
-          {{- end }}
-          {{- if .Values.castai.clusterID }}
-            - name: CASTAI_CLUSTER_ID
-              value: {{ .Values.castai.clusterID | quote }}
-          {{- end }}
+          {{- else if not .Values.controller.envFrom }}
+            {{- fail "castai.clusterID or castai.clusterIdSecretKeyRef must be provided" }}
           {{- end }}
           {{- range $k, $v := .Values.controller.additionalEnv }}
             - name: {{ $k }}
@@ -112,8 +108,12 @@ spec:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           {{- if .Values.castai.enabled }}
+          {{- if or .Values.castai.apiKey .Values.castai.apiKeySecretRef }}
             - secretRef:
                 name: {{ include "kvisor.castaiSecretName" . }}
+          {{- else if not .Values.controller.envFrom }}
+            {{- fail "castai.apiKey or castai.apiKeySecretRef must be provided" }}
+          {{- end }}
           {{- end }}
           ports:
             - name: http-server

--- a/charts/kvisor/templates/secret.yaml
+++ b/charts/kvisor/templates/secret.yaml
@@ -1,11 +1,11 @@
-{{- if and .Values.castai.enabled (eq .Values.castai.apiKeySecretRef "")  }}
+{{- if and .Values.castai.enabled .Values.castai.apiKey }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Release.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- include "kvisor.labels" . | nindent 4}}
+    {{- include "kvisor.labels" . | nindent 4 }}
 data:
-  API_KEY: {{ required "castai.apiKey must be provided" .Values.castai.apiKey | b64enc | quote }}
+  API_KEY: {{ .Values.castai.apiKey | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
## Test case 1

Set `castai.apiKey` and `castai.clusterID` values:

<details>
<summary>result</summary>

```shell
$ helm template castai-kvisor charts/kvisor -f - > helm-test-1.yaml <<EOF
castai:
  enabled: true
  apiKey: foo
  clusterID: bar
controller:
  enabled: true
agent:
  enabled: true
EOF
```

Secret is created with the API key:

```yaml
# Source: castai-kvisor/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: castai-kvisor
  namespace: default
data:
  API_KEY: "Zm9v"
```

Both agent and controller reference the secret and the cluster ID:

```yaml
# Source: castai-kvisor/templates/agent.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: castai-kvisor-agent
  namespace: default
...
          env:
            - name: CASTAI_CLUSTER_ID
              value: "bar"
          envFrom:
            - secretRef:
                name: castai-kvisor

# Source: castai-kvisor/templates/controller.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: castai-kvisor-controller
  namespace: default
...
          env:
            - name: CASTAI_CLUSTER_ID
              value: "bar"
          envFrom:
            - secretRef:
                name: castai-kvisor
```
</details>

## Test case 2

Set `castai.apiKeySecretRef` and `castai.clusterIdSecretKeyRef` values:

<details>
<summary>result</summary>

```shell
$ helm template castai-kvisor charts/kvisor -f - > helm-test-2.yaml <<EOF
castai:
  enabled: true
  apiKeySecretRef: castai-kvisor-secret
  clusterIdSecretKeyRef:
    name: castai-cluster-id
controller:
  enabled: true
agent:
  enabled: true
EOF
```

Secret is not created.

Both agent and controller reference the secret and the cluster ID:

```yaml
# Source: castai-kvisor/templates/agent.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: castai-kvisor-agent
  namespace: default
...
          env:
            - name: CASTAI_CLUSTER_ID
              valueFrom:
                secretKeyRef:
                  name: castai-cluster-id
                  key: CLUSTER_ID
          envFrom:
            - secretRef:
                name: castai-kvisor-secret

# Source: castai-kvisor/templates/controller.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: castai-kvisor-controller
  namespace: default
...
          env:
            - name: CASTAI_CLUSTER_ID
              valueFrom:
                secretKeyRef:
                  name: castai-cluster-id
                  key: CLUSTER_ID
          envFrom:
            - secretRef:
                name: castai-kvisor-secret
```
</details>

## Test case 3

Set API key and cluster ID only using `envFrom` values:

<details>
<summary>result</summary>

```shell
$ helm template castai-kvisor charts/kvisor -f - > helm-test-3.yaml <<EOF
castai:
  enabled: true
controller:
  enabled: true
  envFrom:
    - secretRef:
        name: castai-kvisor-secret
    - secretRef:
        name: castai-cluster-id
agent:
  enabled: true
  envFrom:
    - secretRef:
        name: castai-kvisor-secret
    - secretRef:
        name: castai-cluster-id
EOF
```

Secret is not created.

Both agent and controller reference the secret and the cluster ID:

```yaml
# Source: castai-kvisor/templates/agent.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: castai-kvisor-agent
  namespace: default
...
          envFrom:
            - secretRef:
                name: castai-kvisor-secret
            - secretRef:
                name: castai-cluster-id

# Source: castai-kvisor/templates/controller.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: castai-kvisor-controller
  namespace: default
...
          envFrom:
            - secretRef:
                name: castai-kvisor-secret
            - secretRef:
                name: castai-cluster-id
```
</details>

## Test case 4

Set both `castai.apiKeySecretRef` and `castai.clusterIdSecretKeyRef` values, but also use `envFrom` to reference other secrets:

<details>
<summary>result</summary>

```shell
$ helm template castai-kvisor charts/kvisor -f - > helm-test-4.yaml <<EOF
castai:
  enabled: true
  apiKeySecretRef: castai-kvisor-secret
  clusterIdSecretKeyRef:
    name: castai-cluster-id
controller:
  enabled: true
  envFrom:
    - secretRef:
        name: other-secret
agent:
  enabled: true
  envFrom:
    - secretRef:
        name: other-secret
EOF
```

Secret is not created.

Both agent and controller reference all the secrets and the cluster ID:

```yaml
# Source: castai-kvisor/templates/agent.yaml
apiVersion: apps/v1
kind: DaemonSet
metadata:
  name: castai-kvisor-agent
  namespace: default
...
          env:
            - name: CASTAI_CLUSTER_ID
              valueFrom:
                secretKeyRef:
                  name: castai-cluster-id
                  key: CLUSTER_ID
          envFrom:
            - secretRef:
                name: other-secret
            - secretRef:
                name: castai-kvisor-secret

# Source: castai-kvisor/templates/controller.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: castai-kvisor-controller
  namespace: default
...
          env:
            - name: CASTAI_CLUSTER_ID
              valueFrom:
                secretKeyRef:
                  name: castai-cluster-id
                  key: CLUSTER_ID
          envFrom:
            - secretRef:
                name: other-secret
            - secretRef:
                name: castai-kvisor-secret
```
</details>

## Test case 5

The API key is not provided, but the cluster ID is set:

<details>
<summary>result</summary>

```shell
$ helm template castai-kvisor charts/kvisor -f - > helm-test-5.yaml <<EOF
castai:
  enabled: true
  clusterID: bar
controller:
  enabled: true
agent:
  enabled: true
EOF
```

The following error is expected:

```shell
castai.apiKey or castai.apiKeySecretRef must be provided
```
</details>

## Test case 6

The cluster ID is not provided, but the API key is set:

<details>
<summary>result</summary>

```shell
$ helm template castai-kvisor charts/kvisor -f - > helm-test-5.yaml <<EOF
castai:
  enabled: true
  apiKey: foo
controller:
  enabled: true
agent:
  enabled: true
EOF
```

The following error is expected:

```shell
castai.clusterID or castai.clusterIdSecretKeyRef must be provided
```
</details>
