### PR TITLE
Do not crash process tree init when container process cannot be snaphotted

### DIFF
--- a/pkg/processtree/processtree.go
+++ b/pkg/processtree/processtree.go
@@ -135,7 +135,8 @@ func (c *ProcessTreeCollectorImpl) Init(ctx context.Context) error {
 	for _, p := range processes {
 		procProcesses, err := c.proc.SnapshotProcessTree(p.PID)
 		if err != nil {
-			return err
+			c.log.Warnf("cannot snapshot process tree for PID %d: %v", p.PID, err)
+			continue
 		}
 
 		processesMap := make(map[ProcessKey]Process)


### PR DESCRIPTION

There can be cases where the container runtime gets out of sync with running containers and might return a PID that has already exited. This would crash kvisor, as the process tree initialization woulud fail.

Instead of failing, the init logic now ignores PIDs it cannot snapshot and a warning is logged.