### PR TITLE
Make automount SA token configurable

### DIFF
--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -48,7 +48,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "kvisor.agent.serviceAccountName" . }}
-      automountServiceAccountToken: false
+      automountServiceAccountToken: {{ .Values.agent.automountServiceAccountToken }}
       hostPID: true
       securityContext:
         {{- toYaml .Values.agent.securityContext | nindent 8 }}

--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -58,6 +58,9 @@ agent:
     # If not set and create is true, a name is generated using the fullname template
     name: ""
 
+  # Specifies whether the service account token should be automounted.
+  automountServiceAccountToken: false
+
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:


### PR DESCRIPTION
Currently this defaults to false which breaks mounting the token to use the SA. 

I'm not certain if this was intended behavior or not, so leaving the default to false but allowing it to be configured (default k8s behavior for this is true). 

