### PR TITLE
Fallback cluster service cidr discovery

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.controller
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ghcr.io/castai/kvisor/kvisor-controller:${{ env.head_commit_sha }}
 
@@ -101,7 +101,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.agent
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ghcr.io/castai/kvisor/kvisor-agent:${{ env.head_commit_sha }}
 
@@ -111,7 +111,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.scanners
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ghcr.io/castai/kvisor/kvisor-scanners:${{ env.head_commit_sha }}
 
@@ -121,7 +121,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.controller
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ghcr.io/castai/kvisor/kvisor-controller:${{ env.head_commit_sha }},ghcr.io/castai/kvisor/kvisor-controller:latest
 
@@ -131,7 +131,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.agent
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ghcr.io/castai/kvisor/kvisor-agent:${{ env.head_commit_sha }},ghcr.io/castai/kvisor/kvisor-agent:latest
 
@@ -141,7 +141,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.scanners
-          platforms: linux/amd64
+          platforms: linux/arm64,linux/amd64
           push: true
           tags: ghcr.io/castai/kvisor/kvisor-scanners:${{ env.head_commit_sha }},ghcr.io/castai/kvisor/kvisor-scanners:latest
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,18 @@ jobs:
       - name: Build linter go binary amd64
         run: UNAME_M=x86_64 VERSION=${RELEASE_TAG:-commit-$GITHUB_SHA} make kvisor-linter
 
+      - name: Build agent go binary arm64
+        run: UNAME_M=arm64 VERSION=${RELEASE_TAG:-commit-$GITHUB_SHA} make kvisor-agent
+
+      - name: Build controller go binary arm64
+        run: UNAME_M=arm64 VERSION=${RELEASE_TAG:-commit-$GITHUB_SHA} make kvisor-controller
+
+      - name: Build image-scanner go binary arm64
+        run: UNAME_M=arm64 VERSION=${RELEASE_TAG:-commit-$GITHUB_SHA} make kvisor-image-scanner
+
+      - name: Build linter go binary arm64
+        run: UNAME_M=arm64 VERSION=${RELEASE_TAG:-commit-$GITHUB_SHA} make kvisor-linter
+
       - name: Run golangci-lint
         # You may pin to the exact commit or the version.
         # uses: golangci/golangci-lint-action@537aa1903e5d359d0b27dbc19ddd22c5087f3fbc

--- a/cmd/agent/daemon/config/config.go
+++ b/cmd/agent/daemon/config/config.go
@@ -73,6 +73,7 @@ type NetflowConfig struct {
 	ExportInterval              time.Duration              `json:"exportInterval"`
 	Grouping                    ebpftracer.NetflowGrouping `json:"grouping"`
 	MaxPublicIPs                int16                      `json:"maxPublicIPs"`
+	CheckClusterNetworkRanges   bool                       `json:"checkClusterNetworkRanges"`
 }
 
 type ClickhouseConfig struct {

--- a/cmd/agent/daemon/daemon.go
+++ b/cmd/agent/daemon/daemon.go
@@ -81,6 +81,7 @@ func NewRunCommand(version string) *cobra.Command {
 		ingressNightmareExploitDetectionSignatureEnabled = command.Flags().Bool("signature-ingress-nightmare-exploit-detection-enabled", true, "Enables the detection signature to detect exploits of ingress nightmare")
 
 		netflowEnabled                     = command.Flags().Bool("netflow-enabled", false, "Enables netflow tracking")
+		netflowCheckClusterNetworkRanges   = command.Flags().Bool("netflow-check-cluster-network-ranges", true, "Check cluster network ranges before enriching destinations")
 		netflowSampleSubmitIntervalSeconds = command.Flags().Uint64("netflow-sample-submit-interval-seconds", 15, "Netflow sample submit interval")
 		netflowExportInterval              = command.Flags().Duration("netflow-export-interval", 15*time.Second, "Netflow export interval")
 		netflowMaxPublicIPsBucket          = command.Flags().Int16("netflow-max-public-ips-bucket", -1, "Maximum number of unique public IPs destination before aggregating into 0.0.0.0 range")
@@ -196,6 +197,7 @@ func NewRunCommand(version string) *cobra.Command {
 				Grouping:                    netflowGrouping,
 				ExportInterval:              *netflowExportInterval,
 				MaxPublicIPs:                *netflowMaxPublicIPsBucket,
+				CheckClusterNetworkRanges:   *netflowCheckClusterNetworkRanges,
 			},
 			Clickhouse: config.ClickhouseConfig{
 				Addr:     *clickhouseAddr,

--- a/cmd/controller/kube/server_test.go
+++ b/cmd/controller/kube/server_test.go
@@ -180,4 +180,49 @@ func TestServer(t *testing.T) {
 		r.ElementsMatch([]string{"10.8.0.0/14", "fd00::/48"}, resp.PodsCidr)
 		r.ElementsMatch([]string{"10.30.0.0/14", "fd01::/48"}, resp.ServiceCidr)
 	})
+
+	t.Run("get service cidr from fallback", func(t *testing.T) {
+		r := require.New(t)
+		clientset := fake.NewClientset()
+		client := NewClient(log, "castai-kvisor", "kvisor", Version{}, clientset)
+		client.index = NewIndex()
+
+		client.index.ipsDetails[netip.MustParseAddr("10.10.10.10")] = IPInfo{
+			PodInfo: &PodInfo{
+				Pod: &corev1.Pod{
+					Status: corev1.PodStatus{
+						PodIP: "10.10.10.10",
+						PodIPs: []corev1.PodIP{
+							{
+								IP: "10.10.10.10",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		client.index.ipsDetails[netip.MustParseAddr("fd00::1")] = IPInfo{
+			Service: &corev1.Service{
+				Spec: corev1.ServiceSpec{
+					ClusterIPs: []string{"10.10.10.10"},
+				},
+			},
+		}
+		clientset.PrependReactor("create", "services", func(action kubetesting.Action) (bool, runtime.Object, error) {
+			svc := action.(kubetesting.CreateAction).GetObject().(*corev1.Service)
+			switch svc.Spec.ClusterIP {
+			case "0.0.0.0":
+				return true, svc, fmt.Errorf("bad")
+			case "::":
+				return true, svc, fmt.Errorf("bad")
+			}
+			return false, nil, nil
+		})
+
+		srv := NewServer(client)
+		resp, err := srv.GetClusterInfo(ctx, &kubepb.GetClusterInfoRequest{})
+		r.NoError(err)
+		r.Equal([]string{"10.10.0.0/16"}, resp.ServiceCidr)
+	})
 }

--- a/cmd/controller/kube/server_test.go
+++ b/cmd/controller/kube/server_test.go
@@ -205,7 +205,7 @@ func TestServer(t *testing.T) {
 		client.index.ipsDetails[netip.MustParseAddr("fd00::1")] = IPInfo{
 			Service: &corev1.Service{
 				Spec: corev1.ServiceSpec{
-					ClusterIPs: []string{"10.10.10.10"},
+					ClusterIPs: []string{"10.10.10.10", "fd00::1"},
 				},
 			},
 		}
@@ -223,6 +223,6 @@ func TestServer(t *testing.T) {
 		srv := NewServer(client)
 		resp, err := srv.GetClusterInfo(ctx, &kubepb.GetClusterInfoRequest{})
 		r.NoError(err)
-		r.Equal([]string{"10.10.0.0/16"}, resp.ServiceCidr)
+		r.Equal([]string{"10.8.0.0/14", "fd00::/48"}, resp.ServiceCidr)
 	})
 }


### PR DESCRIPTION
We expect to receive error from control plane to get real service cidr range, usually it looks like this
```
The Service "my-service" is invalid: spec.clusterIPs: Invalid value: []string{"0.0.0.0"}: failed to allocate IP 0.0.0.0: the provided IP (0.0.0.0) is not in the valid range. The range of valid IPs is 10.30.0.0/24
```

Ok EKS it doesn't return valid range.
```
The Service "my-service" is invalid: spec.clusterIPs: Invalid value: []string{"0.0.0.0"}: failed to allocate IP 0.0.0.0: the provided network does not match the current range
```