### PR TITLE
Upgrade ch-exporter to v0.3.18

### DIFF
--- a/charts/kvisor/Chart.yaml
+++ b/charts/kvisor/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "v1.55.25"
 
 dependencies:
   - name: reliability-metrics-ch-exporter
-    version: "0.3.17"
+    version: "0.3.18"
     repository: "https://castai.github.io/helm-charts"
     condition: reliabilityMetrics.enabled
     alias: reliabilityMetrics


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Upgrades the `reliability-metrics-ch-exporter` subchart dependency from `0.3.17` to `0.3.18`.

### Key changes
- `charts/kvisor/Chart.yaml`: Bumped the `reliability-metrics-ch-exporter` dependency version from `0.3.17` to `0.3.18`.

### Impact
Deployments with `reliabilityMetrics.enabled=true` will install the updated subchart version.