### PR TITLE
Skip sending empty batch

### DIFF
--- a/cmd/agent/daemon/pipeline/events_pipeline.go
+++ b/cmd/agent/daemon/pipeline/events_pipeline.go
@@ -39,6 +39,10 @@ func (c *Controller) runEventsPipeline(ctx context.Context) error {
 				Data: &castaipb.DataBatchItem_ContainerEvents{ContainerEvents: group.pb},
 			})
 		}
+		// Skip if no changes.
+		if len(items) == 0 {
+			return
+		}
 		c.sendDataBatch(reason, metrics.PipelineEBPFEvents, items)
 
 		// Reset stats and group items after send.

--- a/cmd/agent/daemon/pipeline/netflow_pipeline.go
+++ b/cmd/agent/daemon/pipeline/netflow_pipeline.go
@@ -95,6 +95,10 @@ func (c *Controller) runNetflowPipeline(ctx context.Context) error {
 				})
 			}
 		}
+		// Skip if no changes.
+		if len(items) == 0 {
+			return
+		}
 		c.sendDataBatch(reason, metrics.PipelineNetflows, items)
 
 		// Reset after sent.

--- a/cmd/agent/daemon/pipeline/stats_pipeline.go
+++ b/cmd/agent/daemon/pipeline/stats_pipeline.go
@@ -78,6 +78,10 @@ func (c *Controller) runStatsPipeline(ctx context.Context) error {
 				},
 			})
 		}
+		// Skip if no changes.
+		if len(items) == 0 {
+			return
+		}
 		c.sendDataBatch("container stats scrape", metrics.PipelineStats, items)
 		batchState.reset()
 		now := time.Now()

--- a/pkg/containers/client.go
+++ b/pkg/containers/client.go
@@ -165,7 +165,7 @@ func (c *Client) LoadContainers(ctx context.Context) error {
 		}
 		added++
 	}
-	c.log.Debugf("loaded %d containers out of %d", added, len(containersList.Containers))
+	c.log.Infof("loaded %d containers out of %d", added, len(containersList.Containers))
 	return nil
 }
 


### PR DESCRIPTION
It's possible that there are no batch items yet and we should skip sending it. For example, container stats batch requires at least two scrapes.