### PR TITLE
feat: Adding HTTP proxy support for reliability

### DIFF
--- a/charts/kvisor/Chart.yaml
+++ b/charts/kvisor/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: "v1.55.25"
 
 dependencies:
   - name: reliability-metrics-ch-exporter
-    version: "0.3.17"
+    version: "0.3.19"
     repository: "https://castai.github.io/helm-charts"
     condition: reliabilityMetrics.enabled
     alias: reliabilityMetrics

--- a/charts/kvisor/templates/_helpers.tpl
+++ b/charts/kvisor/templates/_helpers.tpl
@@ -592,3 +592,26 @@ Formula (dynamicSizing): memory = 40 + (N × 27) + 30 MiB, clamped to [120, 1024
     - name: obi-shared
       mountPath: /shared
 {{- end -}}
+
+{{/*
+Emit HTTPS_PROXY / HTTP_PROXY / NO_PROXY env vars when the corresponding
+global.proxy.* value is non-empty. Each var is independently conditional —
+no envelope `enabled` flag.
+
+Include in containers that make external connections (agent, controller,
+ch-exporter). Do NOT include in OBI or OTel collector sidecars.
+*/}}
+{{- define "kvisor.proxyEnvVars" -}}
+{{- with ((.Values.global).proxy).httpsProxy }}
+- name: HTTPS_PROXY
+  value: {{ . | quote }}
+{{- end }}
+{{- with ((.Values.global).proxy).httpProxy }}
+- name: HTTP_PROXY
+  value: {{ . | quote }}
+{{- end }}
+{{- with ((.Values.global).proxy).noProxy }}
+- name: NO_PROXY
+  value: {{ . | quote }}
+{{- end }}
+{{- end }}

--- a/charts/kvisor/templates/agent.yaml
+++ b/charts/kvisor/templates/agent.yaml
@@ -170,6 +170,7 @@ spec:
             - name: {{ $k }}
               value: "{{ $v }}"
           {{- end }}
+          {{- include "kvisor.proxyEnvVars" . | nindent 12 }}
           ports:
             - containerPort: {{.Values.agent.metricsHTTPListenPort}}
               name: metrics

--- a/charts/kvisor/templates/controller.yaml
+++ b/charts/kvisor/templates/controller.yaml
@@ -125,6 +125,7 @@ spec:
             - name: {{ $key }}
               value: {{ $value }}
           {{- end }}
+          {{- include "kvisor.proxyEnvVars" . | nindent 12 }}
           envFrom:
           {{- with .Values.controller.envFrom }}
             {{- toYaml . | nindent 12 }}

--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -39,6 +39,22 @@ imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""
 
+# Proxy configuration — set any of these to inject the corresponding env var
+# into the kvisor agent, controller, and ch-exporter containers. Each var is
+# emitted independently when non-empty; presence implies activation.
+#
+# OTel collector sidecars and OBI are intentionally excluded: collectors talk
+# to ClickHouse via native TCP (unaffected by HTTP proxies), and OBI only
+# communicates on localhost.
+#
+# This block propagates automatically to the reliabilityMetrics subchart via
+# Helm's global values mechanism.
+global:
+  proxy:
+    httpProxy: ""
+    httpsProxy: ""
+    noProxy: ""
+
 # Labels to add to all resources.
 # TODO: Add for all resources
 commonLabels: {}

--- a/docs/reliability-stack-installation.md
+++ b/docs/reliability-stack-installation.md
@@ -476,6 +476,29 @@ reliabilityMetrics:
           key: "password"
 ```
 
+### Proxy Configuration (HTTPS_PROXY / HTTP_PROXY / NO_PROXY)
+
+Some clusters route outbound traffic through a corporate HTTP CONNECT proxy.
+Set proxy values once under `global.proxy` — they automatically propagate to
+the kvisor agent, controller, and the ch-exporter (subchart). Each variable
+is independently optional: only the ones you set are emitted.
+
+```yaml
+global:
+  proxy:
+    httpsProxy: "http://appproxy.corp.example:3128"
+    httpProxy:  "http://appproxy.corp.example:3128"
+    noProxy:    ".cluster.local,.svc,10.0.0.0/16,127.0.0.1,localhost"
+```
+
+**What gets the proxy vars:** kvisor agent, kvisor controller, ch-exporter —
+the components that initiate gRPC/REST calls to the CAST AI mothership.
+
+**What doesn't (intentionally):** OBI (only talks to `localhost`) and the
+OTel collector sidecars (write to ClickHouse over native TCP, which is not
+affected by HTTP proxies). Make sure `noProxy` includes `.svc` so in-cluster
+service traffic bypasses the proxy.
+
 ## Verification
 
 ### 1. Check Pod Status


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Add support for injecting `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables into kvisor components that initiate external connections. Each variable is independently optional and emitted only when its corresponding `global.proxy` value is non-empty.

### Why
Enable kvisor deployment in environments where outbound traffic to the CAST AI mothership must route through corporate HTTP CONNECT proxies.

### Key changes
- `values.yaml`: Introduce `global.proxy` configuration block with `httpProxy`, `httpsProxy`, and `noProxy` fields
- `_helpers.tpl`: Add `kvisor.proxyEnvVars` helper template to conditionally render proxy environment variables
- `templates/agent.yaml`: Include `kvisor.proxyEnvVars` in agent container environment specification
- `templates/controller.yaml`: Include `kvisor.proxyEnvVars` in controller container environment specification
- `Chart.yaml`: Bump `reliability-metrics-ch-exporter` dependency to `0.3.19` to support proxy configuration propagation via global values
- `docs/reliability-stack-installation.md`: Add proxy configuration section documenting supported components and exclusions

### Impact
- **Scope limitation**: Proxy variables are intentionally excluded from OBI and OpenTelemetry collector sidecars. OBI communicates only over localhost, and collectors write to ClickHouse via native TCP (unaffected by HTTP proxies).
- **Subchart propagation**: `global.proxy` values automatically propagate to the `reliabilityMetrics` subchart via Helm's global values mechanism.
- **Additive only**: No breaking changes; existing deployments without proxy configuration continue to function unchanged.