### PR TITLE
chore: Add Windows node affinity exclusion for kvisor

### DIFF
--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -133,6 +133,10 @@ agent:
                 operator: NotIn
                 values:
                   - fargate
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                  - windows
 
   dnsPolicy: ClusterFirstWithHostNet
 
@@ -424,7 +428,15 @@ controller:
 
   tolerations: []
 
-  affinity: {}
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: kubernetes.io/os
+                operator: NotIn
+                values:
+                  - windows
 
   dnsPolicy: ClusterFirst
 


### PR DESCRIPTION
Kvisor agent DaemonSet was missing a kubernetes.io/os node affinity rule, causing it to be scheduled on Windows nodes which is not consistent with the default behaviour of our services.