### PR TITLE
fix: Fix default exporter image

### DIFF
--- a/charts/kvisor/values.yaml
+++ b/charts/kvisor/values.yaml
@@ -645,4 +645,4 @@ reliabilityMetrics:
   exporter:
     image:
       repository: us-docker.pkg.dev/castai-hub/library/reliability-metrics-ch-exporter
-      tag: "v0.3.17"
+      tag: "v0.3.19"


### PR DESCRIPTION


---
### Kimchi Summary
### What changed
Bumps the reliability metrics ClickHouse exporter image tag from `v0.3.17` to `v0.3.19`.

### Key changes
- `charts/kvisor/values.yaml`: Updated `reliabilityMetrics.exporter.image.tag` from `v0.3.17` to `v0.3.19`.