### PR TITLE
Use CLUSTER_ID as a fallback for CASTAI_CLUSTER_ID

### DIFF
--- a/charts/kvisor/templates/_helpers.tpl
+++ b/charts/kvisor/templates/_helpers.tpl
@@ -59,10 +59,10 @@ Create chart name and version as used by the chart label.
 {{- if and .Values.castai.clusterID .Values.castai.clusterIdSecretKeyRef.name }}
   {{- fail "clusterID and clusterIdSecretKeyRef are mutually exclusive" }}
 {{- else if .Values.castai.clusterID }}
-- name: CASTAI_CLUSTER_ID
+- name: CLUSTER_ID
   value: {{ .Values.castai.clusterID | quote }}
 {{- else if .Values.castai.clusterIdSecretKeyRef.name }}
-- name: CASTAI_CLUSTER_ID
+- name: CLUSTER_ID
   valueFrom:
     secretKeyRef:
       name: {{ .Values.castai.clusterIdSecretKeyRef.name }}

--- a/cmd/controller/state/imagescan/scanner.go
+++ b/cmd/controller/state/imagescan/scanner.go
@@ -213,7 +213,7 @@ func (s *Scanner) ScanImage(ctx context.Context, params ScanImageParams) (rerr e
 			Value: s.cfg.CastaiGRPCAddress,
 		},
 		{
-			Name:  "CASTAI_CLUSTER_ID",
+			Name:  "CLUSTER_ID",
 			Value: s.cfg.CastaiClusterID,
 		},
 		{
@@ -440,7 +440,7 @@ func scanJobSpec(
 ) *batchv1.Job {
 	podLabels := map[string]string{}
 	podLabels["reports.cast.ai/name"] = "castai-imgscan"
-	
+
 	if cfg.CloudProvider == "aks" {
 		podLabels["azure.workload.identity/use"] = "true"
 	}

--- a/cmd/controller/state/imagescan/scanner_test.go
+++ b/cmd/controller/state/imagescan/scanner_test.go
@@ -204,7 +204,7 @@ func TestScanner(t *testing.T) {
 												Value: "api.cast.ai:443",
 											},
 											{
-												Name:  "CASTAI_CLUSTER_ID",
+												Name:  "CLUSTER_ID",
 												Value: "abcd",
 											},
 											{

--- a/cmd/imagescan/collector/collector_test.go
+++ b/cmd/imagescan/collector/collector_test.go
@@ -36,6 +36,7 @@ import (
 
 func TestCollector(t *testing.T) {
 	t.Run("collect and sends metadata", func(t *testing.T) {
+		t.Setenv("CASTAI_GRPC_INSECURE", "true")
 		imgName := "notused"
 		imgID := "gke.gcr.io/phpmyadmin@sha256:b0d9c54760b35edd1854e5710c1a62a28ad2d2b070c801da3e30a3e59c19e7e3" //nolint:gosec
 
@@ -268,7 +269,6 @@ func TestCollectorLargeImageDockerTar(t *testing.T) {
 	ingestClient := &mockIngestClient{}
 
 	c := New(log, config.Config{
-		CastaiAPIGrpcAddr: srv.URL,
 		ImageID:           imgID,
 		ImageName:         imgName,
 		Timeout:           5 * time.Minute,

--- a/cmd/imagescan/config/config.go
+++ b/cmd/imagescan/config/config.go
@@ -1,9 +1,7 @@
 package config
 
 import (
-	"errors"
 	"io/fs"
-	"os"
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
@@ -33,11 +31,7 @@ const (
 )
 
 type Config struct {
-	CastaiClusterID   string `envconfig:"CASTAI_CLUSTER_ID" required:"true"`
-	CastaiAPIGrpcAddr string `envconfig:"CASTAI_API_GRPC_ADDR" required:"true"`
-	// The api key is required, but we support two differnt ways of setting it.
-	CastaiAPIKey       string `envconfig:"CASTAI_API_KEY"`
-	CastaiGRPCInsecure bool   `envconfig:"CASTAI_GRPC_INSECURE"`
+	CastaiGRPCInsecure bool `envconfig:"CASTAI_GRPC_INSECURE"`
 
 	BlobsCacheURL     string        `envconfig:"COLLECTOR_BLOBS_CACHE_URL"`
 	ImageID           string        `envconfig:"COLLECTOR_IMAGE_ID" required:"true"`
@@ -61,15 +55,6 @@ func FromEnv() (Config, error) {
 	var cfg Config
 	if err := envconfig.Process("", &cfg); err != nil {
 		return Config{}, err
-	}
-
-	if cfg.CastaiAPIKey == "" {
-		// fall back to non `CASTAI` prefix env variable
-		if apiKey, found := os.LookupEnv("API_KEY"); found {
-			cfg.CastaiAPIKey = apiKey
-		} else {
-			return Config{}, errors.New("required environment variable not set: CASTAI_API_KEY or API_KEY are missing")
-		}
 	}
 
 	return cfg, nil

--- a/cmd/imagescan/imgscan.go
+++ b/cmd/imagescan/imgscan.go
@@ -45,12 +45,11 @@ func run(ctx context.Context, log *logrus.Logger, version string) error {
 
 	blobsCache := blobscache.NewRemoteBlobsCacheClient(cfg.BlobsCacheURL)
 
-	ingestClient, err := castai.NewClient(fmt.Sprintf("kvisor-imagescan/%s", version), castai.Config{
-		ClusterID:   cfg.CastaiClusterID,
-		APIKey:      cfg.CastaiAPIKey,
-		APIGrpcAddr: cfg.CastaiAPIGrpcAddr,
-		Insecure:    cfg.CastaiGRPCInsecure,
-	})
+	castaiClientCfg, err := castai.NewConfigFromEnv(cfg.CastaiGRPCInsecure)
+	if err != nil {
+		return fmt.Errorf("failed to initialize CAST AI client config: %w", err)
+	}
+	ingestClient, err := castai.NewClient(fmt.Sprintf("kvisor-imagescan/%s", version), castaiClientCfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/castai/client.go
+++ b/pkg/castai/client.go
@@ -13,19 +13,6 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-type Config struct {
-	ClusterID   string `json:"clusterID"`
-	APIKey      string `json:"-"`
-	APIGrpcAddr string `json:"APIGrpcAddr"`
-	Insecure    bool   `json:"insecure"`
-
-	CompressionName string `json:"compression"`
-}
-
-func (c Config) Valid() bool {
-	return c.ClusterID != "" && c.APIKey != "" && c.APIGrpcAddr != ""
-}
-
 func NewClient(userAgent string, cfg Config) (*Client, error) {
 	tls := credentials.NewTLS(nil)
 	if strings.HasPrefix(cfg.APIGrpcAddr, "localhost") || cfg.Insecure {

--- a/pkg/castai/config.go
+++ b/pkg/castai/config.go
@@ -1,0 +1,57 @@
+package castai
+
+import (
+	"fmt"
+	"os"
+)
+
+type Config struct {
+	ClusterID   string `json:"clusterID"`
+	APIKey      string `json:"-"`
+	APIGrpcAddr string `json:"APIGrpcAddr"`
+	Insecure    bool   `json:"insecure"`
+
+	CompressionName string `json:"compression"`
+}
+
+func NewConfigFromEnv(insecure bool) (Config, error) {
+	gRPCAddress, found := os.LookupEnv("CASTAI_API_GRPC_ADDR")
+	if !found {
+		return Config{}, fmt.Errorf("missing environment variable: CASTAI_API_GRPC_ADDR")
+	}
+
+	clusterID, err := lookupConfigVariable("CLUSTER_ID")
+	if err != nil {
+		return Config{}, err
+	}
+
+	apiKey, err := lookupConfigVariable("API_KEY")
+	if err != nil {
+		return Config{}, err
+	}
+
+	return Config{
+		APIKey:      apiKey,
+		APIGrpcAddr: gRPCAddress,
+		ClusterID:   clusterID,
+		Insecure:    insecure,
+	}, nil
+}
+
+func (c Config) Valid() bool {
+	return c.ClusterID != "" && c.APIKey != "" && c.APIGrpcAddr != ""
+}
+
+func lookupConfigVariable(name string) (string, error) {
+	key, found := os.LookupEnv("CASTAI_" + name)
+	if found && key != "" {
+		return key, nil
+	}
+
+	key, found = os.LookupEnv(name)
+	if found && key != "" {
+		return key, nil
+	}
+
+	return "", fmt.Errorf("environment variable missing: please provide either `CAST_%s` or `%s`", name, name)
+}


### PR DESCRIPTION
The configmap created by the castai/k8s-agent is using `CLUSTER_ID` as the key to store the cluster ID https://github.com/castai/k8s-agent/blob/20cae4159dee0c8557f8bb99911e0c67379eebcf/internal/services/metadata/store.go#L38-L47

However kvisor expects `CASTAI_CLUSTER_ID` which makes not possible to re-use the same configmap. Fallback to `CLUSTER_ID` when `CASTAI_CLUSTER_ID` is not set.