### PR TITLE
Allow setting custom containerd socket path

### DIFF
--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -149,11 +149,9 @@ spec:
               readOnly: true
             - name: debugfs
               mountPath: /sys/kernel/debug
-          {{- if .Values.agent.containerd.enabled }}
             - name: containerd-sock
               mountPath: /run/containerd/containerd.sock
               readOnly: true
-          {{- end }}
       dnsPolicy: {{.Values.agent.dnsPolicy}}
       {{- with .Values.agent.nodeSelector }}
       nodeSelector:
@@ -180,12 +178,10 @@ spec:
             path: /sys/fs/cgroup
         - name: cgroup-mountdir
           emptyDir: {}
-      {{- if and .Values.agent.containerd.enabled .Values.agent.containerd.socketPath }}
         - name: containerd-sock
           hostPath:
-            path: {{ .Values.agent.containerd.socketPath }}
+            path: {{ .Values.agent.containerdSocketPath }}
             type: Socket
-      {{- end }}
 {{- end }}
 ---
 {{- if .Values.agent.serviceAccount.create -}}

--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -145,9 +145,8 @@ agent:
   # Additional environment variables for the agent container via configMaps or secrets.
   envFrom: []
 
-  containerd:
-    enabled: true
-    socketPath: "/run/containerd/containerd.sock"
+  # Custom socket path for containerd.
+  containerdSocketPath: "/run/containerd/containerd.sock"
 
 controller:
   enabled: true


### PR DESCRIPTION
In k3s clusters containerd socket is mounted on `/run/k3s/containerd/containerd.sock`, we need to overwrite the default value in such cases.