### PR TITLE
Add exponential backoff for requests sent by kvisor

### DIFF
--- a/cmd/agent/daemon/app/app.go
+++ b/cmd/agent/daemon/app/app.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/ClickHouse/clickhouse-go/v2"
+	"github.com/cenkalti/backoff/v5"
 	"github.com/go-playground/validator/v10"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -55,11 +56,17 @@ func New(cfg *config.Config) *App {
 	if err := validator.New().Struct(cfg); err != nil {
 		panic(fmt.Errorf("invalid config: %w", err).Error())
 	}
-	return &App{cfg: cfg}
+	return &App{
+		cfg:                             cfg,
+		remoteConfigBackoffInitInterval: 5 * time.Second,
+		remoteConfigBackoffMaxInterval:  5 * time.Minute,
+	}
 }
 
 type App struct {
-	cfg *config.Config
+	cfg                             *config.Config
+	remoteConfigBackoffInitInterval time.Duration
+	remoteConfigBackoffMaxInterval  time.Duration
 }
 
 func parseLogLevel(lvlStr string) (slog.Level, error) {
@@ -519,29 +526,29 @@ Currently we care only care about dns responses with valid answers.
 }
 
 func (a *App) syncRemoteConfig(ctx context.Context, client *castai.Client) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
-		jsonConfig, err := json.Marshal(a.cfg) //nolint:musttag
-		if err != nil {
-			return fmt.Errorf("marshaling config: %w", err)
-		}
-		_, err = client.GRPC.GetConfiguration(ctx, &castaipb.GetConfigurationRequest{
+	jsonConfig, err := json.Marshal(a.cfg) //nolint:musttag
+	if err != nil {
+		return fmt.Errorf("marshaling config: %w", err)
+	}
+
+	eb := backoff.NewExponentialBackOff()
+	eb.InitialInterval = a.remoteConfigBackoffInitInterval
+	eb.MaxInterval = a.remoteConfigBackoffMaxInterval
+
+	_, err = backoff.Retry(ctx, func() (struct{}, error) {
+		_, err := client.GRPC.GetConfiguration(ctx, &castaipb.GetConfigurationRequest{
 			CurrentConfig: &castaipb.GetConfigurationRequest_Agent{
 				Agent: jsonConfig,
 			},
 		})
 		if err != nil {
 			slog.Error(fmt.Sprintf("fetching initial config: %v", err))
-			time.Sleep(5 * time.Second)
-			continue
+			return struct{}{}, err
 		}
 		slog.Info("initial config synced")
-		return nil
-	}
+		return struct{}{}, nil
+	}, backoff.WithBackOff(eb), backoff.WithMaxElapsedTime(0))
+	return err
 }
 
 func getActiveEnrichers(cfg config.EnricherConfig, log *logging.Logger, mountNamespacePIDStore *types.PIDsPerNamespace) []enrichment.EventEnricher {

--- a/cmd/controller/controllers/castai_controller.go
+++ b/cmd/controller/controllers/castai_controller.go
@@ -17,9 +17,10 @@ import (
 )
 
 type CastaiConfig struct {
-	RemoteConfigSyncDuration        time.Duration `validate:"required" json:"remoteConfigSyncDuration"`
-	RemoteConfigBackoffInitInterval time.Duration `json:"remoteConfigBackoffInitInterval"`
-	RemoteConfigBackoffMaxInterval  time.Duration `json:"remoteConfigBackoffMaxInterval"`
+	RemoteConfigSyncDuration           time.Duration `validate:"required" json:"remoteConfigSyncDuration"`
+	RemoteConfigBackoffInitInterval    time.Duration `json:"remoteConfigBackoffInitInterval"`
+	RemoteConfigBackoffMaxInterval     time.Duration `json:"remoteConfigBackoffMaxInterval"`
+	RemoteConfigBackoffMaxElapsedTime  time.Duration `json:"remoteConfigBackoffMaxElapsedTime"`
 }
 
 func NewCastaiController(log *logging.Logger, cfg CastaiConfig, appJSONConfig []byte, kubeClient *kube.Client, castaiClient *castai.Client) *CastaiController {
@@ -30,7 +31,10 @@ func NewCastaiController(log *logging.Logger, cfg CastaiConfig, appJSONConfig []
 		cfg.RemoteConfigBackoffInitInterval = 5 * time.Second
 	}
 	if cfg.RemoteConfigBackoffMaxInterval == 0 {
-		cfg.RemoteConfigBackoffMaxInterval = 5 * time.Minute
+		cfg.RemoteConfigBackoffMaxInterval = 60 * time.Second
+	}
+	if cfg.RemoteConfigBackoffMaxElapsedTime == 0 {
+		cfg.RemoteConfigBackoffMaxElapsedTime = 5 * time.Minute
 	}
 	return &CastaiController{
 		id:                          "castai",
@@ -109,7 +113,7 @@ func (c *CastaiController) fetchInitialRemoteConfig(ctx context.Context) error {
 		c.updateRemoteConfig(cfg)
 		c.log.Info("initial config synced")
 		return struct{}{}, nil
-	}, backoff.WithBackOff(eb), backoff.WithMaxElapsedTime(0))
+	}, backoff.WithBackOff(eb), backoff.WithMaxElapsedTime(c.cfg.RemoteConfigBackoffMaxElapsedTime))
 	return err
 }
 

--- a/cmd/controller/controllers/castai_controller.go
+++ b/cmd/controller/controllers/castai_controller.go
@@ -17,36 +17,29 @@ import (
 )
 
 type CastaiConfig struct {
-	RemoteConfigSyncDuration           time.Duration `validate:"required" json:"remoteConfigSyncDuration"`
-	RemoteConfigBackoffInitInterval    time.Duration `json:"remoteConfigBackoffInitInterval"`
-	RemoteConfigBackoffMaxInterval     time.Duration `json:"remoteConfigBackoffMaxInterval"`
-	RemoteConfigBackoffMaxElapsedTime  time.Duration `json:"remoteConfigBackoffMaxElapsedTime"`
+	RemoteConfigSyncDuration time.Duration `validate:"required" json:"remoteConfigSyncDuration"`
 }
 
 func NewCastaiController(log *logging.Logger, cfg CastaiConfig, appJSONConfig []byte, kubeClient *kube.Client, castaiClient *castai.Client) *CastaiController {
 	if cfg.RemoteConfigSyncDuration == 0 {
 		cfg.RemoteConfigSyncDuration = 5 * time.Minute
 	}
-	if cfg.RemoteConfigBackoffInitInterval == 0 {
-		cfg.RemoteConfigBackoffInitInterval = 5 * time.Second
-	}
-	if cfg.RemoteConfigBackoffMaxInterval == 0 {
-		cfg.RemoteConfigBackoffMaxInterval = 60 * time.Second
-	}
-	if cfg.RemoteConfigBackoffMaxElapsedTime == 0 {
-		cfg.RemoteConfigBackoffMaxElapsedTime = 5 * time.Minute
-	}
 	return &CastaiController{
-		id:                          "castai",
-		enabled:                     castaiClient != nil,
-		log:                         log.WithField("component", "castai_ctrl"),
-		kubeClient:                  kubeClient,
-		cfg:                         cfg,
-		appJSONConfig:               appJSONConfig,
-		castaiClient:                castaiClient,
+		id:                                "castai",
+		enabled:                           castaiClient != nil,
+		log:                               log.WithField("component", "castai_ctrl"),
+		kubeClient:                        kubeClient,
+		cfg:                               cfg,
+		appJSONConfig:                     appJSONConfig,
+		castaiClient:                      castaiClient,
 		remoteConfigFetchErrors:     &atomic.Int64{},
 		removeConfigMaxFailures:     10,
 		streamReconnectWaitDuration: 2 * time.Second,
+		remoteConfigBackoff: backoffConfig{
+			InitInterval:   5 * time.Second,
+			MaxInterval:    60 * time.Second,
+			MaxElapsedTime: 5 * time.Minute,
+		},
 	}
 }
 
@@ -62,6 +55,13 @@ type CastaiController struct {
 	remoteConfigFetchErrors     *atomic.Int64
 	removeConfigMaxFailures     int64
 	streamReconnectWaitDuration time.Duration
+	remoteConfigBackoff         backoffConfig
+}
+
+type backoffConfig struct {
+	InitInterval   time.Duration
+	MaxInterval    time.Duration
+	MaxElapsedTime time.Duration
 }
 
 func (c *CastaiController) Enabled() bool {
@@ -97,8 +97,8 @@ func (c *CastaiController) fetchConfig(ctx context.Context, req *castaipb.GetCon
 
 func (c *CastaiController) fetchInitialRemoteConfig(ctx context.Context) error {
 	eb := backoff.NewExponentialBackOff()
-	eb.InitialInterval = c.cfg.RemoteConfigBackoffInitInterval
-	eb.MaxInterval = c.cfg.RemoteConfigBackoffMaxInterval
+	eb.InitialInterval = c.remoteConfigBackoff.InitInterval
+	eb.MaxInterval = c.remoteConfigBackoff.MaxInterval
 
 	_, err := backoff.Retry(ctx, func() (struct{}, error) {
 		cfg, err := c.fetchConfig(ctx, &castaipb.GetConfigurationRequest{
@@ -113,7 +113,7 @@ func (c *CastaiController) fetchInitialRemoteConfig(ctx context.Context) error {
 		c.updateRemoteConfig(cfg)
 		c.log.Info("initial config synced")
 		return struct{}{}, nil
-	}, backoff.WithBackOff(eb), backoff.WithMaxElapsedTime(c.cfg.RemoteConfigBackoffMaxElapsedTime))
+	}, backoff.WithBackOff(eb), backoff.WithMaxElapsedTime(c.remoteConfigBackoff.MaxElapsedTime))
 	return err
 }
 

--- a/cmd/controller/controllers/castai_controller.go
+++ b/cmd/controller/controllers/castai_controller.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cenkalti/backoff/v5"
+
 	castaipb "github.com/castai/kvisor/api/v1/runtime"
 	"github.com/castai/kvisor/cmd/controller/kube"
 	"github.com/castai/kvisor/pkg/castai"
@@ -15,26 +17,32 @@ import (
 )
 
 type CastaiConfig struct {
-	RemoteConfigSyncDuration time.Duration `validate:"required" json:"remoteConfigSyncDuration"`
+	RemoteConfigSyncDuration        time.Duration `validate:"required" json:"remoteConfigSyncDuration"`
+	RemoteConfigBackoffInitInterval time.Duration `json:"remoteConfigBackoffInitInterval"`
+	RemoteConfigBackoffMaxInterval  time.Duration `json:"remoteConfigBackoffMaxInterval"`
 }
 
 func NewCastaiController(log *logging.Logger, cfg CastaiConfig, appJSONConfig []byte, kubeClient *kube.Client, castaiClient *castai.Client) *CastaiController {
 	if cfg.RemoteConfigSyncDuration == 0 {
 		cfg.RemoteConfigSyncDuration = 5 * time.Minute
 	}
+	if cfg.RemoteConfigBackoffInitInterval == 0 {
+		cfg.RemoteConfigBackoffInitInterval = 5 * time.Second
+	}
+	if cfg.RemoteConfigBackoffMaxInterval == 0 {
+		cfg.RemoteConfigBackoffMaxInterval = 5 * time.Minute
+	}
 	return &CastaiController{
-		id:                             "castai",
-		enabled:                        castaiClient != nil,
-		log:                            log.WithField("component", "castai_ctrl"),
-		kubeClient:                     kubeClient,
-		cfg:                            cfg,
-		appJSONConfig:                  appJSONConfig,
-		castaiClient:                   castaiClient,
-		remoteConfigFetchErrors:        &atomic.Int64{},
-		remoteConfigInitialSyncTimeout: 1 * time.Minute,
-		remoteConfigRetryWaitDuration:  20 * time.Second,
-		removeConfigMaxFailures:        10,
-		streamReconnectWaitDuration:    2 * time.Second,
+		id:                          "castai",
+		enabled:                     castaiClient != nil,
+		log:                         log.WithField("component", "castai_ctrl"),
+		kubeClient:                  kubeClient,
+		cfg:                         cfg,
+		appJSONConfig:               appJSONConfig,
+		castaiClient:                castaiClient,
+		remoteConfigFetchErrors:     &atomic.Int64{},
+		removeConfigMaxFailures:     10,
+		streamReconnectWaitDuration: 2 * time.Second,
 	}
 }
 
@@ -47,11 +55,9 @@ type CastaiController struct {
 	castaiClient  *castai.Client
 	appJSONConfig []byte
 
-	remoteConfigFetchErrors        *atomic.Int64
-	removeConfigMaxFailures        int64
-	streamReconnectWaitDuration    time.Duration
-	remoteConfigRetryWaitDuration  time.Duration
-	remoteConfigInitialSyncTimeout time.Duration
+	remoteConfigFetchErrors     *atomic.Int64
+	removeConfigMaxFailures     int64
+	streamReconnectWaitDuration time.Duration
 }
 
 func (c *CastaiController) Enabled() bool {
@@ -62,10 +68,7 @@ func (c *CastaiController) Run(ctx context.Context) error {
 	c.log.Info("running")
 	defer c.log.Infof("stopping")
 
-	ctxCtx, cancel := context.WithTimeout(ctx, c.remoteConfigInitialSyncTimeout)
-	defer cancel()
-
-	if err := c.fetchInitialRemoteConfig(ctxCtx); err != nil {
+	if err := c.fetchInitialRemoteConfig(ctx); err != nil {
 		return fmt.Errorf("fetching initial config: %w", err)
 	}
 
@@ -89,13 +92,11 @@ func (c *CastaiController) fetchConfig(ctx context.Context, req *castaipb.GetCon
 }
 
 func (c *CastaiController) fetchInitialRemoteConfig(ctx context.Context) error {
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	eb := backoff.NewExponentialBackOff()
+	eb.InitialInterval = c.cfg.RemoteConfigBackoffInitInterval
+	eb.MaxInterval = c.cfg.RemoteConfigBackoffMaxInterval
 
+	_, err := backoff.Retry(ctx, func() (struct{}, error) {
 		cfg, err := c.fetchConfig(ctx, &castaipb.GetConfigurationRequest{
 			CurrentConfig: &castaipb.GetConfigurationRequest_Controller{
 				Controller: c.appJSONConfig,
@@ -103,13 +104,13 @@ func (c *CastaiController) fetchInitialRemoteConfig(ctx context.Context) error {
 		})
 		if err != nil {
 			c.log.Errorf("fetching initial config: %v", err)
-			sleep(ctx, c.remoteConfigRetryWaitDuration)
-			continue
+			return struct{}{}, err
 		}
 		c.updateRemoteConfig(cfg)
 		c.log.Info("initial config synced")
-		return nil
-	}
+		return struct{}{}, nil
+	}, backoff.WithBackOff(eb), backoff.WithMaxElapsedTime(0))
+	return err
 }
 
 func (c *CastaiController) runRemoteConfigSyncLoop(ctx context.Context) error {

--- a/cmd/controller/controllers/castai_controller_test.go
+++ b/cmd/controller/controllers/castai_controller_test.go
@@ -31,7 +31,7 @@ func TestCastaiController(t *testing.T) {
 			},
 		}
 		ctrl := newTestCastaiController(log, kubeClient, client)
-		ctrl.cfg.RemoteConfigBackoffMaxElapsedTime = 50 * time.Millisecond
+		ctrl.remoteConfigBackoff.MaxElapsedTime = 50 * time.Millisecond
 		err := ctrl.Run(ctx)
 		r.EqualError(err, "fetching initial config: ups")
 	})
@@ -96,11 +96,15 @@ func newTestCastaiController(log *logging.Logger, kubeClient *kube.Client, clien
 		GRPC: client,
 	}
 	cfg := CastaiConfig{
-		RemoteConfigSyncDuration:        10 * time.Millisecond,
-		RemoteConfigBackoffInitInterval: 10 * time.Millisecond,
-		RemoteConfigBackoffMaxInterval:  50 * time.Millisecond,
+		RemoteConfigSyncDuration: 10 * time.Millisecond,
 	}
-	return NewCastaiController(log, cfg, []byte{}, kubeClient, castaiClient)
+	ctrl := NewCastaiController(log, cfg, []byte{}, kubeClient, castaiClient)
+	ctrl.remoteConfigBackoff = backoffConfig{
+		InitInterval:   10 * time.Millisecond,
+		MaxInterval:    50 * time.Millisecond,
+		MaxElapsedTime: 5 * time.Minute,
+	}
+	return ctrl
 }
 
 type testGrpcClient struct {

--- a/cmd/controller/controllers/castai_controller_test.go
+++ b/cmd/controller/controllers/castai_controller_test.go
@@ -23,6 +23,19 @@ func TestCastaiController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	t.Run("stop on initial config failure after max elapsed time", func(t *testing.T) {
+		r := require.New(t)
+		client := &testGrpcClient{
+			getConfigurationResponse: func() (*castaipb.GetConfigurationResponse, error) {
+				return nil, errors.New("ups")
+			},
+		}
+		ctrl := newTestCastaiController(log, kubeClient, client)
+		ctrl.cfg.RemoteConfigBackoffMaxElapsedTime = 50 * time.Millisecond
+		err := ctrl.Run(ctx)
+		r.EqualError(err, "fetching initial config: ups")
+	})
+
 	t.Run("stop on initial config failure when context is cancelled", func(t *testing.T) {
 		r := require.New(t)
 		cancelCtx, cancelFn := context.WithCancel(ctx)

--- a/cmd/controller/controllers/castai_controller_test.go
+++ b/cmd/controller/controllers/castai_controller_test.go
@@ -23,18 +23,39 @@ func TestCastaiController(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	t.Run("stop on initial config failure", func(t *testing.T) {
+	t.Run("stop on initial config failure when context is cancelled", func(t *testing.T) {
 		r := require.New(t)
+		cancelCtx, cancelFn := context.WithCancel(ctx)
+		calls := 0
 		client := &testGrpcClient{
 			getConfigurationResponse: func() (*castaipb.GetConfigurationResponse, error) {
+				calls++
+				if calls >= 3 {
+					cancelFn()
+				}
 				return nil, errors.New("ups")
 			},
 		}
 		ctrl := newTestCastaiController(log, kubeClient, client)
-		ctrl.remoteConfigInitialSyncTimeout = 50 * time.Millisecond
-		ctrl.remoteConfigRetryWaitDuration = 10 * time.Millisecond
-		err := ctrl.Run(ctx)
-		r.ErrorIs(err, context.DeadlineExceeded)
+		err := ctrl.Run(cancelCtx)
+		r.ErrorIs(err, context.Canceled)
+	})
+
+	t.Run("retries initial config fetch until success", func(t *testing.T) {
+		r := require.New(t)
+		calls := 0
+		client := &testGrpcClient{
+			getConfigurationResponse: func() (*castaipb.GetConfigurationResponse, error) {
+				calls++
+				if calls < 3 {
+					return nil, errors.New("ups")
+				}
+				return &castaipb.GetConfigurationResponse{}, nil
+			},
+		}
+		ctrl := newTestCastaiController(log, kubeClient, client)
+		r.NoError(ctrl.fetchInitialRemoteConfig(ctx))
+		r.Equal(3, calls)
 	})
 
 	t.Run("stop on config loop failure after max retries", func(t *testing.T) {
@@ -51,8 +72,6 @@ func TestCastaiController(t *testing.T) {
 			},
 		}
 		ctrl := newTestCastaiController(log, kubeClient, client)
-		ctrl.remoteConfigInitialSyncTimeout = 50 * time.Millisecond
-		ctrl.remoteConfigRetryWaitDuration = 10 * time.Millisecond
 		ctrl.removeConfigMaxFailures = 3
 		err := ctrl.Run(ctx)
 		r.ErrorContains(err, "remote config fetch errors reached")
@@ -64,7 +83,9 @@ func newTestCastaiController(log *logging.Logger, kubeClient *kube.Client, clien
 		GRPC: client,
 	}
 	cfg := CastaiConfig{
-		RemoteConfigSyncDuration: 10 * time.Millisecond,
+		RemoteConfigSyncDuration:        10 * time.Millisecond,
+		RemoteConfigBackoffInitInterval: 10 * time.Millisecond,
+		RemoteConfigBackoffMaxInterval:  50 * time.Millisecond,
 	}
 	return NewCastaiController(log, cfg, []byte{}, kubeClient, castaiClient)
 }

--- a/cmd/controller/controllers/types.go
+++ b/cmd/controller/controllers/types.go
@@ -1,9 +1,5 @@
 package controllers
 
-import (
-	"context"
-	"time"
-)
 
 type PodsStats struct {
 	ContainerStatuses []ContainerStatusStats `json:"containerStatuses"`
@@ -51,13 +47,3 @@ type Namespace struct {
 	Name string `json:"name"`
 }
 
-func sleep(ctx context.Context, d time.Duration) {
-	timeout := time.NewTimer(d)
-	defer timeout.Stop()
-	select {
-	case <-ctx.Done():
-		return
-	case <-timeout.C:
-		return
-	}
-}


### PR DESCRIPTION
Previously, both the kvisor agent and controller used fixed-interval retries when fetching the initial remote configuration:
  - Agent: retried every 5s forever
  - Controller: retried every 20s, giving up after 1 minute (causing crashloop on large clusters)

  Both components now use exponential backoff with jitter:
  - Initial interval: 5s
  - Max interval: 5 minutes
  - Multiplier: 1.5x
  - Jitter: ±50% of each interval (e.g. first retry waits between 2.5s–7.5s)
  - Max elapsed time:
    - 5 minutes for **controller**
    - none - retries forever until context is cancelled for **agent**

  The controller no longer has a 1-minute timeout, so it will no longer crashloop when the rate limit is exceeded on large clusters. The jitter spreads retries across agents to reduce thundering herd against the server's rate limit.