### PR TITLE
feat: Add support for global env registry in kvisor

### DIFF
--- a/charts/kvisor/templates/_helpers.tpl
+++ b/charts/kvisor/templates/_helpers.tpl
@@ -371,6 +371,20 @@ Resolve CASTAI_API_URL: global.castai.apiURL > .Values.castai.apiURL
 {{- end }}
 
 {{/*
+Resolve image repository: prepend global.registry if set.
+Usage: {{ include "kvisor.imageRepository" (dict "repository" .Values.image.repository "Values" .Values) }}
+*/}}
+{{- define "kvisor.imageRepository" -}}
+{{- $repository := required "repository must be provided" .repository -}}
+{{- $registry := ((.Values.global | default dict).registry) | default "" -}}
+{{- if $registry -}}
+{{- printf "%s/%s" (trimSuffix "/" $registry) $repository -}}
+{{- else -}}
+{{- $repository -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 OBI (OpenTelemetry eBPF Instrumentation) sidecar container security context.
 Uses fine-grained capabilities instead of privileged: true.
 Capabilities: BPF, SYS_PTRACE, NET_RAW, CHECKPOINT_RESTORE, DAC_READ_SEARCH, PERFMON.

--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -63,7 +63,7 @@ spec:
       initContainers:
       {{- if (include "kvisor.gpuEnabled" .) }}
         - name: gpu-feature-discovery
-          image: "{{ .Values.image.repository }}-agent:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.image.repository "Values" .Values) }}-agent:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "/usr/local/bin/kvisor-agent"
@@ -96,7 +96,7 @@ spec:
         - name: kvisor
           securityContext:
             {{- include "kvisor.agent.containerSecurityContext" . | nindent 12 }}
-          image: "{{ .Values.image.repository }}-agent:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.image.repository "Values" .Values) }}-agent:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.agent.resources | nindent 12 }}
@@ -213,7 +213,7 @@ spec:
             {{- end }}
       {{- if (dig "reliabilityMetrics" "enabled" false .Values.agent) }}
         - name: obi
-          image: "{{ .Values.agent.reliabilityMetrics.obi.image.repository }}:{{ .Values.agent.reliabilityMetrics.obi.image.tag }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.agent.reliabilityMetrics.obi.image.repository "Values" .Values) }}:{{ .Values.agent.reliabilityMetrics.obi.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["/shared/entrypoint.sh"]
           securityContext:
@@ -287,7 +287,7 @@ spec:
           {{- end }}
       {{- if (dig "reliabilityMetrics" "collector" "enabled" false .Values.agent) }}
         - name: otel-collector
-          image: "{{ .Values.agent.reliabilityMetrics.collector.image.repository }}:{{ .Values.agent.reliabilityMetrics.collector.image.tag }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.agent.reliabilityMetrics.collector.image.repository "Values" .Values) }}:{{ .Values.agent.reliabilityMetrics.collector.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsUser: 0
@@ -366,7 +366,7 @@ spec:
       {{- if (include "kvisor.gpuEnabled" .) }}
         {{- $provider := include "kvisor.cloudProvider" . }}
         - name: dcgm-exporter
-          image: "{{ .Values.agent.gpu.dcgmExporter.image.repository }}:{{ .Values.agent.gpu.dcgmExporter.image.tag }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.agent.gpu.dcgmExporter.image.repository "Values" .Values) }}:{{ .Values.agent.gpu.dcgmExporter.image.tag }}"
           imagePullPolicy: {{ .Values.agent.gpu.dcgmExporter.image.pullPolicy }}
           securityContext:
             privileged: {{ eq $provider "gke" }}

--- a/charts/kvisor/templates/cast-mock-server.yaml
+++ b/charts/kvisor/templates/cast-mock-server.yaml
@@ -26,7 +26,7 @@ spec:
       containers:
         - name: generator
           securityContext: {}
-          image: "{{ .Values.mockServer.image.repository }}:{{ .Values.mockServer.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.mockServer.image.repository "Values" .Values) }}:{{ .Values.mockServer.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.mockServer.image.pullPolicy }}
           args:
             - "--mode=controller"

--- a/charts/kvisor/templates/clickhouse.yaml
+++ b/charts/kvisor/templates/clickhouse.yaml
@@ -27,7 +27,7 @@ spec:
       securityContext: {}
       containers:
         - name: schema
-          image: "{{ .Values.image.repository }}-agent:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.image.repository "Values" .Values) }}-agent:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command:
             - "/usr/local/bin/kvisor-agent"
           args:
@@ -40,7 +40,7 @@ spec:
                 name: {{ include "kvisor.clickhouse.fullname" . }}
         - name: storage
           securityContext: {}
-          image: "{{ .Values.clickhouse.image.repository }}:{{ .Values.clickhouse.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.clickhouse.image.repository "Values" .Values) }}:{{ .Values.clickhouse.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.clickhouse.image.pullPolicy }}
           env:
             - name: CLICKHOUSE_USER

--- a/charts/kvisor/templates/controller.yaml
+++ b/charts/kvisor/templates/controller.yaml
@@ -50,7 +50,7 @@ spec:
       priorityClassName: {{ .Values.controller.priorityClass }}
       containers:
         - name: controller
-          image: "{{ .Values.image.repository }}-controller:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.image.repository "Values" .Values) }}-controller:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{.Values.image.pullPolicy}}
           volumeMounts:
             {{- if .Values.controller.netflow.staticCIDRs.mappings }}
@@ -160,7 +160,7 @@ spec:
             periodSeconds: 5
       {{- if and (dig "reliabilityMetrics" "enabled" false .Values.controller) (dig "reliabilityMetrics" "collector" "enabled" false .Values.controller) }}
         - name: otel-collector
-          image: "{{ .Values.controller.reliabilityMetrics.collector.image.repository }}:{{ .Values.controller.reliabilityMetrics.collector.image.tag }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.controller.reliabilityMetrics.collector.image.repository "Values" .Values) }}:{{ .Values.controller.reliabilityMetrics.collector.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           securityContext:
             runAsUser: 10001

--- a/charts/kvisor/templates/event-generator.yaml
+++ b/charts/kvisor/templates/event-generator.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: generator
           securityContext: {}
-          image: "{{ .Values.eventGenerator.image.repository }}:{{ .Values.eventGenerator.image.tag | default .Chart.AppVersion }}"
+          image: "{{ include "kvisor.imageRepository" (dict "repository" .Values.eventGenerator.image.repository "Values" .Values) }}:{{ .Values.eventGenerator.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.eventGenerator.image.pullPolicy }}
           args:
             - "--mode=controller"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Adds support for a global container registry override via `global.registry` value. All image references across the chart now use a new helper template that prepends the global registry when set, enabling centralized registry configuration.

### Why
Enables deployment in air-gapped environments or with private registry mirrors without manually overriding each individual image repository.

### Key changes
- Added `kvisor.imageRepository` helper in `_helpers.tpl` to resolve image repositories with optional `global.registry` prefix
- Updated `charts/kvisor/templates/agent.yaml` to use helper for `gpu-feature-discovery`, `kvisor`, `obi`, `otel-collector`, and `dcgm-exporter` containers
- Updated `charts/kvisor/templates/cast-mock-server.yaml` to use helper for the generator container
- Updated `charts/kvisor/templates/clickhouse.yaml` to use helper for `schema` and `storage` containers  
- Updated `charts/kvisor/templates/controller.yaml` to use helper for `controller` and `otel-collector` containers
- Updated `charts/kvisor/templates/event-generator.yaml` to use helper for the generator container

### Impact
Backward compatible: if `global.registry` is unset, images resolve to their original repositories. Set `global.registry` (e.g., `my-registry.io/castai`) to prefix all images automatically.