### PR TITLE
Clarify grpcAddr comment in values.yaml

### DIFF
--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -14,7 +14,9 @@ castai:
   apiKeySecretRef: ""
 
   # CASTAI grpc public api address.
-  # Note: If your cluster is in the EU region, update the grpcAddr to: https://kvisor.prod-eu.cast.ai:443
+  # Must match the CAST AI console your organization is registered with:
+  #   console.cast.ai    -> kvisor.prod-master.cast.ai:443
+  #   console.eu.cast.ai -> kvisor.prod-eu.cast.ai:443
   grpcAddr: "kvisor.prod-master.cast.ai:443"
 
   apiURL: ""


### PR DESCRIPTION
The previous comment suggested updating grpcAddr based on the cluster's cloud region (e.g. "EU region"), which is misleading. The correct mapping is based on which CAST AI console the organization is registered with, not where the cluster physically runs.

---
### Kimchi Summary
### What changed
Clarifies the documentation for the `castai.grpcAddr` Helm value to explicitly map CAST AI console URLs to their corresponding gRPC endpoints, replacing the previous EU-only guidance.

### Why
Helps users correctly configure the gRPC address based on which CAST AI console (`console.cast.ai` or `console.eu.cast.ai`) their organization is registered with, preventing connection errors due to regional endpoint mismatch.

### Key changes
- `charts/kvisor/values.yaml`: Updated the comment above `castai.grpcAddr` to document the mapping between console domains and gRPC endpoints (`console.cast.ai` → `kvisor.prod-master.cast.ai:443`, `console.eu.cast.ai` → `kvisor.prod-eu.cast.ai:443`).