### PR TITLE
chore: Add umbrella chart support to enable-reliability-stack.sh

### DIFF
--- a/charts/kvisor/scripts/enable-reliability-stack.sh
+++ b/charts/kvisor/scripts/enable-reliability-stack.sh
@@ -10,7 +10,8 @@
 #   3. Install or upgrade the full reliability stack (Phase 2)
 #
 # Supports both fresh installs (with --api-key and --cluster-id) and upgrades
-# of existing kvisor releases.
+# of existing kvisor releases. Auto-detects whether kvisor is installed
+# standalone or via the CAST AI umbrella chart and adjusts accordingly.
 #
 # Usage:
 #   ./enable-reliability-stack.sh [options]
@@ -33,6 +34,11 @@
 #                           e.g. --values-prefix autoscaler.castai-kvisor
 #                           When set, keys like agent.reliabilityMetrics.enabled become
 #                           autoscaler.castai-kvisor.agent.reliabilityMetrics.enabled
+#       --chart-version     Pin chart version (e.g. 0.33.21). Default: auto-detected
+#                           from the currently deployed release to avoid upgrading
+#                           unrelated components.
+#       --upgrade-chart     Upgrade to the latest chart version instead of pinning to
+#                           the currently deployed version.
 #       --dry-run           Print commands without executing
 #       --skip-repo         Skip helm repo add/update
 #   -h, --help              Show this help
@@ -53,9 +59,13 @@ GRPC_ADDR=""
 OBI_PROFILE="auto"
 DYNAMIC_SIZING="false"
 VALUES_PREFIX=""
+CHART_VERSION=""
+UPGRADE_CHART=""
 DRY_RUN=""
 SKIP_REPO=""
 INSTALL_MODE=""
+USER_SET_RELEASE=""
+USER_SET_CHART=""
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
@@ -82,8 +92,8 @@ usage() {
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -n|--namespace)       NAMESPACE="$2"; shift 2 ;;
-    -r|--release)         RELEASE="$2"; shift 2 ;;
-    -c|--chart)           CHART="$2"; shift 2 ;;
+    -r|--release)         RELEASE="$2"; USER_SET_RELEASE="true"; shift 2 ;;
+    -c|--chart)           CHART="$2"; USER_SET_CHART="true"; shift 2 ;;
     --context)            CONTEXT="$2"; shift 2 ;;
     -f|--values-file)     VALUES_FILE="$2"; shift 2 ;;
     --api-key)            API_KEY="$2"; shift 2 ;;
@@ -94,6 +104,8 @@ while [[ $# -gt 0 ]]; do
     --obi-profile)        OBI_PROFILE="$2"; shift 2 ;;
     --dynamic-sizing)     DYNAMIC_SIZING="true"; shift ;;
     --values-prefix)      VALUES_PREFIX="$2"; shift 2 ;;
+    --chart-version)      CHART_VERSION="$2"; shift 2 ;;
+    --upgrade-chart)      UPGRADE_CHART="true"; shift ;;
     --dry-run)            DRY_RUN="true"; shift ;;
     --skip-repo)          SKIP_REPO="true"; shift ;;
     -h|--help)            usage ;;
@@ -294,12 +306,132 @@ if [[ -z "$SKIP_REPO" ]]; then
   ok "Helm repo up to date"
 fi
 
+# ── Auto-detect installation type ────────────────────────────────────────────
+# When the user hasn't explicitly set --release or --chart, scan for an existing
+# kvisor release to determine if it was installed standalone or via the umbrella chart.
+if [[ -z "$USER_SET_RELEASE" ]]; then
+  step "Auto-detecting Installation Type"
+
+  # Get all releases in the namespace as JSON and detect kvisor's installation method.
+  # Chart column tells us: "castai-kvisor-1.x.x" = standalone, "castai-0.x.x" = umbrella.
+  DETECTED=$(helm $HELM_CTX list -n "$NAMESPACE" -o json 2>/dev/null | python3 -c "
+import sys, json, re
+
+releases = json.load(sys.stdin)
+for r in releases:
+    chart = r.get('chart', '')
+    name = r.get('name', '')
+    # Standalone: chart starts with 'castai-kvisor-'
+    if chart.startswith('castai-kvisor-'):
+        print(f'TYPE=standalone')
+        print(f'RELEASE={name}')
+        print(f'CHART_NAME={chart}')
+        sys.exit(0)
+
+for r in releases:
+    chart = r.get('chart', '')
+    name = r.get('name', '')
+    # Umbrella: chart is 'castai-X.Y.Z' (version directly after 'castai-')
+    if re.match(r'^castai-\d+\.\d+\.\d+', chart):
+        print(f'TYPE=umbrella')
+        print(f'RELEASE={name}')
+        print(f'CHART_NAME={chart}')
+        sys.exit(0)
+
+print('TYPE=none')
+" 2>/dev/null) || DETECTED="TYPE=none"
+
+  DETECTED_TYPE=""
+  DETECTED_RELEASE=""
+  DETECTED_CHART_NAME=""
+  while IFS='=' read -r key val; do
+    case "$key" in
+      TYPE)       DETECTED_TYPE="$val" ;;
+      RELEASE)    DETECTED_RELEASE="$val" ;;
+      CHART_NAME) DETECTED_CHART_NAME="$val" ;;
+    esac
+  done <<< "$DETECTED"
+
+  case "$DETECTED_TYPE" in
+    standalone)
+      RELEASE="$DETECTED_RELEASE"
+      if [[ -z "$USER_SET_CHART" ]]; then
+        CHART="castai-helm/castai-kvisor"
+      fi
+      ok "Detected standalone kvisor (release: $RELEASE, chart: $DETECTED_CHART_NAME)"
+      ;;
+    umbrella)
+      RELEASE="$DETECTED_RELEASE"
+      if [[ -z "$USER_SET_CHART" ]]; then
+        CHART="castai-helm/castai"
+      fi
+      if [[ -z "$VALUES_PREFIX" ]]; then
+        # Discover the values path to castai-kvisor by inspecting the release's current values.
+        # The umbrella chart nests kvisor under an intermediate subchart (e.g. autoscaler.castai-kvisor).
+        # We walk the YAML tree to find the path containing a 'castai-kvisor' key with kvisor-like children.
+        VALUES_PREFIX=$(helm $HELM_CTX get values "$DETECTED_RELEASE" -n "$NAMESPACE" -o json 2>/dev/null | python3 -c "
+import sys, json
+
+def find_kvisor_path(obj, path=''):
+    \"\"\"Recursively find the path to a 'castai-kvisor' key that has dict children (agent, controller, etc).\"\"\"
+    if not isinstance(obj, dict):
+        return None
+    for key, val in obj.items():
+        current = f'{path}.{key}' if path else key
+        if key == 'castai-kvisor' and isinstance(val, dict):
+            # Verify it looks like real kvisor config (has agent/controller/castai keys)
+            kvisor_keys = set(val.keys())
+            if kvisor_keys & {'agent', 'controller', 'castai', 'enabled'}:
+                return current
+        result = find_kvisor_path(val, current)
+        if result:
+            return result
+    return None
+
+data = json.load(sys.stdin)
+path = find_kvisor_path(data)
+if path:
+    print(path)
+else:
+    # Fallback: try common known paths
+    print('castai-kvisor')
+" 2>/dev/null) || VALUES_PREFIX="castai-kvisor"
+      fi
+      ok "Detected umbrella chart (release: $RELEASE, chart: $DETECTED_CHART_NAME)"
+      info "Auto-configured: --release $RELEASE --chart $CHART --values-prefix $VALUES_PREFIX"
+      ;;
+    *)
+      info "No existing CAST AI release found in namespace '$NAMESPACE' — using defaults"
+      ;;
+  esac
+fi
+
 # ── Check existing release ──────────────────────────────────────────────────
 step "Checking Existing Release"
 
 if helm $HELM_CTX status "$RELEASE" -n "$NAMESPACE" >/dev/null 2>&1; then
   CURRENT_REVISION=$(helm $HELM_CTX history "$RELEASE" -n "$NAMESPACE" --max 1 -o json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['revision'])" 2>/dev/null || echo "?")
   ok "Release '$RELEASE' found (revision $CURRENT_REVISION) — upgrade mode"
+
+  # Auto-detect chart version to pin upgrades (avoid bumping unrelated components).
+  # --upgrade-chart skips pinning; --chart-version overrides detection.
+  if [[ -z "$UPGRADE_CHART" && -z "$CHART_VERSION" ]]; then
+    CHART_VERSION=$(helm $HELM_CTX history "$RELEASE" -n "$NAMESPACE" --max 1 -o json 2>/dev/null | python3 -c "
+import sys, json, re
+entry = json.load(sys.stdin)[0]
+chart = entry.get('chart', '')
+# Extract version from chart string like 'castai-0.33.21' or 'castai-kvisor-1.0.117'
+m = re.match(r'.*?-(\d+\.\d+\.\d+.*)$', chart)
+if m:
+    print(m.group(1))
+" 2>/dev/null) || CHART_VERSION=""
+    if [[ -n "$CHART_VERSION" ]]; then
+      info "Pinning chart version to $CHART_VERSION (use --upgrade-chart for latest)"
+    fi
+  fi
+  if [[ -n "$UPGRADE_CHART" ]]; then
+    info "Upgrading to latest chart version (--upgrade-chart)"
+  fi
 
   # Auto-detect which Secret holds the CAST AI API key.
   # Standalone kvisor creates "castai-kvisor"; the umbrella chart creates "castai-credentials".
@@ -336,6 +468,12 @@ else
   ok "Fresh install mode — will create release '$RELEASE'"
 fi
 
+# ── Build version flag ───────────────────────────────────────────────────────
+HELM_VERSION_FLAG=""
+if [[ -n "$CHART_VERSION" ]]; then
+  HELM_VERSION_FLAG="--version $CHART_VERSION"
+fi
+
 # ── Phase 1: CRD Detection & Operator Bootstrap ─────────────────────────────
 step "Phase 1: ClickHouse Operator CRD Check"
 
@@ -361,7 +499,7 @@ elif [[ -n "$CRD_EXISTS" ]]; then
 
   PHASE1_CMD="helm upgrade --install $RELEASE $CHART \\
     -n $NAMESPACE --create-namespace \\
-    $HELM_CTX"
+    $HELM_CTX $HELM_VERSION_FLAG"
 
   if [[ -n "$INSTALL_MODE" ]]; then
     PHASE1_CMD="$PHASE1_CMD $(build_creds_flags)"
@@ -395,7 +533,7 @@ else
   # We explicitly disable install.enabled so the ClickHouseInstallation CR isn't created yet.
   PHASE1_CMD="helm upgrade --install $RELEASE $CHART \\
     -n $NAMESPACE --create-namespace \\
-    $HELM_CTX"
+    $HELM_CTX $HELM_VERSION_FLAG"
 
   # Fresh installs need credentials; upgrades reuse existing values
   if [[ -n "$INSTALL_MODE" ]]; then
@@ -488,7 +626,7 @@ step "Phase 2: Enabling Full Reliability Stack"
 # Build the helm command with all reliability flags
 HELM_CMD="helm upgrade --install $RELEASE $CHART \\
   -n $NAMESPACE --create-namespace \\
-  $HELM_CTX"
+  $HELM_CTX $HELM_VERSION_FLAG"
 
 # Fresh installs need credentials; upgrades reuse existing values
 if [[ -n "$INSTALL_MODE" ]]; then

--- a/charts/kvisor/scripts/enable-reliability-stack.sh
+++ b/charts/kvisor/scripts/enable-reliability-stack.sh
@@ -537,7 +537,7 @@ print('TYPE=none')
         # Discover the values path to castai-kvisor by inspecting the release's current values.
         # The umbrella chart nests kvisor under an intermediate subchart (e.g. autoscaler.castai-kvisor).
         # We walk the YAML tree to find the path containing a 'castai-kvisor' key with kvisor-like children.
-        VALUES_PREFIX=$(helm $HELM_CTX get values "$DETECTED_RELEASE" -n "$NAMESPACE" -o json 2>/dev/null | python3 -c "
+        VALUES_PREFIX=$(helm $HELM_CTX get values -a "$DETECTED_RELEASE" -n "$NAMESPACE" -o json 2>/dev/null | python3 -c "
 import sys, json
 
 def find_kvisor_path(obj, path=''):

--- a/charts/kvisor/scripts/enable-reliability-stack.sh
+++ b/charts/kvisor/scripts/enable-reliability-stack.sh
@@ -29,6 +29,10 @@
 #       --obi-profile       OBI sizing profile: auto, small, medium, large, xlarge (default: auto)
 #                           'auto' runs obi-sizing-report.sh to detect the best profile
 #       --dynamic-sizing    Enable OBI dynamic sizing (default: false)
+#       --values-prefix     Prefix for all --set keys (for umbrella charts).
+#                           e.g. --values-prefix autoscaler.castai-kvisor
+#                           When set, keys like agent.reliabilityMetrics.enabled become
+#                           autoscaler.castai-kvisor.agent.reliabilityMetrics.enabled
 #       --dry-run           Print commands without executing
 #       --skip-repo         Skip helm repo add/update
 #   -h, --help              Show this help
@@ -48,6 +52,7 @@ CLUSTER_ID_SECRET=""
 GRPC_ADDR=""
 OBI_PROFILE="auto"
 DYNAMIC_SIZING="false"
+VALUES_PREFIX=""
 DRY_RUN=""
 SKIP_REPO=""
 INSTALL_MODE=""
@@ -88,6 +93,7 @@ while [[ $# -gt 0 ]]; do
     --grpc-addr)          GRPC_ADDR="$2"; shift 2 ;;
     --obi-profile)        OBI_PROFILE="$2"; shift 2 ;;
     --dynamic-sizing)     DYNAMIC_SIZING="true"; shift ;;
+    --values-prefix)      VALUES_PREFIX="$2"; shift 2 ;;
     --dry-run)            DRY_RUN="true"; shift ;;
     --skip-repo)          SKIP_REPO="true"; shift ;;
     -h|--help)            usage ;;
@@ -103,6 +109,17 @@ if [[ -n "$CONTEXT" ]]; then
   KUBECTL_CTX="--context $CONTEXT"
   HELM_CTX="--kube-context $CONTEXT"
 fi
+
+# Prefix a --set key with VALUES_PREFIX if set.
+# Usage: setkey "agent.reliabilityMetrics.enabled=true"  →  "--set autoscaler.castai-kvisor.agent.reliabilityMetrics.enabled=true"
+setkey() {
+  local kv="$1"
+  if [[ -n "$VALUES_PREFIX" ]]; then
+    echo "--set ${VALUES_PREFIX}.${kv}"
+  else
+    echo "--set ${kv}"
+  fi
+}
 
 run_cmd() {
   if [[ -n "$DRY_RUN" ]]; then
@@ -283,6 +300,22 @@ step "Checking Existing Release"
 if helm $HELM_CTX status "$RELEASE" -n "$NAMESPACE" >/dev/null 2>&1; then
   CURRENT_REVISION=$(helm $HELM_CTX history "$RELEASE" -n "$NAMESPACE" --max 1 -o json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)[0]['revision'])" 2>/dev/null || echo "?")
   ok "Release '$RELEASE' found (revision $CURRENT_REVISION) — upgrade mode"
+
+  # Auto-detect which Secret holds the CAST AI API key.
+  # Standalone kvisor creates "castai-kvisor"; the umbrella chart creates "castai-credentials".
+  # The ch-exporter subchart defaults to "castai-kvisor", so we must override when different.
+  DETECTED_API_KEY_SECRET=""
+  for candidate in castai-kvisor castai-credentials; do
+    if kubectl $KUBECTL_CTX get secret "$candidate" -n "$NAMESPACE" >/dev/null 2>&1; then
+      DETECTED_API_KEY_SECRET="$candidate"
+      break
+    fi
+  done
+  if [[ -n "$DETECTED_API_KEY_SECRET" ]]; then
+    info "Detected API key secret: $DETECTED_API_KEY_SECRET"
+  else
+    warn "Could not detect API key secret — ch-exporter will use chart default (castai-kvisor)"
+  fi
 else
   warn "Release '$RELEASE' not found in namespace '$NAMESPACE'"
   # For fresh install, we need credentials from one of:
@@ -307,9 +340,52 @@ fi
 step "Phase 1: ClickHouse Operator CRD Check"
 
 CRD_EXISTS=""
+OPERATOR_RUNNING=""
 if kubectl $KUBECTL_CTX get crd clickhouseinstallations.clickhouse.altinity.com >/dev/null 2>&1; then
   CRD_EXISTS="true"
-  ok "ClickHouseInstallation CRD already exists — skipping operator install"
+  # CRD exists — but check if the operator is actually running.
+  # It may have been deleted (e.g. after a failed install cleanup) while the CRD remained.
+  if kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" -l app=clickhouse-operator --field-selector=status.phase=Running 2>/dev/null | grep -q clickhouse-operator; then
+    OPERATOR_RUNNING="true"
+    ok "ClickHouseInstallation CRD already exists and operator is running — skipping operator install"
+  else
+    warn "ClickHouseInstallation CRD exists but operator is not running — will install operator"
+  fi
+fi
+
+if [[ -n "$OPERATOR_RUNNING" ]]; then
+  : # nothing to do
+elif [[ -n "$CRD_EXISTS" ]]; then
+  # CRD present but operator missing — run Phase 1 to reinstall the operator
+  info "Reinstalling ClickHouse operator (CRD already registered, skipping CRD wait)..."
+
+  PHASE1_CMD="helm upgrade --install $RELEASE $CHART \\
+    -n $NAMESPACE --create-namespace \\
+    $HELM_CTX"
+
+  if [[ -n "$INSTALL_MODE" ]]; then
+    PHASE1_CMD="$PHASE1_CMD $(build_creds_flags)"
+  else
+    PHASE1_CMD="$PHASE1_CMD \\
+    --reset-then-reuse-values"
+    if [[ -n "$VALUES_FILE" ]]; then
+      PHASE1_CMD="$PHASE1_CMD -f '${VALUES_FILE//"'"/"'\\''"}'"
+    fi
+  fi
+
+  PHASE1_CMD="$PHASE1_CMD \\
+    $(setkey reliabilityMetrics.enabled=true) \\
+    $(setkey reliabilityMetrics.operator.enabled=true) \\
+    $(setkey reliabilityMetrics.install.enabled=false) \\
+    $(setkey reliabilityMetrics.exporter.enabled=false)"
+
+  run_cmd "$PHASE1_CMD"
+
+  if [[ -z "$DRY_RUN" ]]; then
+    info "Waiting for operator pod to be ready..."
+    kubectl $KUBECTL_CTX rollout status deployment -n "$NAMESPACE" -l app=clickhouse-operator --timeout=60s 2>/dev/null || true
+    ok "ClickHouse operator ready"
+  fi
 else
   warn "ClickHouseInstallation CRD not found"
   info "Installing ClickHouse operator first (Phase 1)..."
@@ -334,10 +410,10 @@ else
   fi
 
   PHASE1_CMD="$PHASE1_CMD \\
-    --set reliabilityMetrics.enabled=true \\
-    --set reliabilityMetrics.operator.enabled=true \\
-    --set reliabilityMetrics.install.enabled=false \\
-    --set reliabilityMetrics.exporter.enabled=false"
+    $(setkey reliabilityMetrics.enabled=true) \\
+    $(setkey reliabilityMetrics.operator.enabled=true) \\
+    $(setkey reliabilityMetrics.install.enabled=false) \\
+    $(setkey reliabilityMetrics.exporter.enabled=false)"
 
   run_cmd "$PHASE1_CMD"
 
@@ -427,22 +503,42 @@ else
 fi
 
 HELM_CMD="$HELM_CMD \\
-  --set agent.reliabilityMetrics.enabled=true \\
-  --set agent.reliabilityMetrics.obi.sizingProfile=$OBI_PROFILE \\
-  --set agent.reliabilityMetrics.obi.dynamicSizing=$DYNAMIC_SIZING \\
-  --set controller.reliabilityMetrics.enabled=true \\
-  --set reliabilityMetrics.enabled=true \\
-  --set reliabilityMetrics.install.enabled=true \\
-  --set reliabilityMetrics.exporter.enabled=true"
+  $(setkey agent.reliabilityMetrics.enabled=true) \\
+  $(setkey agent.reliabilityMetrics.obi.sizingProfile=$OBI_PROFILE) \\
+  $(setkey agent.reliabilityMetrics.obi.dynamicSizing=$DYNAMIC_SIZING) \\
+  $(setkey controller.reliabilityMetrics.enabled=true) \\
+  $(setkey reliabilityMetrics.enabled=true) \\
+  $(setkey reliabilityMetrics.install.enabled=true) \\
+  $(setkey reliabilityMetrics.exporter.enabled=true)"
 
-# If operator was already present (external), don't install ours
-if [[ -n "$CRD_EXISTS" ]]; then
+# Override the ch-exporter API key secret ref if we detected a non-default secret
+if [[ -z "$INSTALL_MODE" && -n "$DETECTED_API_KEY_SECRET" && "$DETECTED_API_KEY_SECRET" != "castai-kvisor" ]]; then
   HELM_CMD="$HELM_CMD \\
-  --set reliabilityMetrics.operator.enabled=false"
+  $(setkey reliabilityMetrics.castai.apiKeySecretRef=$DETECTED_API_KEY_SECRET)"
+  info "Overriding ch-exporter apiKeySecretRef → $DETECTED_API_KEY_SECRET"
+fi
+
+# Under an umbrella chart the ClickHouse service is named <release>-clickhouse (e.g. castai-clickhouse)
+# rather than the standalone default castai-kvisor-clickhouse. Override the collector ClickHouse
+# address when the release name differs from the standalone default (castai-kvisor).
+if [[ "$RELEASE" != "castai-kvisor" ]]; then
+  CH_ADDR="tcp://${RELEASE}-clickhouse.${NAMESPACE}.svc.cluster.local:9000"
+  HELM_CMD="$HELM_CMD \\
+  $(setkey agent.reliabilityMetrics.collector.clickhouseExporter.address=$CH_ADDR) \\
+  $(setkey controller.reliabilityMetrics.collector.clickhouseExporter.address=$CH_ADDR)"
+  info "Overriding ClickHouse address → $CH_ADDR"
+fi
+
+# Only skip installing our operator if an external one was already running before we started.
+# If we installed it in Phase 1 (either CRD was missing, or CRD existed but operator wasn't running),
+# we need operator.enabled=true so it stays managed by this release.
+if [[ -n "$OPERATOR_RUNNING" ]]; then
+  HELM_CMD="$HELM_CMD \\
+  $(setkey reliabilityMetrics.operator.enabled=false)"
   info "Using existing ClickHouse operator (not installing chart's operator)"
 else
   HELM_CMD="$HELM_CMD \\
-  --set reliabilityMetrics.operator.enabled=true"
+  $(setkey reliabilityMetrics.operator.enabled=true)"
   info "ClickHouse operator enabled (installed in Phase 1)"
 fi
 
@@ -456,19 +552,30 @@ run_cmd "$HELM_CMD"
 if [[ -z "$DRY_RUN" ]]; then
   step "Phase 3: Verifying Rollout"
 
+  # Under an umbrella chart the release name is used as a helm instance label prefix,
+  # e.g. release=castai → daemonset castai-castai-kvisor-agent.
+  # Under a standalone chart, release=castai-kvisor → daemonset castai-kvisor-agent.
+  # Derive the resource name prefix: if VALUES_PREFIX is set we're in umbrella mode.
+  if [[ -n "$VALUES_PREFIX" ]]; then
+    AGENT_DS="${RELEASE}-castai-kvisor-agent"
+    AGENT_LABEL="app.kubernetes.io/name=castai-kvisor-agent"
+  else
+    AGENT_DS="${RELEASE}-agent"
+    AGENT_LABEL="app.kubernetes.io/name=${RELEASE}-agent"
+  fi
+
   info "Waiting for agent DaemonSet rollout..."
-  kubectl $KUBECTL_CTX rollout status daemonset/${RELEASE}-agent -n "$NAMESPACE" --timeout=120s 2>/dev/null || {
+  kubectl $KUBECTL_CTX rollout status daemonset/${AGENT_DS} -n "$NAMESPACE" --timeout=120s 2>/dev/null || {
     warn "DaemonSet rollout not complete within 120s. Check pods:"
-    kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" -l app.kubernetes.io/name=${RELEASE}-agent
+    kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" -l "$AGENT_LABEL"
   }
 
   echo ""
   info "Pod status:"
-  kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" -l "app.kubernetes.io/instance=${RELEASE##castai-}" 2>/dev/null || \
-    kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" 2>/dev/null | grep -E "kvisor|clickhouse"
+  kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" 2>/dev/null | grep -E "kvisor|clickhouse"
 
   echo ""
-  AGENT_PODS=$(kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" -l app.kubernetes.io/name=${RELEASE}-agent -o name 2>/dev/null | head -1)
+  AGENT_PODS=$(kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" -l "$AGENT_LABEL" -o name 2>/dev/null | head -1)
   if [[ -n "$AGENT_PODS" ]]; then
     POD_NAME="${AGENT_PODS##*/}"
     info "Checking OBI container on $POD_NAME..."

--- a/charts/kvisor/scripts/enable-reliability-stack.sh
+++ b/charts/kvisor/scripts/enable-reliability-stack.sh
@@ -72,7 +72,10 @@ INSTALL_MODE=""
 USER_SET_RELEASE=""
 USER_SET_CHART=""
 DETECTED_API_KEY_SECRET=""
+CRD_EXISTS=""
 OPERATOR_RUNNING=""
+OPERATOR_NS=""
+OPERATOR_WATCH_WARNING=""
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
@@ -163,6 +166,70 @@ run_cmd() {
     # Use eval because $HELM_CTX/$KUBECTL_CTX must expand to multiple args or nothing.
     # Values containing shell metacharacters are single-quoted in build_creds_flags().
     eval "$@"
+  fi
+}
+
+# Detect ClickHouse operator across all namespaces and verify it watches our target namespace.
+# Sets: OPERATOR_RUNNING="true" if operator is running AND watches NAMESPACE.
+#        OPERATOR_NS (namespace where operator was found)
+#        OPERATOR_WATCH_WARNING (set if operator runs but doesn't watch our namespace)
+detect_operator() {
+  OPERATOR_NS=""
+  OPERATOR_WATCH_WARNING=""
+
+  # Find the clickhouse-operator deployment across all namespaces.
+  # Different installation methods use different labels, so we search by multiple strategies:
+  #   1. Label: clickhouse.altinity.com/app=chop (Altinity's own label, most reliable)
+  #   2. Label: app=clickhouse-operator (older Altinity Helm chart)
+  #   3. Label: app.kubernetes.io/name contains clickhouse-operator (convention, may include version suffix)
+  local deploy_info=""
+  for label in "clickhouse.altinity.com/app=chop" "app=clickhouse-operator"; do
+    deploy_info=$(kubectl $KUBECTL_CTX get deployments --all-namespaces -l "$label" \
+      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null) || true
+    if [[ -n "$deploy_info" ]]; then
+      break
+    fi
+  done
+
+  # Fallback: search by deployment name containing "clickhouse-operator" (not just "clickhouse")
+  if [[ -z "$deploy_info" ]]; then
+    deploy_info=$(kubectl $KUBECTL_CTX get deployments --all-namespaces \
+      -o jsonpath='{range .items[*]}{.metadata.namespace}{"\t"}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+      | grep "clickhouse-operator" || true)
+  fi
+
+  if [[ -z "$deploy_info" ]]; then
+    return 1
+  fi
+
+  # Take the first match
+  OPERATOR_NS=$(echo "$deploy_info" | head -1 | cut -f1)
+  local deploy_name
+  deploy_name=$(echo "$deploy_info" | head -1 | cut -f2)
+
+  # Verify the deployment has running pods
+  local ready_replicas
+  ready_replicas=$(kubectl $KUBECTL_CTX get deployment "$deploy_name" -n "$OPERATOR_NS" \
+    -o jsonpath='{.status.readyReplicas}' 2>/dev/null) || ready_replicas="0"
+  if [[ "${ready_replicas:-0}" -lt 1 ]]; then
+    return 1
+  fi
+
+  # Check if the operator watches our namespace.
+  # WATCH_NAMESPACES env var: empty = all namespaces, comma-separated list = specific namespaces.
+  local watch_ns
+  watch_ns=$(kubectl $KUBECTL_CTX get deployment "$deploy_name" -n "$OPERATOR_NS" \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="WATCH_NAMESPACES")].value}' 2>/dev/null) || watch_ns=""
+
+  if [[ -z "$watch_ns" ]]; then
+    # Empty WATCH_NAMESPACES = watches all namespaces
+    OPERATOR_RUNNING="true"
+  elif echo ",$watch_ns," | grep -q ",$NAMESPACE,"; then
+    # Our namespace is in the watch list
+    OPERATOR_RUNNING="true"
+  else
+    # Operator runs but doesn't watch our namespace
+    OPERATOR_WATCH_WARNING="true"
   fi
 }
 
@@ -535,11 +602,13 @@ CRD_EXISTS=""
 OPERATOR_RUNNING=""
 if kubectl $KUBECTL_CTX get crd clickhouseinstallations.clickhouse.altinity.com >/dev/null 2>&1; then
   CRD_EXISTS="true"
-  # CRD exists — but check if the operator is actually running.
-  # It may have been deleted (e.g. after a failed install cleanup) while the CRD remained.
-  if kubectl $KUBECTL_CTX get pods -n "$NAMESPACE" -l app=clickhouse-operator --field-selector=status.phase=Running 2>/dev/null | grep -q clickhouse-operator; then
-    OPERATOR_RUNNING="true"
-    ok "ClickHouseInstallation CRD already exists and operator is running — skipping operator install"
+  detect_operator || true
+  if [[ -n "$OPERATOR_RUNNING" ]]; then
+    ok "ClickHouseInstallation CRD exists and operator is running (in namespace: $OPERATOR_NS) — skipping operator install"
+  elif [[ -n "$OPERATOR_WATCH_WARNING" ]]; then
+    warn "ClickHouse operator found in namespace '$OPERATOR_NS' but it does NOT watch namespace '$NAMESPACE'"
+    warn "The operator's WATCH_NAMESPACES does not include '$NAMESPACE' — ClickHouseInstallation CRs will be ignored"
+    warn "Either add '$NAMESPACE' to the operator's WATCH_NAMESPACES or install a dedicated operator"
   else
     warn "ClickHouseInstallation CRD exists but operator is not running — will install operator"
   fi
@@ -674,6 +743,17 @@ if [[ "$OBI_PROFILE" == "auto" ]]; then
   fi
 fi
 
+# ── CRD / Operator Detection ─────────────────────────────────────────────────
+# Read-only kubectl checks — runs in all modes (including print-only) so we
+# know whether Phase 1 is needed. Falls back gracefully if cluster unreachable.
+if [[ -z "$CRD_EXISTS" ]]; then
+  # Only check if not already set by the cluster-dependent block above
+  if kubectl $KUBECTL_CTX get crd clickhouseinstallations.clickhouse.altinity.com >/dev/null 2>&1; then
+    CRD_EXISTS="true"
+    detect_operator || true
+  fi
+fi
+
 # Rebuild version flag (may have been set inside the cluster-dependent block, or via --chart-version)
 HELM_VERSION_FLAG=""
 if [[ -n "$CHART_VERSION" ]]; then
@@ -681,12 +761,23 @@ if [[ -n "$CHART_VERSION" ]]; then
 fi
 
 # ── Print-only: Phase 1 (operator bootstrap) ────────────────────────────────
-# In print-only mode we can't check the cluster, so always output the Phase 1
-# command. The user can skip it if the CRD already exists.
-if [[ -n "$PRINT_ONLY" ]]; then
-  step "Phase 1: Install ClickHouse Operator (skip if CRD already exists)"
-  info "Check first: kubectl get crd clickhouseinstallations.clickhouse.altinity.com"
-  echo ""
+# Show Phase 1 only when the operator isn't already running and watching our namespace.
+if [[ -n "$PRINT_ONLY" && -z "$OPERATOR_RUNNING" ]]; then
+  if [[ -n "$OPERATOR_WATCH_WARNING" ]]; then
+    step "Phase 1: ClickHouse Operator — WARNING"
+    warn "ClickHouse operator found in namespace '$OPERATOR_NS' but does NOT watch '$NAMESPACE'"
+    warn "Either add '$NAMESPACE' to the operator's WATCH_NAMESPACES env var,"
+    warn "or run Command #1 below to install a dedicated operator in '$NAMESPACE'."
+    echo ""
+  elif [[ -n "$CRD_EXISTS" ]]; then
+    step "Phase 1: Install ClickHouse Operator"
+    warn "CRD exists but operator is not running — Phase 1 will reinstall it"
+    echo ""
+  else
+    step "Phase 1: Install ClickHouse Operator"
+    info "ClickHouse CRD not found — Phase 1 installs the operator and registers the CRD"
+    echo ""
+  fi
 
   PHASE1_CMD="$(build_helm_base)"
 
@@ -712,6 +803,8 @@ if [[ -n "$PRINT_ONLY" ]]; then
   print_cmd_block "Wait for CRD" "kubectl wait --for=condition=Established \\
   crd/clickhouseinstallations.clickhouse.altinity.com --timeout=60s"
   echo ""
+elif [[ -n "$PRINT_ONLY" ]]; then
+  ok "ClickHouse operator already running (namespace: ${OPERATOR_NS:-$NAMESPACE}) — skipping Phase 1"
 fi
 
 # ── Phase 2: Enable Full Reliability Stack ───────────────────────────────────

--- a/charts/kvisor/scripts/enable-reliability-stack.sh
+++ b/charts/kvisor/scripts/enable-reliability-stack.sh
@@ -90,6 +90,18 @@ warn()  { printf "${YELLOW}⚠${NC}  %s\n" "$*"; }
 err()   { printf "${RED}✗${NC}  %s\n" "$*" >&2; }
 step()  { printf "\n${BOLD}${CYAN}━━━ %s${NC}\n" "$*"; }
 
+# Print a command inside a clearly delimited block for copy-pasting.
+# Usage: print_cmd_block "label" "command string"
+print_cmd_block() {
+  local label="$1" cmd="$2"
+  printf "\n${BOLD}${GREEN}▶ %s${NC}\n" "$label"
+  printf "${CYAN}┌─────────────────────────────────────────────────────────────────${NC}\n"
+  while IFS= read -r line; do
+    printf "${CYAN}│${NC} %s\n" "$line"
+  done <<< "$cmd"
+  printf "${CYAN}└─────────────────────────────────────────────────────────────────${NC}\n"
+}
+
 usage() {
   sed -n '/^# Usage:/,/^# ─/p' "$0" | sed '$ d' | sed 's/^# //' | sed 's/^#//'
   exit 0
@@ -152,6 +164,22 @@ run_cmd() {
     # Values containing shell metacharacters are single-quoted in build_creds_flags().
     eval "$@"
   fi
+}
+
+# Build the base "helm upgrade --install" prefix with optional context and version flags.
+# Avoids blank continuation lines when HELM_CTX or HELM_VERSION_FLAG are empty.
+build_helm_base() {
+  local cmd="helm upgrade --install $RELEASE $CHART \\
+  -n $NAMESPACE --create-namespace"
+  if [[ -n "$HELM_CTX" ]]; then
+    cmd="$cmd \\
+  $HELM_CTX"
+  fi
+  if [[ -n "$HELM_VERSION_FLAG" ]]; then
+    cmd="$cmd \\
+  $HELM_VERSION_FLAG"
+  fi
+  echo "$cmd"
 }
 
 # Build helm flags for CAST AI credentials (fresh install only)
@@ -523,25 +551,23 @@ elif [[ -n "$CRD_EXISTS" ]]; then
   # CRD present but operator missing — run Phase 1 to reinstall the operator
   info "Reinstalling ClickHouse operator (CRD already registered, skipping CRD wait)..."
 
-  PHASE1_CMD="helm upgrade --install $RELEASE $CHART \\
-    -n $NAMESPACE --create-namespace \\
-    $HELM_CTX $HELM_VERSION_FLAG"
+  PHASE1_CMD="$(build_helm_base)"
 
   if [[ -n "$INSTALL_MODE" ]]; then
     PHASE1_CMD="$PHASE1_CMD $(build_creds_flags)"
   else
     PHASE1_CMD="$PHASE1_CMD \\
-    --reset-then-reuse-values"
+  --reset-then-reuse-values"
     if [[ -n "$VALUES_FILE" ]]; then
       PHASE1_CMD="$PHASE1_CMD -f '${VALUES_FILE//"'"/"'\\''"}'"
     fi
   fi
 
   PHASE1_CMD="$PHASE1_CMD \\
-    $(setkey reliabilityMetrics.enabled=true) \\
-    $(setkey reliabilityMetrics.operator.enabled=true) \\
-    $(setkey reliabilityMetrics.install.enabled=false) \\
-    $(setkey reliabilityMetrics.exporter.enabled=false)"
+  $(setkey reliabilityMetrics.enabled=true) \\
+  $(setkey reliabilityMetrics.operator.enabled=true) \\
+  $(setkey reliabilityMetrics.install.enabled=false) \\
+  $(setkey reliabilityMetrics.exporter.enabled=false)"
 
   run_cmd "$PHASE1_CMD"
 
@@ -557,16 +583,14 @@ else
 
   # Phase 1: Install just the operator to register the CRD.
   # We explicitly disable install.enabled so the ClickHouseInstallation CR isn't created yet.
-  PHASE1_CMD="helm upgrade --install $RELEASE $CHART \\
-    -n $NAMESPACE --create-namespace \\
-    $HELM_CTX $HELM_VERSION_FLAG"
+  PHASE1_CMD="$(build_helm_base)"
 
   # Fresh installs need credentials; upgrades reuse existing values
   if [[ -n "$INSTALL_MODE" ]]; then
     PHASE1_CMD="$PHASE1_CMD $(build_creds_flags)"
   else
     PHASE1_CMD="$PHASE1_CMD \\
-    --reset-then-reuse-values"
+  --reset-then-reuse-values"
     # Layer -f values on top of reused values (allows overriding openPorts, env, etc.)
     if [[ -n "$VALUES_FILE" ]]; then
       PHASE1_CMD="$PHASE1_CMD -f '${VALUES_FILE//"'"/"'\\''"}'"
@@ -574,10 +598,10 @@ else
   fi
 
   PHASE1_CMD="$PHASE1_CMD \\
-    $(setkey reliabilityMetrics.enabled=true) \\
-    $(setkey reliabilityMetrics.operator.enabled=true) \\
-    $(setkey reliabilityMetrics.install.enabled=false) \\
-    $(setkey reliabilityMetrics.exporter.enabled=false)"
+  $(setkey reliabilityMetrics.enabled=true) \\
+  $(setkey reliabilityMetrics.operator.enabled=true) \\
+  $(setkey reliabilityMetrics.install.enabled=false) \\
+  $(setkey reliabilityMetrics.exporter.enabled=false)"
 
   run_cmd "$PHASE1_CMD"
 
@@ -664,9 +688,7 @@ if [[ -n "$PRINT_ONLY" ]]; then
   info "Check first: kubectl get crd clickhouseinstallations.clickhouse.altinity.com"
   echo ""
 
-  PHASE1_CMD="helm upgrade --install $RELEASE $CHART \\
-  -n $NAMESPACE --create-namespace \\
-  $HELM_CTX $HELM_VERSION_FLAG"
+  PHASE1_CMD="$(build_helm_base)"
 
   if [[ -n "$INSTALL_MODE" ]]; then
     PHASE1_CMD="$PHASE1_CMD $(build_creds_flags)"
@@ -684,9 +706,11 @@ if [[ -n "$PRINT_ONLY" ]]; then
   $(setkey reliabilityMetrics.install.enabled=false) \\
   $(setkey reliabilityMetrics.exporter.enabled=false)"
 
-  run_cmd "$PHASE1_CMD"
+  print_cmd_block "Command #1 — Install operator" "$PHASE1_CMD"
   echo ""
-  info "Wait for CRD: kubectl wait --for=condition=Established crd/clickhouseinstallations.clickhouse.altinity.com --timeout=60s"
+  info "Then wait for CRD before running command #2:"
+  print_cmd_block "Wait for CRD" "kubectl wait --for=condition=Established \\
+  crd/clickhouseinstallations.clickhouse.altinity.com --timeout=60s"
   echo ""
 fi
 
@@ -694,9 +718,7 @@ fi
 step "Phase 2: Enabling Full Reliability Stack"
 
 # Build the helm command with all reliability flags
-HELM_CMD="helm upgrade --install $RELEASE $CHART \\
-  -n $NAMESPACE --create-namespace \\
-  $HELM_CTX $HELM_VERSION_FLAG"
+HELM_CMD="$(build_helm_base)"
 
 # Fresh installs need credentials; upgrades reuse existing values
 if [[ -n "$INSTALL_MODE" ]]; then
@@ -759,9 +781,50 @@ fi
 
 info "OBI sizing profile: $OBI_PROFILE"
 info "Dynamic sizing: $DYNAMIC_SIZING"
-echo ""
 
-run_cmd "$HELM_CMD"
+if [[ -n "$PRINT_ONLY" ]]; then
+  print_cmd_block "Command #2 — Enable full reliability stack" "$HELM_CMD"
+else
+  echo ""
+  run_cmd "$HELM_CMD"
+fi
+
+# ── Print-only: Common Overrides ─────────────────────────────────────────────
+if [[ -n "$PRINT_ONLY" ]]; then
+  echo ""
+  step "Common Overrides (add to Phase 2 command above)"
+  echo ""
+  echo "  # OBI: which ports to instrument (controls process discovery)"
+  echo "  $(setkey 'agent.reliabilityMetrics.obi.openPorts=8080\,8443\,6379\,5432')"
+  echo ""
+  echo "  # OBI: sizing profile (small/medium/large/xlarge) — or use --obi-profile flag"
+  echo "  $(setkey agent.reliabilityMetrics.obi.sizingProfile=large)"
+  echo ""
+  echo "  # OBI: enable dynamic sizing (auto-checks process count at startup)"
+  echo "  $(setkey agent.reliabilityMetrics.obi.dynamicSizing=true)"
+  echo ""
+  echo "  # OBI: exclude a namespace from instrumentation (use -f values file for multiple)"
+  echo "  $(setkey 'agent.reliabilityMetrics.obi.exclude[0].k8s_namespace=monitoring')"
+  echo ""
+  echo "  # ClickHouse: increase memory for large clusters (100+ nodes)"
+  echo "  $(setkey reliabilityMetrics.install.resources.limits.memory=4Gi)"
+  echo ""
+  echo "  # ClickHouse: increase disk for high-cardinality workloads"
+  echo "  $(setkey reliabilityMetrics.install.persistence.size=200Gi)"
+  echo ""
+  echo "  # ClickHouse: credentials from existing Secret"
+  echo "  $(setkey 'reliabilityMetrics.auth.password.valueFrom.secretKeyRef.name=my-ch-secret')"
+  echo "  $(setkey 'reliabilityMetrics.auth.password.valueFrom.secretKeyRef.key=password')"
+  echo ""
+  echo "  # Cluster proxy (or use --cluster-proxy flag)"
+  echo "  $(setkey controller.extraArgs.cluster-proxy-enabled=true)"
+  echo ""
+  echo "  # Use a values file instead of --set flags (recommended for complex configs)"
+  echo "  # Script flag: -f /path/to/values.yaml"
+  echo ""
+  echo "  # Full docs: docs/reliability-stack-installation.md"
+  echo "  # OBI sizing: docs/obi-sizing.md"
+fi
 
 # ── Phase 3: Verify Rollout ──────────────────────────────────────────────────
 if [[ -z "$DRY_RUN" ]]; then

--- a/charts/kvisor/scripts/enable-reliability-stack.sh
+++ b/charts/kvisor/scripts/enable-reliability-stack.sh
@@ -39,6 +39,9 @@
 #                           unrelated components.
 #       --upgrade-chart     Upgrade to the latest chart version instead of pinning to
 #                           the currently deployed version.
+#       --storage-class     StorageClass for ClickHouse PVC (e.g. gp3, premium-rwo).
+#                           Overrides the cluster default. Useful when no default
+#                           StorageClass is set (common on EKS 1.33+)
 #       --cluster-proxy     Also enable the kvisor cluster proxy feature
 #       --print-only        Print the final helm commands and exit (no preflight,
 #                           no auto-detection from cluster — uses defaults/flags only)
@@ -64,6 +67,7 @@ DYNAMIC_SIZING="false"
 VALUES_PREFIX=""
 CHART_VERSION=""
 UPGRADE_CHART=""
+STORAGE_CLASS=""
 CLUSTER_PROXY=""
 PRINT_ONLY=""
 DRY_RUN=""
@@ -128,6 +132,7 @@ while [[ $# -gt 0 ]]; do
     --values-prefix)      VALUES_PREFIX="$2"; shift 2 ;;
     --chart-version)      CHART_VERSION="$2"; shift 2 ;;
     --upgrade-chart)      UPGRADE_CHART="true"; shift ;;
+    --storage-class)      STORAGE_CLASS="$2"; shift 2 ;;
     --cluster-proxy)      CLUSTER_PROXY="true"; shift ;;
     --print-only)         PRINT_ONLY="true"; DRY_RUN="true"; shift ;;
     --dry-run)            DRY_RUN="true"; shift ;;
@@ -419,6 +424,48 @@ for ba in bad_arch:
   fi
 fi
 
+# ── StorageClass check ──────────────────────────────────────────────────────
+# ClickHouse PVCs don't specify a storageClassName — they rely on a default.
+# EKS 1.33+ creates gp2 but doesn't mark it as default, causing silent PVC Pending.
+step "StorageClass Check"
+DEFAULT_SC=$(kubectl $KUBECTL_CTX get sc -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{"\n"}{end}' 2>/dev/null) || DEFAULT_SC=""
+if [[ -n "$STORAGE_CLASS" ]]; then
+  ok "StorageClass override: $STORAGE_CLASS (via --storage-class)"
+elif [[ -z "$DEFAULT_SC" ]]; then
+  warn "No default StorageClass found!"
+  warn "ClickHouse requires a default StorageClass for its PersistentVolumeClaim."
+  warn "Without one, the ClickHouse pod will stay Pending indefinitely."
+  echo ""
+  info "Option 1: Re-run with --storage-class <name> to target a specific StorageClass"
+  info "Option 2: Mark an existing StorageClass as default:"
+  # Check if gp2 exists (common on EKS) and suggest marking it as default
+  if kubectl $KUBECTL_CTX get sc gp2 >/dev/null 2>&1; then
+    info "  kubectl annotate storageclass gp2 storageclass.kubernetes.io/is-default-class=true"
+  elif kubectl $KUBECTL_CTX get sc gp3 >/dev/null 2>&1; then
+    info "  kubectl annotate storageclass gp3 storageclass.kubernetes.io/is-default-class=true"
+  else
+    SC_LIST=$(kubectl $KUBECTL_CTX get sc -o jsonpath='{.items[*].metadata.name}' 2>/dev/null) || SC_LIST=""
+    if [[ -n "$SC_LIST" ]]; then
+      info "Available StorageClasses: $SC_LIST"
+      info "  kubectl annotate storageclass <name> storageclass.kubernetes.io/is-default-class=true"
+    else
+      warn "No StorageClasses found at all — install a CSI driver (e.g. EBS CSI for EKS)"
+    fi
+  fi
+  echo ""
+  if [[ -z "$DRY_RUN" ]]; then
+    err "Proceed without a default StorageClass? [y/N]"
+    read -r REPLY
+    if [[ ! "$REPLY" =~ ^[Yy]$ ]]; then
+      err "Aborted. Set a default StorageClass and re-run."
+      exit 1
+    fi
+    warn "Proceeding without default StorageClass — ClickHouse PVC may stay Pending"
+  fi
+else
+  ok "Default StorageClass: $DEFAULT_SC"
+fi
+
 # ── Helm repo ───────────────────────────────────────────────────────────────
 if [[ -z "$SKIP_REPO" ]]; then
   step "Helm Repository"
@@ -695,6 +742,29 @@ fi
 
 fi # end of [[ -z "$PRINT_ONLY" ]] — cluster-dependent sections
 
+# ── StorageClass check (print-only mode) ─────────────────────────────────────
+# When running in print-only mode, the preflight block above is skipped.
+# Still check for a default StorageClass since it's a kubectl-only read.
+if [[ -n "$PRINT_ONLY" ]]; then
+  if [[ -n "$STORAGE_CLASS" ]]; then
+    ok "StorageClass override: $STORAGE_CLASS (via --storage-class)"
+  else
+    DEFAULT_SC=$(kubectl $KUBECTL_CTX get sc -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{"\n"}{end}' 2>/dev/null) || DEFAULT_SC=""
+    if [[ -z "$DEFAULT_SC" ]]; then
+      warn "No default StorageClass found! ClickHouse PVC will stay Pending."
+      info "Fix: re-run with --storage-class <name>, or mark a default:"
+      if kubectl $KUBECTL_CTX get sc gp2 >/dev/null 2>&1; then
+        info "  kubectl annotate storageclass gp2 storageclass.kubernetes.io/is-default-class=true"
+      elif kubectl $KUBECTL_CTX get sc gp3 >/dev/null 2>&1; then
+        info "  kubectl annotate storageclass gp3 storageclass.kubernetes.io/is-default-class=true"
+      fi
+      echo ""
+    else
+      ok "Default StorageClass: $DEFAULT_SC"
+    fi
+  fi
+fi
+
 # ── Auto-detect OBI profile ──────────────────────────────────────────────────
 # Runs outside the print-only guard — only needs kubectl (not helm).
 # Falls back gracefully if the cluster isn't reachable.
@@ -872,6 +942,13 @@ if [[ -n "$CLUSTER_PROXY" ]]; then
   info "Cluster proxy enabled"
 fi
 
+# Override ClickHouse StorageClass if specified
+if [[ -n "$STORAGE_CLASS" ]]; then
+  HELM_CMD="$HELM_CMD \\
+  $(setkey reliabilityMetrics.install.persistence.storageClass=$STORAGE_CLASS)"
+  info "ClickHouse StorageClass: $STORAGE_CLASS"
+fi
+
 info "OBI sizing profile: $OBI_PROFILE"
 info "Dynamic sizing: $DYNAMIC_SIZING"
 
@@ -904,6 +981,9 @@ if [[ -n "$PRINT_ONLY" ]]; then
   echo ""
   echo "  # ClickHouse: increase disk for high-cardinality workloads"
   echo "  $(setkey reliabilityMetrics.install.persistence.size=200Gi)"
+  echo ""
+  echo "  # ClickHouse: explicit StorageClass (or use --storage-class flag)"
+  echo "  $(setkey reliabilityMetrics.install.persistence.storageClass=gp3)"
   echo ""
   echo "  # ClickHouse: credentials from existing Secret"
   echo "  $(setkey 'reliabilityMetrics.auth.password.valueFrom.secretKeyRef.name=my-ch-secret')"
@@ -977,6 +1057,9 @@ if [[ -z "$PRINT_ONLY" ]]; then
   echo "  Release:        $RELEASE"
   echo "  OBI profile:    $OBI_PROFILE"
   echo "  Dynamic sizing: $DYNAMIC_SIZING"
+  if [[ -n "$STORAGE_CLASS" ]]; then
+    echo "  StorageClass:   $STORAGE_CLASS"
+  fi
   echo ""
   echo "Next steps:"
   echo "  • Verify ClickHouse is ready:  kubectl get chi -n $NAMESPACE"

--- a/charts/kvisor/scripts/enable-reliability-stack.sh
+++ b/charts/kvisor/scripts/enable-reliability-stack.sh
@@ -39,6 +39,9 @@
 #                           unrelated components.
 #       --upgrade-chart     Upgrade to the latest chart version instead of pinning to
 #                           the currently deployed version.
+#       --cluster-proxy     Also enable the kvisor cluster proxy feature
+#       --print-only        Print the final helm commands and exit (no preflight,
+#                           no auto-detection from cluster — uses defaults/flags only)
 #       --dry-run           Print commands without executing
 #       --skip-repo         Skip helm repo add/update
 #   -h, --help              Show this help
@@ -61,11 +64,15 @@ DYNAMIC_SIZING="false"
 VALUES_PREFIX=""
 CHART_VERSION=""
 UPGRADE_CHART=""
+CLUSTER_PROXY=""
+PRINT_ONLY=""
 DRY_RUN=""
 SKIP_REPO=""
 INSTALL_MODE=""
 USER_SET_RELEASE=""
 USER_SET_CHART=""
+DETECTED_API_KEY_SECRET=""
+OPERATOR_RUNNING=""
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 RED='\033[0;31m'
@@ -106,6 +113,8 @@ while [[ $# -gt 0 ]]; do
     --values-prefix)      VALUES_PREFIX="$2"; shift 2 ;;
     --chart-version)      CHART_VERSION="$2"; shift 2 ;;
     --upgrade-chart)      UPGRADE_CHART="true"; shift ;;
+    --cluster-proxy)      CLUSTER_PROXY="true"; shift ;;
+    --print-only)         PRINT_ONLY="true"; DRY_RUN="true"; shift ;;
     --dry-run)            DRY_RUN="true"; shift ;;
     --skip-repo)          SKIP_REPO="true"; shift ;;
     -h|--help)            usage ;;
@@ -134,7 +143,9 @@ setkey() {
 }
 
 run_cmd() {
-  if [[ -n "$DRY_RUN" ]]; then
+  if [[ -n "$PRINT_ONLY" ]]; then
+    printf "%s\n" "$*"
+  elif [[ -n "$DRY_RUN" ]]; then
     printf "${YELLOW}[dry-run]${NC} %s\n" "$*"
   else
     # Use eval because $HELM_CTX/$KUBECTL_CTX must expand to multiple args or nothing.
@@ -170,6 +181,21 @@ build_creds_flags() {
     echo "--set 'castai.grpcAddr=${GRPC_ADDR//"'"/"'\\''"}'"
   fi
 }
+
+# ── Print-only mode: skip all cluster interaction ────────────────────────────
+# In --print-only mode we skip preflight, auto-detection, Phase 1, and OBI sizing.
+# The user must provide --release, --chart, --values-prefix if not using defaults.
+# If credentials are supplied via flags, assume fresh install mode.
+if [[ -n "$PRINT_ONLY" ]]; then
+  HAS_CREDS=""
+  [[ -n "$VALUES_FILE" ]] && HAS_CREDS="true"
+  [[ -n "$API_KEY" || -n "$API_KEY_SECRET" ]] && [[ -n "$CLUSTER_ID" || -n "$CLUSTER_ID_SECRET" ]] && HAS_CREDS="true"
+  if [[ -n "$HAS_CREDS" ]]; then
+    INSTALL_MODE="true"
+  fi
+fi
+
+if [[ -z "$PRINT_ONLY" ]]; then
 
 # ── Preflight checks ────────────────────────────────────────────────────────
 step "Preflight Checks"
@@ -574,7 +600,11 @@ else
   fi
 fi
 
+fi # end of [[ -z "$PRINT_ONLY" ]] — cluster-dependent sections
+
 # ── Auto-detect OBI profile ──────────────────────────────────────────────────
+# Runs outside the print-only guard — only needs kubectl (not helm).
+# Falls back gracefully if the cluster isn't reachable.
 if [[ "$OBI_PROFILE" == "auto" ]]; then
   step "Auto-detecting OBI Profile"
   SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -618,6 +648,46 @@ if [[ "$OBI_PROFILE" == "auto" ]]; then
       ok "Auto-detected profile: $OBI_PROFILE (max ${SIZING_MAX_PROCS:-?} procs across ${SIZING_NODES:-?} nodes)"
     fi
   fi
+fi
+
+# Rebuild version flag (may have been set inside the cluster-dependent block, or via --chart-version)
+HELM_VERSION_FLAG=""
+if [[ -n "$CHART_VERSION" ]]; then
+  HELM_VERSION_FLAG="--version $CHART_VERSION"
+fi
+
+# ── Print-only: Phase 1 (operator bootstrap) ────────────────────────────────
+# In print-only mode we can't check the cluster, so always output the Phase 1
+# command. The user can skip it if the CRD already exists.
+if [[ -n "$PRINT_ONLY" ]]; then
+  step "Phase 1: Install ClickHouse Operator (skip if CRD already exists)"
+  info "Check first: kubectl get crd clickhouseinstallations.clickhouse.altinity.com"
+  echo ""
+
+  PHASE1_CMD="helm upgrade --install $RELEASE $CHART \\
+  -n $NAMESPACE --create-namespace \\
+  $HELM_CTX $HELM_VERSION_FLAG"
+
+  if [[ -n "$INSTALL_MODE" ]]; then
+    PHASE1_CMD="$PHASE1_CMD $(build_creds_flags)"
+  else
+    PHASE1_CMD="$PHASE1_CMD \\
+  --reset-then-reuse-values"
+    if [[ -n "$VALUES_FILE" ]]; then
+      PHASE1_CMD="$PHASE1_CMD -f '${VALUES_FILE//"'"/"'\\''"}'"
+    fi
+  fi
+
+  PHASE1_CMD="$PHASE1_CMD \\
+  $(setkey reliabilityMetrics.enabled=true) \\
+  $(setkey reliabilityMetrics.operator.enabled=true) \\
+  $(setkey reliabilityMetrics.install.enabled=false) \\
+  $(setkey reliabilityMetrics.exporter.enabled=false)"
+
+  run_cmd "$PHASE1_CMD"
+  echo ""
+  info "Wait for CRD: kubectl wait --for=condition=Established crd/clickhouseinstallations.clickhouse.altinity.com --timeout=60s"
+  echo ""
 fi
 
 # ── Phase 2: Enable Full Reliability Stack ───────────────────────────────────
@@ -680,6 +750,13 @@ else
   info "ClickHouse operator enabled (installed in Phase 1)"
 fi
 
+# Enable cluster proxy if requested
+if [[ -n "$CLUSTER_PROXY" ]]; then
+  HELM_CMD="$HELM_CMD \\
+  $(setkey controller.extraArgs.cluster-proxy-enabled=true)"
+  info "Cluster proxy enabled"
+fi
+
 info "OBI sizing profile: $OBI_PROFILE"
 info "Dynamic sizing: $DYNAMIC_SIZING"
 echo ""
@@ -728,25 +805,27 @@ if [[ -z "$DRY_RUN" ]]; then
 fi
 
 # ── Summary ──────────────────────────────────────────────────────────────────
-step "Done"
-echo ""
-if [[ -n "$INSTALL_MODE" ]]; then
-  MODE_LABEL="install"
-  printf "${GREEN}${BOLD}Reliability metrics stack installed!${NC}\n"
-else
-  MODE_LABEL="upgrade"
-  printf "${GREEN}${BOLD}Reliability metrics stack upgraded!${NC}\n"
+if [[ -z "$PRINT_ONLY" ]]; then
+  step "Done"
+  echo ""
+  if [[ -n "$INSTALL_MODE" ]]; then
+    MODE_LABEL="install"
+    printf "${GREEN}${BOLD}Reliability metrics stack installed!${NC}\n"
+  else
+    MODE_LABEL="upgrade"
+    printf "${GREEN}${BOLD}Reliability metrics stack upgraded!${NC}\n"
+  fi
+  echo ""
+  echo "  Mode:           $MODE_LABEL"
+  echo "  Namespace:      $NAMESPACE"
+  echo "  Release:        $RELEASE"
+  echo "  OBI profile:    $OBI_PROFILE"
+  echo "  Dynamic sizing: $DYNAMIC_SIZING"
+  echo ""
+  echo "Next steps:"
+  echo "  • Verify ClickHouse is ready:  kubectl get chi -n $NAMESPACE"
+  echo "  • Check OBI logs:              kubectl logs -n $NAMESPACE <agent-pod> -c obi"
+  echo "  • Run OBI sizing report:       ./charts/kvisor/scripts/obi-sizing-report.sh"
+  echo "  • View sizing guide:           docs/obi-sizing.md"
+  echo ""
 fi
-echo ""
-echo "  Mode:           $MODE_LABEL"
-echo "  Namespace:      $NAMESPACE"
-echo "  Release:        $RELEASE"
-echo "  OBI profile:    $OBI_PROFILE"
-echo "  Dynamic sizing: $DYNAMIC_SIZING"
-echo ""
-echo "Next steps:"
-echo "  • Verify ClickHouse is ready:  kubectl get chi -n $NAMESPACE"
-echo "  • Check OBI logs:              kubectl logs -n $NAMESPACE <agent-pod> -c obi"
-echo "  • Run OBI sizing report:       ./charts/kvisor/scripts/obi-sizing-report.sh"
-echo "  • View sizing guide:           docs/obi-sizing.md"
-echo ""

--- a/docs/reliability-stack-installation.md
+++ b/docs/reliability-stack-installation.md
@@ -122,6 +122,23 @@ helm install castai-kvisor castai-helm/castai-kvisor \
 
 ### Option 2: Enable on Existing Kvisor (Manual)
 
+> **⚠️ Umbrella Chart: API Key Secret Name**
+>
+> When kvisor is installed via the `castai` umbrella chart (not standalone `castai-kvisor`), the CAST AI API key is stored in a secret named `castai-credentials` rather than the default `castai-kvisor`. You must override `reliabilityMetrics.castai.apiKeySecretRef` accordingly, and prefix all values with `autoscaler.castai-kvisor.`:
+> ```bash
+> helm upgrade castai castai-helm/castai -n castai-agent --reuse-values \
+>   --set "autoscaler.castai-kvisor.agent.reliabilityMetrics.enabled=true" \
+>   --set "autoscaler.castai-kvisor.agent.reliabilityMetrics.collector.clickhouseExporter.address=tcp://castai-clickhouse.castai-agent.svc.cluster.local:9000" \
+>   --set "autoscaler.castai-kvisor.controller.reliabilityMetrics.enabled=true" \
+>   --set "autoscaler.castai-kvisor.controller.reliabilityMetrics.collector.clickhouseExporter.address=tcp://castai-clickhouse.castai-agent.svc.cluster.local:9000" \
+>   --set "autoscaler.castai-kvisor.reliabilityMetrics.enabled=true" \
+>   --set "autoscaler.castai-kvisor.reliabilityMetrics.operator.enabled=true" \
+>   --set "autoscaler.castai-kvisor.reliabilityMetrics.install.enabled=true" \
+>   --set "autoscaler.castai-kvisor.reliabilityMetrics.exporter.enabled=true" \
+>   --set "autoscaler.castai-kvisor.reliabilityMetrics.castai.apiKeySecretRef=castai-credentials"
+> ```
+> The `enable-reliability-stack.sh` script handles both of these automatically when `--release castai` is set — it detects the correct secret name and derives the correct ClickHouse service address from the release name.
+
 > **⚠️ CRD Chicken-and-Egg Problem**
 >
 > If the cluster has no ClickHouse Operator CRD (`clickhouse.altinity.com/v1`), enabling `reliabilityMetrics.install.enabled=true` will fail with:

--- a/docs/reliability-stack-installation.md
+++ b/docs/reliability-stack-installation.md
@@ -81,9 +81,14 @@ helm repo update castai-helm
 
 The `enable-reliability-stack.sh` script handles the ClickHouse Operator CRD bootstrapping automatically. It detects whether the CRD exists, installs the operator first if needed, waits for the CRD to register, then enables the full stack.
 
+The script **auto-detects** whether kvisor is installed standalone (`castai-kvisor` chart) or via the CAST AI umbrella chart (`castai` chart) and adjusts the release name, chart reference, and values prefix accordingly. No manual flags needed in most cases.
+
 ```bash
-# Basic usage (existing kvisor installation, auto-detects OBI profile)
+# Basic usage — auto-detects standalone vs umbrella, auto-detects OBI profile
 ./charts/kvisor/scripts/enable-reliability-stack.sh
+
+# Dry-run (prints commands without executing — recommended for first run)
+./charts/kvisor/scripts/enable-reliability-stack.sh --dry-run
 
 # With context and explicit profile
 ./charts/kvisor/scripts/enable-reliability-stack.sh \
@@ -96,8 +101,11 @@ The `enable-reliability-stack.sh` script handles the ClickHouse Operator CRD boo
   --context <kube-context> \
   -f /path/to/my-values.yaml
 
-# Dry-run (prints commands without executing)
-./charts/kvisor/scripts/enable-reliability-stack.sh --dry-run
+# Explicit overrides (if auto-detection doesn't apply to your setup)
+./charts/kvisor/scripts/enable-reliability-stack.sh \
+  --release <helm-release-name> \
+  --chart <chart-reference> \
+  --values-prefix <subchart-path>
 ```
 
 The `-f` / `--values-file` flag layers your values file on top of the chart defaults and any previously-set user values (via `--reset-then-reuse-values`). This is the recommended way to configure `openPorts`, exclusions, ClickHouse resources, and exporter settings for production clusters.
@@ -122,11 +130,18 @@ helm install castai-kvisor castai-helm/castai-kvisor \
 
 ### Option 2: Enable on Existing Kvisor (Manual)
 
-> **⚠️ Umbrella Chart: API Key Secret Name**
+> **⚠️ Umbrella Chart**
 >
-> When kvisor is installed via the `castai` umbrella chart (not standalone `castai-kvisor`), the CAST AI API key is stored in a secret named `castai-credentials` rather than the default `castai-kvisor`. You must override `reliabilityMetrics.castai.apiKeySecretRef` accordingly, and prefix all values with `autoscaler.castai-kvisor.`:
+> When kvisor is installed via the `castai` umbrella chart (not standalone `castai-kvisor`), three things differ:
+> 1. The API key secret is `castai-credentials` (not `castai-kvisor`)
+> 2. All `--set` keys must be prefixed to route into the kvisor subchart (e.g. `autoscaler.castai-kvisor.*` — the exact prefix depends on the umbrella chart structure)
+> 3. The ClickHouse service name becomes `castai-clickhouse` (not `castai-kvisor-clickhouse`)
+>
+> **Recommended:** Use the `enable-reliability-stack.sh` script — it auto-detects umbrella vs standalone and discovers the correct values prefix automatically.
+>
+> Manual example for reference (verify the prefix for your umbrella chart version):
 > ```bash
-> helm upgrade castai castai-helm/castai -n castai-agent --reuse-values \
+> helm upgrade castai castai-helm/castai -n castai-agent --reset-then-reuse-values \
 >   --set "autoscaler.castai-kvisor.agent.reliabilityMetrics.enabled=true" \
 >   --set "autoscaler.castai-kvisor.agent.reliabilityMetrics.collector.clickhouseExporter.address=tcp://castai-clickhouse.castai-agent.svc.cluster.local:9000" \
 >   --set "autoscaler.castai-kvisor.controller.reliabilityMetrics.enabled=true" \
@@ -137,7 +152,6 @@ helm install castai-kvisor castai-helm/castai-kvisor \
 >   --set "autoscaler.castai-kvisor.reliabilityMetrics.exporter.enabled=true" \
 >   --set "autoscaler.castai-kvisor.reliabilityMetrics.castai.apiKeySecretRef=castai-credentials"
 > ```
-> The `enable-reliability-stack.sh` script handles both of these automatically when `--release castai` is set — it detects the correct secret name and derives the correct ClickHouse service address from the release name.
 
 > **⚠️ CRD Chicken-and-Egg Problem**
 >

--- a/docs/reliability-stack-installation.md
+++ b/docs/reliability-stack-installation.md
@@ -65,8 +65,15 @@ OBI (eBPF probes) ──OTLP──▶ OTel Collector ──SQL INSERT──▶ C
 - `helm` (3.12+) and `kubectl` installed and configured
 - CAST AI account with API key and cluster onboarded to CAST AI
 - **Altinity ClickHouse operator**: Either let the chart install it (`reliabilityMetrics.operator.enabled=true`) or ensure one is already running in the cluster (`reliabilityMetrics.operator.enabled=false`)
+- **Default StorageClass** (or explicit override): ClickHouse requires a PersistentVolumeClaim. If your cluster has no default StorageClass (common on EKS 1.33+ where `gp2` exists but isn't marked default), either mark one as default or use the `--storage-class` flag:
+  ```bash
+  # Option A: Mark gp2 as default
+  kubectl annotate storageclass gp2 storageclass.kubernetes.io/is-default-class=true
+  # Option B: Pass explicitly to the install script
+  ./enable-reliability-stack.sh --storage-class gp2
+  ```
 
-> **Preflight check**: The `enable-reliability-stack.sh` script automatically checks kernel version and architecture on all nodes before proceeding. If any node fails, you'll be prompted to confirm before continuing.
+> **Preflight check**: The `enable-reliability-stack.sh` script automatically checks kernel version, architecture, and StorageClass availability on all nodes before proceeding. If any check fails, you'll be prompted to confirm before continuing.
 
 ### Helm Repo Setup
 
@@ -107,6 +114,11 @@ The script **auto-detects** whether kvisor is installed standalone (`castai-kvis
 ./charts/kvisor/scripts/enable-reliability-stack.sh \
   --context <kube-context> \
   --cluster-proxy
+
+# With explicit StorageClass (when no default SC exists, e.g. EKS 1.33+)
+./charts/kvisor/scripts/enable-reliability-stack.sh \
+  --context <kube-context> \
+  --storage-class gp3
 
 # With a custom values file (overrides openPorts, exclusions, ClickHouse config, etc.)
 ./charts/kvisor/scripts/enable-reliability-stack.sh \
@@ -402,6 +414,7 @@ reliabilityMetrics:
         memory: 2Gi
     persistence:
       size: 100Gi
+      # storageClass: gp3  # Explicit SC; omit to use cluster default
 
   # ch-exporter sidecar
   exporter:

--- a/docs/reliability-stack-installation.md
+++ b/docs/reliability-stack-installation.md
@@ -90,11 +90,23 @@ The script **auto-detects** whether kvisor is installed standalone (`castai-kvis
 # Dry-run (prints commands without executing — recommended for first run)
 ./charts/kvisor/scripts/enable-reliability-stack.sh --dry-run
 
+# Print-only mode — outputs both Phase 1 (operator) and Phase 2 (full stack)
+# helm commands without any cluster access. Useful for CI/CD or review.
+# Includes comments explaining when Phase 1 can be skipped.
+./charts/kvisor/scripts/enable-reliability-stack.sh --print-only \
+  --release castai --chart castai-helm/castai \
+  --values-prefix autoscaler.castai-kvisor
+
 # With context and explicit profile
 ./charts/kvisor/scripts/enable-reliability-stack.sh \
   --context <kube-context> \
   --obi-profile large \
   --dynamic-sizing
+
+# With cluster proxy enabled (creates RBAC + service account for kvisor proxy)
+./charts/kvisor/scripts/enable-reliability-stack.sh \
+  --context <kube-context> \
+  --cluster-proxy
 
 # With a custom values file (overrides openPorts, exclusions, ClickHouse config, etc.)
 ./charts/kvisor/scripts/enable-reliability-stack.sh \


### PR DESCRIPTION
- Add --values-prefix flag and setkey() helper to prefix all --set keys, enabling use with umbrella charts (e.g. autoscaler.castai-kvisor.*)
- Auto-detect the CAST AI API key secret name (castai-kvisor vs castai-credentials) and override reliabilityMetrics.castai.apiKeySecretRef accordingly
- Override the OTel collector ClickHouse address when release != castai-kvisor, since the service name is derived from the release (e.g. castai-clickhouse)
- Distinguish CRD-exists-but-operator-missing from CRD+operator-running to correctly handle reinstall scenarios without skipping Phase 1
- Fix rollout verification resource names for umbrella chart deployments
- Add umbrella chart callout to reliability-stack-installation.md
- print only support
- storage class support